### PR TITLE
Add ONNX Model Variants of CenterNet for OD, HPE, and 3D_BB

### DIFF
--- a/centernet/pytorch/loader.py
+++ b/centernet/pytorch/loader.py
@@ -18,36 +18,43 @@ class ModelLoader(ForgeModel):
     """CenterNet model loader implementation."""
 
     @classmethod
-    def load_model(cls):
+    def load_model(cls, **kwargs):
         """Load and return the CenterNet model instance with default settings.
 
         Returns:
             Onnx model: The CenterNet model instance.
         """
         # Load model with defaults
-        file = get_file("test_files/onnx/centernet/centernet_resnet18.onnx")
+        variant_name = kwargs.get("variant_name", "dla1x_od")
+        path = f"test_files/onnx/centernet/{variant_name}.onnx"
+        file = get_file(path)
         model = onnx.load(file)
 
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, **kwargs):
         """Load and return sample inputs for the CenterNet model with default settings.
 
         Returns:
             torch.Tensor: Sample input tensor that can be fed to the model.
         """
         # Create a random input tensor with the correct shape, using default dtype
+        variant_name = kwargs.get("variant_name", "dla1x_od")
+        # Set input resolution based on the task:
+        # Use 512x512 for Object Detection (OD) and Human Pose Estimation (HPE) variants,
+        # and 1280x384 for 3D Bounding Box (3D_BB) Detection variants
+        if "od" in variant_name or "hpe" in variant_name:
+            h, w = 512, 512
+        else:
+            h, w = 1280, 384
         image_file = get_file(
             "https://github.com/xingyizhou/CenterNet/raw/master/images/17790319373_bd19b24cfc_k.jpg"
         )
-        image = Image.open(image_file).convert("RGB").resize((512, 512))
+        image = Image.open(image_file).convert("RGB").resize((h, w))
         m, s = np.mean(image, axis=(0, 1)), np.std(image, axis=(0, 1))
         preprocess = transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Normalize(mean=m, std=s),
-            ]
+            [transforms.ToTensor(), transforms.Normalize(mean=m, std=s)]
         )
         input_tensor = preprocess(image)
         inputs = input_tensor.unsqueeze(0)


### PR DESCRIPTION
**Problem description:**
This PR introduces the CenterNet model in ONNX format for multiple tasks, including **Object Detection** (OD), **Human Pose Estimation** (HPE), and **3D Bounding Box** (3D_BB).
 The implementation is based on the official CenterNet [repository](https://github.com/xingyizhou/CenterNet) 
Supported model variants for each task are:

- Object Detection: dla1x, dla2x, resdcn101, resdcn18

- Human Pose Estimation: dla1x, dla3x

- 3D Bounding Box Detection: ddd_3dop, ddd_sub


