### PR TITLE
Add 5 Models: AutoEncoder Linear, Bloom, Clip, Codegen, Deit

### DIFF
--- a/autoencoder_linear/__init__.py
+++ b/autoencoder_linear/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Autoencoder Linear model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/autoencoder_linear/pytorch/__init__.py
+++ b/autoencoder_linear/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Autoencoder Linear PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/autoencoder_linear/pytorch/loader.py
+++ b/autoencoder_linear/pytorch/loader.py
@@ -12,6 +12,7 @@ from datasets import load_dataset
 from ...base import ForgeModel
 from .src.linear_ae import LinearAE
 
+
 class ModelLoader(ForgeModel):
     """Autoencoder linear model loader implementation."""
 
@@ -66,6 +67,3 @@ class ModelLoader(ForgeModel):
             batch_tensor = batch_tensor.to(dtype_override)
 
         return batch_tensor
-
-
-

--- a/autoencoder_linear/pytorch/loader.py
+++ b/autoencoder_linear/pytorch/loader.py
@@ -34,7 +34,7 @@ class ModelLoader(ForgeModel):
             model = model.to(dtype_override)
 
         return model
-    
+
     @classmethod
     def load_inputs(cls, dtype_override=None, batch_size=1):
         """Load and return sample inputs for the Autoencoder Linear model with default settings.
@@ -45,7 +45,7 @@ class ModelLoader(ForgeModel):
             batch_size: Optional batch size to override the default batch size of 1.
 
         Returns:
-            torch.Tensor: Sample input tensor that can be fed to the model.
+            torch.Tensor: A batch of input tensors that can be fed to the model.
         """
 
         # Define transform to normalize data

--- a/autoencoder_linear/pytorch/loader.py
+++ b/autoencoder_linear/pytorch/loader.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/linear_autoencoder/pytorch_linear_autoencoder.py
+"""
+Autoencoder Linear model loader implementation
+"""
+import torch
+import torchvision.transforms as transforms
+from datasets import load_dataset
+
+from ...base import ForgeModel
+from .src.linear_ae import LinearAE
+
+class ModelLoader(ForgeModel):
+    """Autoencoder linear model loader implementation."""
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load and return the Autoencoder Linear model instance with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Autoencoder Linear model instance.
+        """
+        model = LinearAE()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+    
+    @classmethod
+    def load_inputs(cls, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the Autoencoder Linear model with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the inputs' default dtype.
+                           If not provided, inputs will use the default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Sample input tensor that can be fed to the model.
+        """
+
+        # Define transform to normalize data
+        transform = transforms.Compose(
+            [
+                transforms.Resize((1, 784)),
+                transforms.ToTensor(),
+                transforms.Normalize((0.1307,), (0.3081,)),
+            ]
+        )
+
+        # Load sample from MNIST dataset
+        dataset = load_dataset("mnist")
+        sample = dataset["train"][0]["image"]
+        batch_tensor = torch.stack([transform(sample)] * batch_size)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            batch_tensor = batch_tensor.to(dtype_override)
+
+        return batch_tensor
+
+
+

--- a/autoencoder_linear/pytorch/src/linear_ae.py
+++ b/autoencoder_linear/pytorch/src/linear_ae.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/linear_autoencoder/pytorch_linear_autoencoder.py
 
+
 import torch
 
 

--- a/autoencoder_linear/pytorch/src/linear_ae.py
+++ b/autoencoder_linear/pytorch/src/linear_ae.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/linear_autoencoder/pytorch_linear_autoencoder.py
+
+import torch
+
+
+class LinearAE(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        # Encoder
+        self.encoder_lin1 = torch.nn.Linear(784, 128)
+        self.encoder_lin2 = torch.nn.Linear(128, 64)
+        self.encoder_lin3 = torch.nn.Linear(64, 12)
+        self.encoder_lin4 = torch.nn.Linear(12, 3)
+
+        # Decoder
+        self.decoder_lin1 = torch.nn.Linear(3, 12)
+        self.decoder_lin2 = torch.nn.Linear(12, 64)
+        self.decoder_lin3 = torch.nn.Linear(64, 128)
+        self.decoder_lin4 = torch.nn.Linear(128, 784)
+
+        # Activation Function
+        self.act_fun = torch.nn.ReLU()
+
+    def forward(self, x):
+        # Encode
+        act = self.encoder_lin1(x)
+        act = self.act_fun(act)
+        act = self.encoder_lin2(act)
+        act = self.act_fun(act)
+        act = self.encoder_lin3(act)
+        act = self.act_fun(act)
+        act = self.encoder_lin4(act)
+
+        # Decode
+        act = self.decoder_lin1(act)
+        act = self.act_fun(act)
+        act = self.decoder_lin2(act)
+        act = self.act_fun(act)
+        act = self.decoder_lin3(act)
+        act = self.act_fun(act)
+        act = self.decoder_lin4(act)
+
+        return act

--- a/bloom/__init__.py
+++ b/bloom/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Bloom model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/bloom/pytorch/__init__.py
+++ b/bloom/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Bloom PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/bloom/pytorch/loader.py
+++ b/bloom/pytorch/loader.py
@@ -64,7 +64,7 @@ class ModelLoader(ForgeModel):
         # Create batch of sample inputs
         cls.test_input = ["This is a sample text from "] * batch_size
 
-        inputs = cls.tokenizer.encode_plus(
+        inputs = cls.tokenizer(
             cls.test_input,
             return_tensors="pt",
             max_length=32,

--- a/bloom/pytorch/loader.py
+++ b/bloom/pytorch/loader.py
@@ -47,10 +47,12 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls, batch_size=1):
+    def load_inputs(cls, dtype_override=None, batch_size=1):
         """Load and return sample inputs for the Bloom model with default settings.
 
         Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
             batch_size: Optional batch size to override the default batch size of 1.
 
         Returns:
@@ -59,7 +61,9 @@ class ModelLoader(ForgeModel):
 
         # Ensure tokenizer is initialized
         if not hasattr(cls, "tokenizer"):
-            cls.load_model()  # This will initialize the tokenizer
+            cls.load_model(
+                dtype_override=dtype_override
+            )  # This will initialize the tokenizer
 
         # Create batch of sample inputs
         cls.test_input = ["This is a sample text from "] * batch_size

--- a/bloom/pytorch/loader.py
+++ b/bloom/pytorch/loader.py
@@ -74,3 +74,22 @@ class ModelLoader(ForgeModel):
         )
 
         return inputs
+
+    @classmethod
+    def decode_output(cls, outputs):
+        """Helper method to decode model outputs into human-readable text.
+
+        Args:
+            outputs: Model output from a forward pass
+
+        Returns:
+            str: Decoded answer text
+        """
+        if not hasattr(cls, "tokenizer"):
+            cls.load_model()  # This will initialize the tokenizer
+
+        # Get logits for the last token in each batch
+        next_token_logits = outputs.logits[:, -1]
+        next_tokens = next_token_logits.softmax(dim=-1).argmax(dim=-1)
+
+        return [cls.tokenizer.decode([token.item()]) for token in next_tokens]

--- a/bloom/pytorch/loader.py
+++ b/bloom/pytorch/loader.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/linear_autoencoder/pytorch_linear_autoencoder.py
+"""
+Bloom model loader implementation
+"""
+
+
+from ...base import ForgeModel
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+
+class ModelLoader(ForgeModel):
+    """Bloom model loader implementation."""
+
+    # Shared configuration parameters
+    model_name = "bigscience/bloom-1b1"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load and return the Bloom model instance with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Bloom model instance.
+        """
+        # Initialize tokenizer first with default or overridden dtype
+        tokenizer_kwargs = {"padding_side": "left"}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        cls.tokenizer = AutoTokenizer.from_pretrained(
+            cls.model_name, **tokenizer_kwargs
+        )
+
+        # Load pre-trained model from HuggingFace
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = AutoModelForCausalLM.from_pretrained(cls.model_name, **model_kwargs)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, batch_size=1):
+        """Load and return sample inputs for the Bloom model with default settings.
+
+        Args:
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            dict: Input tensors and attention masks that can be fed to the model.
+        """
+
+        # Ensure tokenizer is initialized
+        if not hasattr(cls, "tokenizer"):
+            cls.load_model()  # This will initialize the tokenizer
+
+        # Create batch of sample inputs
+        cls.test_input = ["This is a sample text from "] * batch_size
+
+        inputs = cls.tokenizer.encode_plus(
+            cls.test_input,
+            return_tensors="pt",
+            max_length=32,
+            padding="max_length",
+            add_special_tokens=True,
+            truncation=True,
+        )
+
+        return inputs

--- a/clip/__init__.py
+++ b/clip/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+CLIP model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/clip/pytorch/__init__.py
+++ b/clip/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+CLIP PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/clip/pytorch/loader.py
+++ b/clip/pytorch/loader.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/linear_autoencoder/pytorch_linear_autoencoder.py
+"""
+Clip model loader implementation
+"""
+
+
+from ...base import ForgeModel
+from PIL import Image
+from transformers import CLIPProcessor, CLIPModel
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """CLIP model loader implementation."""
+
+    # Shared configuration parameters
+    model_name = "openai/clip-vit-base-patch32"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load and return the CLIP model instance with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The CLIP model instance.
+        """
+        # Initialize processor first with default or overridden dtype
+        processor_kwargs = {}
+        if dtype_override is not None:
+            processor_kwargs["torch_dtype"] = dtype_override
+
+        cls.processor = CLIPProcessor.from_pretrained(
+            cls.model_name, **processor_kwargs
+        )
+
+        # Load pre-trained model from HuggingFace
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = CLIPModel.from_pretrained(cls.model_name, **model_kwargs)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the CLIP model with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            dict: Input tensors, pixel values and attention masks that can be fed to the model.
+        """
+
+        # Ensure processor is initialized
+        if not hasattr(cls, "processor"):
+            cls.load_model()  # This will initialize the processor
+
+        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
+        image = Image.open(str(image_file))
+        batch_images = [image] * batch_size  # Create a batch of images
+
+        text = ["a photo of a cat", "a photo of a dog"]
+        batch_text = [text] * batch_size  # Create a batch of text
+
+        inputs = cls.processor(
+            text=batch_text,
+            images=batch_images,
+            return_tensors="pt",
+            padding=True,
+        )
+
+        if dtype_override is not None:
+            inputs["pixel_values"] = inputs["pixel_values"].to(dtype_override)
+
+        return inputs

--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Codegen model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/codegen/pytorch/__init__.py
+++ b/codegen/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Codegen PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/codegen/pytorch/loader.py
+++ b/codegen/pytorch/loader.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/linear_autoencoder/pytorch_linear_autoencoder.py
+"""
+Codegen model loader implementation
+"""
+
+
+from ...base import ForgeModel
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+class ModelLoader(ForgeModel):
+    """Codegen model loader implementation."""
+
+    # Shared configuration parameters
+    model_name = "Salesforce/codegen-350M-mono"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load and return the Codegen model instance with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Codegen model instance.
+        """
+        cls.tokenizer = AutoTokenizer.from_pretrained(cls.model_name)
+
+        # Load pre-trained model from HuggingFace
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = AutoModelForCausalLM.from_pretrained(cls.model_name, **model_kwargs)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the CLIP model with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            dict: Input tensors, pixel values and attention masks that can be fed to the model.
+        """
+        # Ensure tokenizer is initialized
+        if not hasattr(cls, "tokenizer"):
+            cls.load_model(
+                dtype_override=dtype_override
+            )  # This will initialize the tokenizer
+
+        text = ["def hello_world():"] * batch_size
+        inputs = cls.tokenizer(text, return_tensors="pt")
+
+        return inputs
+
+    @classmethod
+    def decode_outputs(cls, outputs):
+        """Decode the model outputs to text.
+
+        Args:
+            outputs: The model outputs to decode.
+
+        Returns:
+            str: The decoded text.
+        """
+        # Ensure tokenizer is initialized
+        if not hasattr(cls, "tokenizer"):
+            cls.load_model()
+
+        return [cls.tokenizer.decode(output) for output in outputs]

--- a/codegen/pytorch/loader.py
+++ b/codegen/pytorch/loader.py
@@ -41,7 +41,7 @@ class ModelLoader(ForgeModel):
 
     @classmethod
     def load_inputs(cls, dtype_override=None, batch_size=1):
-        """Load and return sample inputs for the CLIP model with default settings.
+        """Load and return sample inputs for the Codegen model with default settings.
 
         Args:
             dtype_override: Optional torch.dtype to override the model's default dtype.

--- a/deit/__init__.py
+++ b/deit/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Deit model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/deit/pytorch/__init__.py
+++ b/deit/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Deit PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/deit/pytorch/loader.py
+++ b/deit/pytorch/loader.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/linear_autoencoder/pytorch_linear_autoencoder.py
+"""
+Deit model loader implementation
+"""
+
+
+from ...base import ForgeModel
+from PIL import Image
+from transformers import AutoFeatureExtractor, ViTForImageClassification
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """Deit model loader implementation."""
+
+    # Shared configuration parameters
+    model_name = "facebook/deit-base-patch16-224"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load and return the Deit model instance with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Deit model instance.
+        """
+        # Initialize feature extractor first
+        cls.feature_extractor = AutoFeatureExtractor.from_pretrained(cls.model_name)
+
+        # Load pre-trained model from HuggingFace
+        model = ViTForImageClassification.from_pretrained(cls.model_name)
+
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the Deit model with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            dict: Preprocessed input tensors suitable for ViTForImageClassification.
+        """
+
+        # Ensure feature extractor is initialized
+        if not hasattr(cls, "feature_extractor"):
+            cls.load_model(
+                dtype_override=dtype_override
+            )  # This will initialize the feature extractor
+
+        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
+        image = Image.open(str(image_file))
+        batch_images = [image] * batch_size  # Create a batch of images
+        inputs = cls.feature_extractor(images=batch_images, return_tensors="pt")
+
+        return inputs


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/920

### Problem Description
Move model implementation from tt-torch into tt-forge-models repo

### What's Changed
- Added autoencoder_linear, bloom, clip, codegen and deit models.
- Passed in optional `batch_size=1` argument to each `load_inputs()` function for these 5 models