### PR TITLE
Update get_file() to take urls (download to cache or get from cache if exists)

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -2,29 +2,85 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import os
+import urllib.parse
+import hashlib
+import requests
 from pathlib import Path
 
 
 def get_file(path):
-    rel_dir, file_name = os.path.split(path)
-    if (
-        "DOCKER_CACHE_ROOT" in os.environ
-        and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
-    ):
-        cache_dir = (
-            Path(os.environ["DOCKER_CACHE_ROOT"])
-            / "models/tt-ci-models-private"
-            / rel_dir
-        )
-    elif "LOCAL_LF_CACHE" in os.environ:
-        cache_dir = Path(os.environ["LOCAL_LF_CACHE"]) / rel_dir
+    """Get a file from local filesystem, cache, or URL.
+
+    This function handles both local files and URLs, retrieving from cache when available
+    or downloading/fetching as needed. For URLs, it creates a unique cached filename using
+    a hash of the URL to prevent collisions.
+
+    Args:
+        path: Path to a local file or URL to download
+
+    Returns:
+        Path to the file in the cache
+    """
+    # Check if path is a URL - handle URLs and files differently
+    is_url = path.startswith(("http://", "https://"))
+
+    if is_url:
+        url = path
+        # Create a hash from the URL to ensure uniqueness and use it to
+        # prevent collisions in downloaded files with same filename
+        url_hash = hashlib.md5(url.encode()).hexdigest()[:10]
+
+        # Get filename from URL, or create one if not available
+        file_name = os.path.basename(urllib.parse.urlparse(url).path)
+        if not file_name:
+            file_name = f"downloaded_file_{url_hash}"
+        else:
+            file_name = f"{url_hash}_{file_name}"
+
+        # For URLs use a separate cache directory structure
+        if (
+            "DOCKER_CACHE_ROOT" in os.environ
+            and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
+        ):
+            cache_dir = Path(os.environ["DOCKER_CACHE_ROOT"]) / "url_cache"
+        elif "LOCAL_LF_CACHE" in os.environ:
+            cache_dir = Path(os.environ["LOCAL_LF_CACHE"]) / "url_cache"
+        else:
+            cache_dir = Path.home() / ".cache/url_cache"
     else:
-        cache_dir = Path.home() / ".cache/lfcache" / rel_dir
+        rel_dir, file_name = os.path.split(path)
+        if (
+            "DOCKER_CACHE_ROOT" in os.environ
+            and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
+        ):
+            cache_dir = (
+                Path(os.environ["DOCKER_CACHE_ROOT"])
+                / "models/tt-ci-models-private"
+                / rel_dir
+            )
+        elif "LOCAL_LF_CACHE" in os.environ:
+            cache_dir = Path(os.environ["LOCAL_LF_CACHE"]) / rel_dir
+        else:
+            cache_dir = Path.home() / ".cache/lfcache" / rel_dir
+
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     file_path = cache_dir / file_name
+
+    # If file is not found in cache, download URL from web, or get file from IRD_LF_CACHE web server.
     if not file_path.exists():
-        if "DOCKER_CACHE_ROOT" in os.environ:
+        if is_url:
+            try:
+                print(f"Downloading {url} to {file_path}")
+                response = requests.get(url, stream=True, timeout=(15, 60))
+                response.raise_for_status()  # Raise exception for HTTP errors
+
+                with open(file_path, "wb") as f:
+                    f.write(response.content)
+
+            except Exception as e:
+                raise RuntimeError(f"Failed to download {url}: {str(e)}")
+        elif "DOCKER_CACHE_ROOT" in os.environ:
             raise FileNotFoundError(
                 f"File {file_path} is not available, check file path. If path is correct, DOCKER_CACHE_ROOT syncs automatically with S3 bucket every hour so please wait for the next sync."
             )

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -22,64 +22,53 @@ def get_file(path):
         Path to the file in the cache
     """
     # Check if path is a URL - handle URLs and files differently
-    is_url = path.startswith(("http://", "https://"))
+    path_is_url = path.startswith(("http://", "https://"))
 
-    if is_url:
-        url = path
-        # Create a hash from the URL to ensure uniqueness and use it to
-        # prevent collisions in downloaded files with same filename
-        url_hash = hashlib.md5(url.encode()).hexdigest()[:10]
+    if path_is_url:
+        # Create a hash from the URL to ensure uniqueness and prevent collisions
+        url_hash = hashlib.md5(path.encode()).hexdigest()[:10]
 
         # Get filename from URL, or create one if not available
-        file_name = os.path.basename(urllib.parse.urlparse(url).path)
+        file_name = os.path.basename(urllib.parse.urlparse(path).path)
         if not file_name:
             file_name = f"downloaded_file_{url_hash}"
         else:
             file_name = f"{url_hash}_{file_name}"
 
-        # For URLs use a separate cache directory structure
-        if (
-            "DOCKER_CACHE_ROOT" in os.environ
-            and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
-        ):
-            cache_dir = Path(os.environ["DOCKER_CACHE_ROOT"]) / "url_cache"
-        elif "LOCAL_LF_CACHE" in os.environ:
-            cache_dir = Path(os.environ["LOCAL_LF_CACHE"]) / "url_cache"
-        else:
-            cache_dir = Path.home() / ".cache/url_cache"
+        rel_path = Path("url_cache")
+        cache_dir_fallback = Path.home() / ".cache/url_cache"
     else:
         rel_dir, file_name = os.path.split(path)
-        if (
-            "DOCKER_CACHE_ROOT" in os.environ
-            and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
-        ):
-            cache_dir = (
-                Path(os.environ["DOCKER_CACHE_ROOT"])
-                / "models/tt-ci-models-private"
-                / rel_dir
-            )
-        elif "LOCAL_LF_CACHE" in os.environ:
-            cache_dir = Path(os.environ["LOCAL_LF_CACHE"]) / rel_dir
-        else:
-            cache_dir = Path.home() / ".cache/lfcache" / rel_dir
+        rel_path = Path("models/tt-ci-models-private") / rel_dir
+        cache_dir_fallback = Path.home() / ".cache/lfcache" / rel_dir
+
+    # Determine the base cache directory based on environment variables
+    if (
+        "DOCKER_CACHE_ROOT" in os.environ
+        and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
+    ):
+        cache_dir = Path(os.environ["DOCKER_CACHE_ROOT"]) / rel_path
+    elif "LOCAL_LF_CACHE" in os.environ:
+        cache_dir = Path(os.environ["LOCAL_LF_CACHE"]) / rel_path
+    else:
+        cache_dir = cache_dir_fallback
 
     cache_dir.mkdir(parents=True, exist_ok=True)
-
     file_path = cache_dir / file_name
 
     # If file is not found in cache, download URL from web, or get file from IRD_LF_CACHE web server.
     if not file_path.exists():
-        if is_url:
+        if path_is_url:
             try:
-                print(f"Downloading {url} to {file_path}")
-                response = requests.get(url, stream=True, timeout=(15, 60))
+                print(f"Downloading file from URL {path} to {file_path}")
+                response = requests.get(path, stream=True, timeout=(15, 60))
                 response.raise_for_status()  # Raise exception for HTTP errors
 
                 with open(file_path, "wb") as f:
                     f.write(response.content)
 
             except Exception as e:
-                raise RuntimeError(f"Failed to download {url}: {str(e)}")
+                raise RuntimeError(f"Failed to download {path}: {str(e)}")
         elif "DOCKER_CACHE_ROOT" in os.environ:
             raise FileNotFoundError(
                 f"File {file_path} is not available, check file path. If path is correct, DOCKER_CACHE_ROOT syncs automatically with S3 bucket every hour so please wait for the next sync."
@@ -89,6 +78,7 @@ def get_file(path):
                 raise ValueError(
                     "IRD_LF_CACHE environment variable is not set. Please set it to the address of the IRD LF cache."
                 )
+            print(f"Downloading file from path {path} to {cache_dir}/{file_name}")
             exit_code = os.system(
                 f"wget -nH -np -R \"indexg.html*\" -P {cache_dir} {os.environ['IRD_LF_CACHE']}/{path} --connect-timeout=15 --read-timeout=60 --tries=3"
             )


### PR DESCRIPTION
This is for https://github.com/tenstorrent/tt-torch/issues/796 and is inspired by the logic in https://github.com/tenstorrent/tt-torch/blob/main/tests/models/yolov10/test_yolov10.py#L25 for downloading images if not in cache.

The single api `get_file()` can now take a file path or url. 

- In case of file path, will fetch from cache that mirrors S3 bucket.
- In case of URL (detected by http, https), will fetch from web directly if doesn't exist in cache, otherwise will get from cache
- Files fetched from url are uniqified by url w/ hash and included in filename to avoid collisions with same filenames
 
 Example outputs when updating yolov10 test in tt-torch to use this change (logic reduced to one line!) follows...
 
 ```
 diff --git a/tests/models/yolov10/test_yolov10.py b/tests/models/yolov10/test_yolov10.py
index d0fd39e6..cf81b189 100644
--- a/tests/models/yolov10/test_yolov10.py
+++ b/tests/models/yolov10/test_yolov10.py
@@ -22,21 +22,7 @@ class ThisTester(ModelTester):
         return model.model

     def _load_inputs(self):
-        image_url = "https://media.roboflow.com/notebooks/examples/dog.jpeg"
-        if (
-            "DOCKER_CACHE_ROOT" in os.environ
-            and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
-        ):
-            download_dir = Path(os.environ["DOCKER_CACHE_ROOT"]) / "yolov10_data"
-        else:
-            download_dir = Path.home() / ".cache/yolov10_data"
-        download_dir.mkdir(parents=True, exist_ok=True)
-
-        load_path = download_dir / image_url.split("/")[-1]
-        if not load_path.exists():
-            response = requests.get(image_url, stream=True)
-            with open(str(load_path), "wb") as f:
-                f.write(response.content)
+        load_path = get_file("https://media.roboflow.com/notebooks/examples/dog.jpeg")
         image = cv2.imread(load_path)
         # image preprocessing:
```

I show 3 different caching examples: 
 
 ```
Using DOCKER_CACHE_ROOT=/localdev/kmabee/tt-torch/docker_cache/ for illustrative purposes
Downloading https://media.roboflow.com/notebooks/examples/dog.jpeg to /localdev/kmabee/tt-torch/docker_cache/url_cache/a40a101191_dog.jpeg

Using LOCAL_LF_CACHE=/localdev/kmabee/tt-torch/local_lf_cache/ for illustrative purposes
Downloading https://media.roboflow.com/notebooks/examples/dog.jpeg to /localdev/kmabee/tt-torch/local_lf_cache/url_cache/a40a101191_dog.jpeg

Using fallback home dir cache:
Downloading https://media.roboflow.com/notebooks/examples/dog.jpeg to /home/kmabee/.cache/url_cache/a40a101191_dog.jpeg
```

When re-running, file is picked up from caches above and not re-downloaded.

Will update changes in https://github.com/tenstorrent/tt-torch/pull/924 to use these once this is merged.

