### PR TITLE
Add Pytorch model demos

### DIFF
--- a/alexnet/__init__.py
+++ b/alexnet/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+AlexNet model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/alexnet/pytorch/__init__.py
+++ b/alexnet/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+AlexNet PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/alexnet/pytorch/loader.py
+++ b/alexnet/pytorch/loader.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+AlexNet model loader implementation
+"""
+
+import torch
+from ...base import ForgeModel
+
+from PIL import Image
+from ...tools.utils import get_file
+from torchvision import transforms
+
+
+class ModelLoader(ForgeModel):
+    """Loads AlexNet model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "alexnet"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained AlexNet model."""
+
+        model = torch.hub.load(
+            "pytorch/vision:v0.10.0", cls.model_name, pretrained=True
+        )
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for AlexNet model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        inputs = preprocess(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/densenet/__init__.py
+++ b/densenet/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Densenet model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/densenet/pytorch/__init__.py
+++ b/densenet/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Densenet PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/densenet/pytorch/loader.py
+++ b/densenet/pytorch/loader.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Densenet model loader implementation
+"""
+
+import torch
+from ...base import ForgeModel
+
+from PIL import Image
+from ...tools.utils import get_file
+from torchvision import transforms
+
+
+class ModelLoader(ForgeModel):
+    """Loads Densenet model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "densenet121"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained Densenet model."""
+
+        model = torch.hub.load(
+            "pytorch/vision:v0.10.0", cls.model_name, pretrained=True
+        )
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Densenet model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        inputs = preprocess(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/ghostnet/__int__.py
+++ b/ghostnet/__int__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Ghostnet model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/ghostnet/pytorch/__init__.py
+++ b/ghostnet/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Ghostnet PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/ghostnet/pytorch/loader.py
+++ b/ghostnet/pytorch/loader.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Ghostnet model loader implementation
+"""
+
+from ...base import ForgeModel
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+from PIL import Image
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """Loads Ghostnet model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "ghostnet_100"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained Ghostnet model."""
+
+        model = timm.create_model(cls.model_name, pretrained=True)
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Ghostnet model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        data_config = resolve_data_config({}, model=cls.load_model())
+        transforms = create_transform(**data_config)
+        inputs = transforms(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/hrnet/__init__.py
+++ b/hrnet/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HRNet model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/hrnet/pytorch/__init__.py
+++ b/hrnet/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HRNet PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/hrnet/pytorch/loader.py
+++ b/hrnet/pytorch/loader.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HRNet model loader implementation
+"""
+
+from ...base import ForgeModel
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+from PIL import Image
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """Loads HRNet model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "hrnet_w18_small"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained HRNet model."""
+
+        model = timm.create_model(cls.model_name, pretrained=True)
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for HRNet model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        data_config = resolve_data_config({}, model=cls.load_model())
+        transforms = create_transform(**data_config)
+        inputs = transforms(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/mgp_str_base/__init__.py
+++ b/mgp_str_base/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MGP-STR model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/mgp_str_base/pytorch/__init__.py
+++ b/mgp_str_base/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MGP-STR PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/mgp_str_base/pytorch/loader.py
+++ b/mgp_str_base/pytorch/loader.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MGP-STR model loader implementation
+"""
+
+from ...base import ForgeModel
+from transformers import MgpstrProcessor, MgpstrForSceneTextRecognition
+from PIL import Image
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """Loads MGP-STR model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "alibaba-damo/mgp-str-base"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained MGP-STR model."""
+
+        model = MgpstrForSceneTextRecognition.from_pretrained(
+            cls.model_name, return_dict=False
+        )
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for MGP-STR model"""
+
+        # Get the Image
+        image_file = get_file("https://i.postimg.cc/ZKwLg2Gw/367-14.png")
+        image = Image.open(image_file).convert("RGB")
+
+        # Preprocess image
+        processor = MgpstrProcessor.from_pretrained(cls.model_name)
+        inputs = processor(
+            images=image,
+            return_tensors="pt",
+        ).pixel_values
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/mlp_mixer/__init__.py
+++ b/mlp_mixer/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLP-Mixer model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/mlp_mixer/pytorch/__init__.py
+++ b/mlp_mixer/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLP-Mixer PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/mlp_mixer/pytorch/loader.py
+++ b/mlp_mixer/pytorch/loader.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLP-Mixer model loader implementation
+"""
+
+from ...base import ForgeModel
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+from PIL import Image
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """Loads MLP-Mixer model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "mixer_s32_224"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained MLP-Mixer model."""
+
+        # To avoid RuntimeError: No pretrained weights exist for mixer_s32_224. Use `pretrained=False` for random init.
+        model = timm.create_model(cls.model_name, pretrained=False)
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for MLP-Mixer model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        data_config = resolve_data_config({}, model=cls.load_model())
+        transforms = create_transform(**data_config)
+        inputs = transforms(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/regnet/__init__.py
+++ b/regnet/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regnet model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/regnet/pytorch/__init__.py
+++ b/regnet/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regnet PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/regnet/pytorch/loader.py
+++ b/regnet/pytorch/loader.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regnet model loader implementation
+"""
+
+from ...base import ForgeModel
+from transformers import AutoFeatureExtractor, RegNetForImageClassification
+from PIL import Image
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """Loads Regnet model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "facebook/regnet-y-040"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained Regnet model."""
+
+        model = RegNetForImageClassification.from_pretrained(
+            cls.model_name, return_dict=False
+        )
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Regnet model"""
+
+        # Get the Image
+        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
+        image = Image.open(image_file)
+
+        # Preprocess image
+        image_processor = AutoFeatureExtractor.from_pretrained(cls.model_name)
+        inputs = image_processor(images=image, return_tensors="pt").pixel_values
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/resnext/__init__.py
+++ b/resnext/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Resnext model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/resnext/pytorch/__init__.py
+++ b/resnext/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Resnext PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/resnext/pytorch/loader.py
+++ b/resnext/pytorch/loader.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Resnext model loader implementation
+"""
+
+import torch
+from ...base import ForgeModel
+
+from PIL import Image
+from ...tools.utils import get_file
+from torchvision import transforms
+
+
+class ModelLoader(ForgeModel):
+    """Loads Resnext model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "resnext50_32x4d"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained Resnext model."""
+
+        model = torch.hub.load(
+            "pytorch/vision:v0.10.0", cls.model_name, pretrained=True
+        )
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Resnext model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        inputs = preprocess(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/vgg/__int__.py
+++ b/vgg/__int__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Vgg model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/vgg/pytorch/__init__.py
+++ b/vgg/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Vgg PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/vgg/pytorch/loader.py
+++ b/vgg/pytorch/loader.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Vgg model loader implementation
+"""
+
+import torch
+from ...base import ForgeModel
+
+from PIL import Image
+from ...tools.utils import get_file
+from torchvision import transforms
+
+
+class ModelLoader(ForgeModel):
+    """Loads Vgg model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "vgg19_bn"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained Vgg model."""
+
+        model = torch.hub.load(
+            "pytorch/vision:v0.10.0", cls.model_name, pretrained=True
+        )
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Vgg model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        inputs = preprocess(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/xception/__init__.py
+++ b/xception/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Xception model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/xception/pytorch/__init__.py
+++ b/xception/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Xception PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/xception/pytorch/loader.py
+++ b/xception/pytorch/loader.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Xception model loader implementation
+"""
+
+from ...base import ForgeModel
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+from PIL import Image
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """Loads Xception model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "xception65"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained Xception model."""
+
+        model = timm.create_model(cls.model_name, pretrained=True)
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Xception model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file).convert("RGB")
+
+        # Preprocess image
+        data_config = resolve_data_config({}, model=cls.load_model())
+        transforms = create_transform(**data_config)
+        inputs = transforms(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs


### PR DESCRIPTION
### Summary 

This PR adds demos for below pytorch models(ported from tt-forge-fe)

- Alexnet
- Densenet
- Ghostnet
- HRNet
- MGP-STR
- MLP-Mixer
- Regnet
- Rexnext
- Vgg
- Xception  

