### PR TITLE
Use get_file(url) more for images and yolov3 custom weights

### DIFF
--- a/centernet/pytorch/loader.py
+++ b/centernet/pytorch/loader.py
@@ -38,15 +38,10 @@ class ModelLoader(ForgeModel):
             torch.Tensor: Sample input tensor that can be fed to the model.
         """
         # Create a random input tensor with the correct shape, using default dtype
-        image = (
-            Image.open(
-                get_file(
-                    "test_files/onnx/centernet/inputs/17790319373_bd19b24cfc_k.jpg"
-                )
-            )
-            .convert("RGB")
-            .resize((512, 512))
+        image_file = get_file(
+            "https://github.com/xingyizhou/CenterNet/raw/master/images/17790319373_bd19b24cfc_k.jpg"
         )
+        image = Image.open(image_file).convert("RGB").resize((512, 512))
         m, s = np.mean(image, axis=(0, 1)), np.std(image, axis=(0, 1))
         preprocess = transforms.Compose(
             [

--- a/yolov4/pytorch/loader.py
+++ b/yolov4/pytorch/loader.py
@@ -7,7 +7,7 @@ YOLOv4 model loader implementation
 import torch
 import cv2
 import numpy as np
-import urllib.request
+from ...tools.utils import get_file
 
 from ...base import ForgeModel
 from .src.yolov4 import Yolov4
@@ -47,13 +47,8 @@ class ModelLoader(ForgeModel):
             torch.Tensor: Sample input tensor that can be fed to the model.
         """
 
-        def url_to_image(url):
-            resp = urllib.request.urlopen(url)
-            image = np.asarray(bytearray(resp.read()), dtype="uint8")
-            image = cv2.imdecode(image, cv2.IMREAD_COLOR)
-            return image
-
-        img = url_to_image("http://images.cocodataset.org/val2017/000000039769.jpg")
+        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
+        img = cv2.imread(str(image_file), cv2.IMREAD_COLOR)
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # Convert BGR to RGB
         img = cv2.resize(img, (640, 480))  # Resize to model input size
         img = img / 255.0  # Normalize to [0,1]


### PR DESCRIPTION
- Simplifies weights download, and less reliance on s3 bucket/cache for letting external users run models