### PR TITLE
Add demos for pytorch models:set2

### DIFF
--- a/distilbert/__init__.py
+++ b/distilbert/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Distilbert model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/distilbert/pytorch/__init__.py
+++ b/distilbert/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Distilbert PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/distilbert/pytorch/loader.py
+++ b/distilbert/pytorch/loader.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Distilbert model loader implementation
+"""
+
+from transformers import DistilBertForMaskedLM, DistilBertTokenizer
+from ...base import ForgeModel
+
+
+class ModelLoader(ForgeModel):
+    """Loads Distilbert model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "distilbert-base-cased"
+    input_prompt = "The capital of France is [MASK]."
+    max_length = 128
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load Distilbert model from Hugging Face."""
+
+        # Initialize tokenizer first with default or overridden dtype
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        cls.tokenizer = DistilBertTokenizer.from_pretrained(
+            cls.model_name, **tokenizer_kwargs
+        )
+
+        # Load pre-trained model from HuggingFace
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = DistilBertForMaskedLM.from_pretrained(cls.model_name, **model_kwargs)
+        model.eval()
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Distilbert model"""
+
+        # Data preprocessing
+        inputs = cls.tokenizer(
+            cls.input_prompt,
+            max_length=cls.max_length,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        return inputs

--- a/dla/__init__.py
+++ b/dla/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DLA model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/dla/pytorch/__init__.py
+++ b/dla/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DLA PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/dla/pytorch/loader.py
+++ b/dla/pytorch/loader.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DLA model loader implementation
+"""
+
+from ...base import ForgeModel
+
+from PIL import Image
+from ...tools.utils import get_file
+from torchvision import transforms
+from .src import dla_model
+
+
+class ModelLoader(ForgeModel):
+    """Loads DLA model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "dla34"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained DLA model."""
+        func = getattr(dla_model, cls.model_name)
+        model = func(pretrained=None)
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for DLA model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        inputs = preprocess(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/dla/pytorch/src/dla_model.py
+++ b/dla/pytorch/src/dla_model.py
@@ -1,0 +1,592 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+"""
+# Code adapted from:
+# https://github.com/ucbdrive/dla
+
+BSD 3-Clause License
+
+Copyright (c) 2018, Fisher Yu
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+
+import math
+from collections import namedtuple
+from os.path import join
+
+import torch
+import torch.utils.model_zoo as model_zoo
+from torch import nn
+
+BatchNorm = nn.BatchNorm2d
+WEB_ROOT = "http://dl.yf.io/dla/models"
+Dataset = namedtuple(
+    "Dataset", ["model_hash", "classes", "mean", "std", "eigval", "eigvec", "name"]
+)
+
+imagenet = Dataset(
+    name="imagenet",
+    classes=1000,
+    mean=[0.485, 0.456, 0.406],
+    std=[0.229, 0.224, 0.225],
+    eigval=[55.46, 4.794, 1.148],
+    eigvec=[
+        [-0.5675, 0.7192, 0.4009],
+        [-0.5808, -0.0045, -0.8140],
+        [-0.5836, -0.6948, 0.4203],
+    ],
+    model_hash={
+        "dla34": "ba72cf86",
+        "dla46_c": "2bfd52c3",
+        "dla46x_c": "d761bae7",
+        "dla60x_c": "b870c45c",
+        "dla60": "24839fc4",
+        "dla60x": "d15cacda",
+        "dla102": "d94d9790",
+        "dla102x": "ad62be81",
+        "dla102x2": "262837b6",
+        "dla169": "0914e092",
+    },
+)
+
+datasets = {"imagenet": imagenet}
+
+
+def get_model_url(data, name):
+    return join(WEB_ROOT, data.name, "{}-{}.pth".format(name, data.model_hash[name]))
+
+
+def conv3x3(in_planes, out_planes, stride=1):
+    "3x3 convolution with padding"
+    return nn.Conv2d(
+        in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False
+    )
+
+
+class BasicBlock(nn.Module):
+    def __init__(self, inplanes, planes, stride=1, dilation=1):
+        super(BasicBlock, self).__init__()
+        self.conv1 = nn.Conv2d(
+            inplanes,
+            planes,
+            kernel_size=3,
+            stride=stride,
+            padding=dilation,
+            bias=False,
+            dilation=dilation,
+        )
+        self.bn1 = BatchNorm(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = nn.Conv2d(
+            planes,
+            planes,
+            kernel_size=3,
+            stride=1,
+            padding=dilation,
+            bias=False,
+            dilation=dilation,
+        )
+        self.bn2 = BatchNorm(planes)
+        self.stride = stride
+
+    def forward(self, x, residual=None):
+        if residual is None:
+            residual = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+
+        out += residual
+        out = self.relu(out)
+
+        return out
+
+
+class Bottleneck(nn.Module):
+    expansion = 2
+
+    def __init__(self, inplanes, planes, stride=1, dilation=1):
+        super(Bottleneck, self).__init__()
+        expansion = Bottleneck.expansion
+        bottle_planes = planes // expansion
+        self.conv1 = nn.Conv2d(inplanes, bottle_planes, kernel_size=1, bias=False)
+        self.bn1 = BatchNorm(bottle_planes)
+        self.conv2 = nn.Conv2d(
+            bottle_planes,
+            bottle_planes,
+            kernel_size=3,
+            stride=stride,
+            padding=dilation,
+            bias=False,
+            dilation=dilation,
+        )
+        self.bn2 = BatchNorm(bottle_planes)
+        self.conv3 = nn.Conv2d(bottle_planes, planes, kernel_size=1, bias=False)
+        self.bn3 = BatchNorm(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.stride = stride
+
+    def forward(self, x, residual=None):
+        if residual is None:
+            residual = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.relu(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+
+        out += residual
+        out = self.relu(out)
+
+        return out
+
+
+class BottleneckX(nn.Module):
+    expansion = 2
+    cardinality = 32
+
+    def __init__(self, inplanes, planes, stride=1, dilation=1):
+        super(BottleneckX, self).__init__()
+        cardinality = BottleneckX.cardinality
+        # dim = int(math.floor(planes * (BottleneckV5.expansion / 64.0)))
+        # bottle_planes = dim * cardinality
+        bottle_planes = planes * cardinality // 32
+        self.conv1 = nn.Conv2d(inplanes, bottle_planes, kernel_size=1, bias=False)
+        self.bn1 = BatchNorm(bottle_planes)
+        self.conv2 = nn.Conv2d(
+            bottle_planes,
+            bottle_planes,
+            kernel_size=3,
+            stride=stride,
+            padding=dilation,
+            bias=False,
+            dilation=dilation,
+            groups=cardinality,
+        )
+        self.bn2 = BatchNorm(bottle_planes)
+        self.conv3 = nn.Conv2d(bottle_planes, planes, kernel_size=1, bias=False)
+        self.bn3 = BatchNorm(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.stride = stride
+
+    def forward(self, x, residual=None):
+        if residual is None:
+            residual = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.relu(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+
+        out += residual
+        out = self.relu(out)
+
+        return out
+
+
+class Root(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, residual):
+        super(Root, self).__init__()
+        self.conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=1,
+            bias=False,
+            padding=(kernel_size - 1) // 2,
+        )
+        self.bn = BatchNorm(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+        self.residual = residual
+
+    def forward(self, *x):
+        children = x
+        x = self.conv(torch.cat(x, 1))
+        x = self.bn(x)
+        if self.residual:
+            x += children[0]
+        x = self.relu(x)
+
+        return x
+
+
+class Tree(nn.Module):
+    def __init__(
+        self,
+        levels,
+        block,
+        in_channels,
+        out_channels,
+        stride=1,
+        level_root=False,
+        root_dim=0,
+        root_kernel_size=1,
+        dilation=1,
+        root_residual=False,
+    ):
+        super(Tree, self).__init__()
+        if root_dim == 0:
+            root_dim = 2 * out_channels
+        if level_root:
+            root_dim += in_channels
+        if levels == 1:
+            self.tree1 = block(in_channels, out_channels, stride, dilation=dilation)
+            self.tree2 = block(out_channels, out_channels, 1, dilation=dilation)
+        else:
+            self.tree1 = Tree(
+                levels - 1,
+                block,
+                in_channels,
+                out_channels,
+                stride,
+                root_dim=0,
+                root_kernel_size=root_kernel_size,
+                dilation=dilation,
+                root_residual=root_residual,
+            )
+            self.tree2 = Tree(
+                levels - 1,
+                block,
+                out_channels,
+                out_channels,
+                root_dim=root_dim + out_channels,
+                root_kernel_size=root_kernel_size,
+                dilation=dilation,
+                root_residual=root_residual,
+            )
+        if levels == 1:
+            self.root = Root(root_dim, out_channels, root_kernel_size, root_residual)
+        self.level_root = level_root
+        self.root_dim = root_dim
+        self.downsample = None
+        self.project = None
+        self.levels = levels
+        if stride > 1:
+            self.downsample = nn.MaxPool2d(stride, stride=stride)
+        if in_channels != out_channels:
+            self.project = nn.Sequential(
+                nn.Conv2d(
+                    in_channels, out_channels, kernel_size=1, stride=1, bias=False
+                ),
+                BatchNorm(out_channels),
+            )
+
+    def forward(self, x, residual=None, children=None):
+        children = [] if children is None else children
+        bottom = self.downsample(x) if self.downsample else x
+        residual = self.project(bottom) if self.project else bottom
+        if self.level_root:
+            children.append(bottom)
+        x1 = self.tree1(x, residual)
+        if self.levels == 1:
+            x2 = self.tree2(x1)
+            x = self.root(x2, x1, *children)
+        else:
+            children.append(x1)
+            x = self.tree2(x1, children=children)
+        return x
+
+
+class DLA(nn.Module):
+    def __init__(
+        self,
+        levels,
+        channels,
+        num_classes=1000,
+        block=BasicBlock,
+        residual_root=False,
+        return_levels=False,
+        pool_size=7,
+        linear_root=False,
+    ):
+        super(DLA, self).__init__()
+        self.channels = channels
+        self.return_levels = return_levels
+        self.num_classes = num_classes
+        self.base_layer = nn.Sequential(
+            nn.Conv2d(3, channels[0], kernel_size=7, stride=1, padding=3, bias=False),
+            BatchNorm(channels[0]),
+            nn.ReLU(inplace=True),
+        )
+        self.level0 = self._make_conv_level(channels[0], channels[0], levels[0])
+        self.level1 = self._make_conv_level(
+            channels[0], channels[1], levels[1], stride=2
+        )
+        self.level2 = Tree(
+            levels[2],
+            block,
+            channels[1],
+            channels[2],
+            2,
+            level_root=False,
+            root_residual=residual_root,
+        )
+        self.level3 = Tree(
+            levels[3],
+            block,
+            channels[2],
+            channels[3],
+            2,
+            level_root=True,
+            root_residual=residual_root,
+        )
+        self.level4 = Tree(
+            levels[4],
+            block,
+            channels[3],
+            channels[4],
+            2,
+            level_root=True,
+            root_residual=residual_root,
+        )
+        self.level5 = Tree(
+            levels[5],
+            block,
+            channels[4],
+            channels[5],
+            2,
+            level_root=True,
+            root_residual=residual_root,
+        )
+
+        self.avgpool = nn.AvgPool2d(pool_size)
+        self.fc = nn.Conv2d(
+            channels[-1], num_classes, kernel_size=1, stride=1, padding=0, bias=True
+        )
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                n = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
+                m.weight.data.normal_(0, math.sqrt(2.0 / n))
+            elif isinstance(m, BatchNorm):
+                m.weight.data.fill_(1)
+                m.bias.data.zero_()
+
+    def _make_level(self, block, inplanes, planes, blocks, stride=1):
+        downsample = None
+        if stride != 1 or inplanes != planes:
+            downsample = nn.Sequential(
+                nn.MaxPool2d(stride, stride=stride),
+                nn.Conv2d(inplanes, planes, kernel_size=1, stride=1, bias=False),
+                BatchNorm(planes),
+            )
+
+        layers = []
+        layers.append(block(inplanes, planes, stride, downsample=downsample))
+        for i in range(1, blocks):
+            layers.append(block(inplanes, planes))
+
+        return nn.Sequential(*layers)
+
+    def _make_conv_level(self, inplanes, planes, convs, stride=1, dilation=1):
+        modules = []
+        for i in range(convs):
+            modules.extend(
+                [
+                    nn.Conv2d(
+                        inplanes,
+                        planes,
+                        kernel_size=3,
+                        stride=stride if i == 0 else 1,
+                        padding=dilation,
+                        bias=False,
+                        dilation=dilation,
+                    ),
+                    BatchNorm(planes),
+                    nn.ReLU(inplace=True),
+                ]
+            )
+            inplanes = planes
+        return nn.Sequential(*modules)
+
+    def forward(self, x):
+        y = []
+        x = self.base_layer(x)
+        for i in range(6):
+            x = getattr(self, "level{}".format(i))(x)
+            y.append(x)
+        if self.return_levels:
+            return y
+        else:
+            x = self.avgpool(x)
+            x = self.fc(x)
+            x = x.view(x.size(0), -1)
+
+            return x
+
+    def load_pretrained_model(self, data_name, name):
+        data = datasets[data_name]
+        fc = self.fc
+        if self.num_classes != data.classes:
+            self.fc = nn.Conv2d(
+                self.channels[-1],
+                data.classes,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+                bias=True,
+            )
+        try:
+            model_url = get_model_url(data, name)
+        except KeyError:
+            raise ValueError("{} trained on {} does not exist.".format(data.name, name))
+        self.load_state_dict(model_zoo.load_url(model_url))
+        self.fc = fc
+
+
+def dla34(pretrained=None, **kwargs):  # DLA-34
+    model = DLA(
+        [1, 1, 1, 2, 2, 1], [16, 32, 64, 128, 256, 512], block=BasicBlock, **kwargs
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla34")
+    return model
+
+
+def dla46_c(pretrained=None, **kwargs):  # DLA-46-C
+    Bottleneck.expansion = 2
+    model = DLA(
+        [1, 1, 1, 2, 2, 1], [16, 32, 64, 64, 128, 256], block=Bottleneck, **kwargs
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla46_c")
+    return model
+
+
+def dla46x_c(pretrained=None, **kwargs):  # DLA-X-46-C
+    BottleneckX.expansion = 2
+    model = DLA(
+        [1, 1, 1, 2, 2, 1], [16, 32, 64, 64, 128, 256], block=BottleneckX, **kwargs
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla46x_c")
+    return model
+
+
+def dla60x_c(pretrained=None, **kwargs):  # DLA-X-60-C
+    BottleneckX.expansion = 2
+    model = DLA(
+        [1, 1, 1, 2, 3, 1], [16, 32, 64, 64, 128, 256], block=BottleneckX, **kwargs
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla60x_c")
+    return model
+
+
+def dla60(pretrained=None, **kwargs):  # DLA-60
+    Bottleneck.expansion = 2
+    model = DLA(
+        [1, 1, 1, 2, 3, 1], [16, 32, 128, 256, 512, 1024], block=Bottleneck, **kwargs
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla60")
+    return model
+
+
+def dla60x(pretrained=None, **kwargs):  # DLA-X-60
+    BottleneckX.expansion = 2
+    model = DLA(
+        [1, 1, 1, 2, 3, 1], [16, 32, 128, 256, 512, 1024], block=BottleneckX, **kwargs
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla60x")
+    return model
+
+
+def dla102(pretrained=None, **kwargs):  # DLA-102
+    Bottleneck.expansion = 2
+    model = DLA(
+        [1, 1, 1, 3, 4, 1],
+        [16, 32, 128, 256, 512, 1024],
+        block=Bottleneck,
+        residual_root=True,
+        **kwargs,
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla102")
+    return model
+
+
+def dla102x(pretrained=None, **kwargs):  # DLA-X-102
+    BottleneckX.expansion = 2
+    model = DLA(
+        [1, 1, 1, 3, 4, 1],
+        [16, 32, 128, 256, 512, 1024],
+        block=BottleneckX,
+        residual_root=True,
+        **kwargs,
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla102x")
+    return model
+
+
+def dla102x2(pretrained=None, **kwargs):  # DLA-X-102 64
+    BottleneckX.cardinality = 64
+    model = DLA(
+        [1, 1, 1, 3, 4, 1],
+        [16, 32, 128, 256, 512, 1024],
+        block=BottleneckX,
+        residual_root=True,
+        **kwargs,
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla102x2")
+    return model
+
+
+def dla169(pretrained=None, **kwargs):  # DLA-169
+    Bottleneck.expansion = 2
+    model = DLA(
+        [1, 1, 2, 3, 5, 1],
+        [16, 32, 128, 256, 512, 1024],
+        block=Bottleneck,
+        residual_root=True,
+        **kwargs,
+    )
+    if pretrained is not None:
+        model.load_pretrained_model(pretrained, "dla169")
+    return model

--- a/mnist/__init__.py
+++ b/mnist/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MNIST model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/mnist/pytorch/__init__.py
+++ b/mnist/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MNIST PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/mnist/pytorch/loader.py
+++ b/mnist/pytorch/loader.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MNIST model loader implementation
+"""
+
+from ...base import ForgeModel
+from .src.utils import load_model, load_input
+
+
+class ModelLoader(ForgeModel):
+    """Loads MNIST model and sample input."""
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained MNIST model."""
+        model = load_model()
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for MNIST model"""
+
+        inputs = load_input()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/mnist/pytorch/src/utils.py
+++ b/mnist/pytorch/src/utils.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+# adapted from https://github.com/pytorch/examples/blob/main/mnist/main.py
+class MnistModel(torch.nn.Module):
+    def __init__(self):
+        super(MnistModel, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+def load_model():
+    model = MnistModel()
+    model.eval()
+    return model
+
+
+def load_input():
+    transform = transforms.Compose([transforms.ToTensor()])
+    test_dataset = datasets.MNIST(
+        root="./data", train=False, transform=transform, download=True
+    )
+    dataloader = DataLoader(test_dataset, batch_size=1)
+    test_input, _ = next(iter(dataloader))
+    return test_input

--- a/mobilenetv1/__init__.py
+++ b/mobilenetv1/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MobilenetV1 model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/mobilenetv1/pytorch/__init__.py
+++ b/mobilenetv1/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MobilenetV1 PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/mobilenetv1/pytorch/loader.py
+++ b/mobilenetv1/pytorch/loader.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MobilenetV1 model loader implementation
+"""
+
+from ...base import ForgeModel
+
+from PIL import Image
+from ...tools.utils import get_file
+from torchvision import transforms
+from .src.utils import MobileNetV1
+
+
+class ModelLoader(ForgeModel):
+    """Loads MobilenetV1 model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "mobilenet_v1"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained MobilenetV1 model."""
+        model = MobileNetV1(9)
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for MobilenetV1 model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        inputs = preprocess(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/mobilenetv1/pytorch/src/utils.py
+++ b/mobilenetv1/pytorch/src/utils.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import torch.nn as nn
+
+
+# SPDX-FileCopyrightText: Copyright (c) 2017 LoRnaTang
+#
+# SPDX-License-Identifier: Apache-2.0
+# https://github.com/Lornatang/MobileNetV1-PyTorch
+class Conv(nn.Module):
+    """
+    Conv block is convolutional layer followed by batch normalization and ReLU activation
+    """
+
+    def __init__(
+        self,
+        in_channel,
+        out_channel,
+        kernel_size=3,
+        stride=1,
+        padding=1,
+        use_relu6=False,
+    ):
+        super().__init__()
+        self.layers = [
+            nn.Conv2d(
+                in_channel,
+                out_channel,
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
+                bias=False,
+            ),
+            nn.BatchNorm2d(out_channel),
+        ]
+
+        if use_relu6:
+            self.layers.append(nn.ReLU6(inplace=True))
+        else:
+            self.layers.append(nn.ReLU(inplace=True))
+
+        self.model = nn.Sequential(*self.layers)
+
+    def forward(self, input):
+        return self.model(input)
+
+
+class Conv_dw_Conv(nn.Module):
+    """
+    Conv_dw is depthwise (dw) convolution layer followed by batch normalization and ReLU activation.
+    Conv_dw_Conv is Conv_dw block followed by Conv block.
+    Implemented Conv_dw_Conv instead of Conv_dw since in MobleNet, every Conv_dw is followed by Conv
+    """
+
+    def __init__(
+        self,
+        in_channel,
+        out_channel,
+        kernel_size=3,
+        stride=1,
+        padding=1,
+        use_relu6=False,
+    ):
+        super().__init__()
+        self.layers = [
+            nn.Conv2d(
+                in_channel,
+                in_channel,
+                kernel_size,
+                stride,
+                padding,
+                bias=False,
+                groups=in_channel,
+            ),
+            nn.BatchNorm2d(in_channel),
+        ]
+        if use_relu6:
+            self.layers.append(nn.ReLU6(inplace=True))
+        else:
+            self.layers.append(nn.ReLU(inplace=True))
+        self.layers.append(
+            Conv(
+                in_channel,
+                out_channel,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+                use_relu6=use_relu6,
+            )
+        )
+        self.model = nn.Sequential(*self.layers)
+
+    def forward(self, input):
+        return self.model(input)
+
+
+class MobileNetV1(nn.Module):
+    def __init__(self, num_classes, use_relu6=False):
+        super().__init__()
+
+        self.num_classes = num_classes
+
+        self.model = nn.Sequential(
+            Conv(3, 32, stride=2, use_relu6=use_relu6),
+            Conv_dw_Conv(32, 64, kernel_size=3, stride=1, use_relu6=use_relu6),
+            Conv_dw_Conv(64, 128, kernel_size=3, stride=2, use_relu6=use_relu6),
+            Conv_dw_Conv(128, 128, kernel_size=3, stride=1, use_relu6=use_relu6),
+            Conv_dw_Conv(128, 256, kernel_size=3, stride=2, use_relu6=use_relu6),
+            Conv_dw_Conv(256, 256, kernel_size=3, stride=1, use_relu6=use_relu6),
+            Conv_dw_Conv(256, 512, kernel_size=3, stride=2, use_relu6=use_relu6),
+            Conv_dw_Conv(512, 512, kernel_size=3, stride=1, use_relu6=use_relu6),
+            Conv_dw_Conv(512, 512, kernel_size=3, stride=1, use_relu6=use_relu6),
+            Conv_dw_Conv(512, 512, kernel_size=3, stride=1, use_relu6=use_relu6),
+            Conv_dw_Conv(512, 512, kernel_size=3, stride=1, use_relu6=use_relu6),
+            Conv_dw_Conv(512, 512, kernel_size=3, stride=1, use_relu6=use_relu6),
+            Conv_dw_Conv(512, 1024, kernel_size=3, stride=2, use_relu6=use_relu6),
+            Conv_dw_Conv(1024, 1024, kernel_size=3, stride=1, use_relu6=use_relu6),
+        )
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Linear(1024, num_classes)
+
+    def forward(self, input):
+        x = self.model(input)
+        x = self.avg_pool(x)
+        x = x.view(-1, 1024)
+        out = self.fc(x)
+
+        return out

--- a/mobilenetv2/__init__.py
+++ b/mobilenetv2/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MobilenetV2 model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/mobilenetv2/pytorch/__init__.py
+++ b/mobilenetv2/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MobilenetV2 PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/mobilenetv2/pytorch/loader.py
+++ b/mobilenetv2/pytorch/loader.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MobilenetV2 model loader implementation
+"""
+
+from ...base import ForgeModel
+import torch
+from PIL import Image
+from ...tools.utils import get_file
+from torchvision import transforms
+from .src.utils import download_model
+
+
+class ModelLoader(ForgeModel):
+    """Loads MobilenetV2 model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "mobilenet_v2"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained MobilenetV2 model."""
+        model = download_model(
+            torch.hub.load, "pytorch/vision:v0.10.0", cls.model_name, pretrained=True
+        )
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for MobilenetV2 model"""
+
+        # Get the Image
+        image_file = get_file(
+            "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        inputs = preprocess(image).unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/mobilenetv2/pytorch/src/utils.py
+++ b/mobilenetv2/pytorch/src/utils.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from loguru import logger
+import requests
+import time
+import os
+import shutil
+import urllib
+
+
+def download_model(download_func, *args, num_retries=3, timeout=180, **kwargs):
+    for _ in range(num_retries):
+        try:
+            return download_func(*args, **kwargs)
+        except (
+            requests.exceptions.HTTPError,
+            urllib.error.HTTPError,
+            requests.exceptions.ReadTimeout,
+            urllib.error.URLError,
+        ):
+            logger.trace("HTTP error occurred. Retrying...")
+            shutil.rmtree(os.path.expanduser("~") + "/.cache", ignore_errors=True)
+            shutil.rmtree(
+                os.path.expanduser("~") + "/.torch/models", ignore_errors=True
+            )
+            shutil.rmtree(
+                os.path.expanduser("~") + "/.torchxrayvision/models_data",
+                ignore_errors=True,
+            )
+            os.mkdir(os.path.expanduser("~") + "/.cache")
+        time.sleep(timeout)
+
+    logger.error("Failed to download the model after multiple retries.")
+    assert False, "Failed to download the model after multiple retries."

--- a/monodepth2/__init__.py
+++ b/monodepth2/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Monodepth2 model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/monodepth2/pytorch/__init__.py
+++ b/monodepth2/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Monodepth2 PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/monodepth2/pytorch/loader.py
+++ b/monodepth2/pytorch/loader.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Monodepth2 model loader implementation
+"""
+
+from ...base import ForgeModel
+from .src.utils import load_model, load_input
+
+
+class ModelLoader(ForgeModel):
+    """Loads Monodepth2 model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "mono_640x192"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained Monodepth2 model."""
+        model, height, width = load_model(cls.model_name)
+        model.eval()
+
+        cls._height = height
+        cls._width = width
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Monodepth2 model"""
+
+        inputs = load_input(cls._height, cls._width)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/monodepth2/pytorch/src/depth_decoder.py
+++ b/monodepth2/pytorch/src/depth_decoder.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Copyright Niantic 2019. Patent Pending. All rights reserved.
+#
+# This software is licensed under the terms of the Monodepth2 licence
+# which allows for non-commercial use only, the full terms of which are made
+# available in the LICENSE file.
+
+from collections import OrderedDict
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from .layers import (
+    Conv3x3,
+    ConvBlock,
+    upsample,
+)
+
+
+class DepthDecoder(nn.Module):
+    def __init__(
+        self, num_ch_enc, scales=range(4), num_output_channels=1, use_skips=True
+    ):
+        super(DepthDecoder, self).__init__()
+
+        self.num_output_channels = num_output_channels
+        self.use_skips = use_skips
+        self.upsample_mode = "nearest"
+        self.scales = scales
+
+        self.num_ch_enc = num_ch_enc
+        self.num_ch_dec = np.array([16, 32, 64, 128, 256])
+
+        # decoder
+        self.convs = OrderedDict()
+        for i in range(4, -1, -1):
+            # upconv_0
+            num_ch_in = self.num_ch_enc[-1] if i == 4 else self.num_ch_dec[i + 1]
+            num_ch_out = self.num_ch_dec[i]
+            self.convs[("upconv", i, 0)] = ConvBlock(num_ch_in, num_ch_out)
+
+            # upconv_1
+            num_ch_in = self.num_ch_dec[i]
+            if self.use_skips and i > 0:
+                num_ch_in += self.num_ch_enc[i - 1]
+            num_ch_out = self.num_ch_dec[i]
+            self.convs[("upconv", i, 1)] = ConvBlock(num_ch_in, num_ch_out)
+
+        for s in self.scales:
+            self.convs[("dispconv", s)] = Conv3x3(
+                self.num_ch_dec[s], self.num_output_channels
+            )
+
+        self.decoder = nn.ModuleList(list(self.convs.values()))
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, input_features):
+        self.outputs = {}
+
+        # decoder
+        x = input_features[-1]
+        for i in range(4, -1, -1):
+            x = self.convs[("upconv", i, 0)](x)
+            x = [upsample(x)]
+            if self.use_skips and i > 0:
+                x += [input_features[i - 1]]
+            x = torch.cat(x, 1)
+            x = self.convs[("upconv", i, 1)](x)
+            if i in self.scales:
+                self.outputs[("disp", i)] = self.sigmoid(self.convs[("dispconv", i)](x))
+
+        return self.outputs

--- a/monodepth2/pytorch/src/layers.py
+++ b/monodepth2/pytorch/src/layers.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright Niantic 2019. Patent Pending. All rights reserved.
+#
+# This software is licensed under the terms of the Monodepth2 licence
+# which allows for non-commercial use only, the full terms of which are made
+# available in the LICENSE file.
+
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ConvBlock(nn.Module):
+    """Layer to perform a convolution followed by ELU"""
+
+    def __init__(self, in_channels, out_channels):
+        super(ConvBlock, self).__init__()
+
+        self.conv = Conv3x3(in_channels, out_channels)
+        self.nonlin = nn.ELU(inplace=True)
+
+    def forward(self, x):
+        out = self.conv(x)
+        out = self.nonlin(out)
+        return out
+
+
+class Conv3x3(nn.Module):
+    """Layer to pad and convolve input"""
+
+    def __init__(self, in_channels, out_channels, use_refl=True):
+        super(Conv3x3, self).__init__()
+
+        if use_refl:
+            self.pad = nn.ReflectionPad2d(1)
+        else:
+            self.pad = nn.ZeroPad2d(1)
+        self.conv = nn.Conv2d(int(in_channels), int(out_channels), 3)
+
+    def forward(self, x):
+        out = self.pad(x)
+        out = self.conv(out)
+        return out
+
+
+def upsample(x):
+    """Upsample input tensor by a factor of 2"""
+    return F.interpolate(x, scale_factor=2, mode="nearest")

--- a/monodepth2/pytorch/src/resnet_encoder.py
+++ b/monodepth2/pytorch/src/resnet_encoder.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright Niantic 2019. Patent Pending. All rights reserved.
+#
+# This software is licensed under the terms of the Monodepth2 licence
+# which allows for non-commercial use only, the full terms of which are made
+# available in the LICENSE file.
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.utils.model_zoo as model_zoo
+import torchvision.models as models
+
+
+class ResNetMultiImageInput(models.ResNet):
+    """Constructs a resnet model with varying number of input images.
+    Adapted from https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
+    """
+
+    def __init__(self, block, layers, num_classes=1000, num_input_images=1):
+        super(ResNetMultiImageInput, self).__init__(block, layers)
+        self.inplanes = 64
+        self.conv1 = nn.Conv2d(
+            num_input_images * 3, 64, kernel_size=7, stride=2, padding=3, bias=False
+        )
+        self.bn1 = nn.BatchNorm2d(64)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.layer1 = self._make_layer(block, 64, layers[0])
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+
+def resnet_multiimage_input(num_layers, pretrained=False, num_input_images=1):
+    """Constructs a ResNet model.
+    Args:
+        num_layers (int): Number of resnet layers. Must be 18 or 50
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        num_input_images (int): Number of frames stacked as input
+    """
+    assert num_layers in [18, 50], "Can only run with 18 or 50 layer resnet"
+    blocks = {18: [2, 2, 2, 2], 50: [3, 4, 6, 3]}[num_layers]
+    block_type = {18: models.resnet.BasicBlock, 50: models.resnet.Bottleneck}[
+        num_layers
+    ]
+    model = ResNetMultiImageInput(block_type, blocks, num_input_images=num_input_images)
+
+    if pretrained:
+        loaded = model_zoo.load_url(
+            models.resnet.model_urls["resnet{}".format(num_layers)]
+        )
+        loaded["conv1.weight"] = (
+            torch.cat([loaded["conv1.weight"]] * num_input_images, 1) / num_input_images
+        )
+        model.load_state_dict(loaded)
+    return model
+
+
+class ResnetEncoder(nn.Module):
+    """Pytorch module for a resnet encoder"""
+
+    def __init__(self, num_layers, pretrained, num_input_images=1):
+        super(ResnetEncoder, self).__init__()
+
+        self.num_ch_enc = np.array([64, 64, 128, 256, 512])
+
+        resnets = {
+            18: models.resnet18,
+            34: models.resnet34,
+            50: models.resnet50,
+            101: models.resnet101,
+            152: models.resnet152,
+        }
+
+        if num_layers not in resnets:
+            raise ValueError(
+                "{} is not a valid number of resnet layers".format(num_layers)
+            )
+
+        if num_input_images > 1:
+            self.encoder = resnet_multiimage_input(
+                num_layers, pretrained, num_input_images
+            )
+        else:
+            self.encoder = resnets[num_layers](pretrained)
+
+        if num_layers > 34:
+            self.num_ch_enc[1:] *= 4
+
+    def forward(self, input_image):
+        self.features = []
+        x = (input_image - 0.45) / 0.225
+        x = self.encoder.conv1(x)
+        x = self.encoder.bn1(x)
+        self.features.append(self.encoder.relu(x))
+        self.features.append(
+            self.encoder.layer1(self.encoder.maxpool(self.features[-1]))
+        )
+        self.features.append(self.encoder.layer2(self.features[-1]))
+        self.features.append(self.encoder.layer3(self.features[-1]))
+        self.features.append(self.encoder.layer4(self.features[-1]))
+
+        return self.features

--- a/monodepth2/pytorch/src/utils.py
+++ b/monodepth2/pytorch/src/utils.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+import torch
+from torchvision import transforms
+import requests
+from PIL import Image
+import PIL.Image as pil
+from io import BytesIO
+from .resnet_encoder import ResnetEncoder
+from .depth_decoder import DepthDecoder
+
+
+class MonoDepth2(torch.nn.Module):
+    def __init__(self, encoder, depth_decoder):
+        super().__init__()
+        self.encoder = encoder
+        self.depth_decoder = depth_decoder
+
+    def forward(self, input):
+        features = self.encoder(input)
+        outputs = self.depth_decoder(features)
+        return outputs[("disp", 0)]
+
+
+def load_model(variant):
+    encoder_path = os.path.join("models", variant, "encoder.pth")
+    depth_decoder_path = os.path.join("models", variant, "depth.pth")
+
+    encoder = ResnetEncoder(18, False)
+    depth_decoder = DepthDecoder(num_ch_enc=encoder.num_ch_enc, scales=range(4))
+
+    loaded_dict_enc = torch.load(encoder_path, map_location="cpu")
+    filtered_dict_enc = {
+        k: v for k, v in loaded_dict_enc.items() if k in encoder.state_dict()
+    }
+    encoder.load_state_dict(filtered_dict_enc)
+
+    loaded_dict = torch.load(depth_decoder_path, map_location="cpu")
+    depth_decoder.load_state_dict(loaded_dict)
+
+    model = MonoDepth2(encoder, depth_decoder)
+    model.eval()
+
+    feed_height = loaded_dict_enc["height"]
+    feed_width = loaded_dict_enc["width"]
+
+    return model, feed_height, feed_width
+
+
+def load_input(feed_height, feed_width):
+
+    image_url = "https://raw.githubusercontent.com/nianticlabs/monodepth2/master/assets/test_image.jpg"
+    response = requests.get(image_url)
+    input_image = Image.open(BytesIO(response.content)).convert("RGB")
+    input_image_resized = input_image.resize((feed_width, feed_height), pil.LANCZOS)
+    input_tensor = transforms.ToTensor()(input_image_resized).unsqueeze(0)
+
+    return input_tensor

--- a/nanogpt/__init__.py
+++ b/nanogpt/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+NanoGPT model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/nanogpt/pytorch/__init__.py
+++ b/nanogpt/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+NanoGPT PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/nanogpt/pytorch/loader.py
+++ b/nanogpt/pytorch/loader.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+NanoGPT model loader implementation
+"""
+
+from ...base import ForgeModel
+
+from transformers import AutoModel, AutoTokenizer
+
+
+class ModelLoader(ForgeModel):
+    """Loads NanoGPT model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "FinancialSupport/NanoGPT"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained NanoGPT model."""
+        model = AutoModel.from_pretrained(
+            cls.model_name,
+            ignore_mismatched_sizes=True,
+            use_cache=False,
+            return_dict=False,
+        )
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for NanoGPT model"""
+
+        tokenizer = AutoTokenizer.from_pretrained(cls.model_name)
+        tokenizer.pad_token = tokenizer.eos_token
+
+        # Input prompt
+        input_prompt = "The financial market showed signs of volatility"
+
+        # Tokenize input
+        inputs = tokenizer(
+            input_prompt,
+            return_tensors="pt",
+            max_length=150,
+            padding=True,
+            truncation=True,
+        )
+
+        return inputs

--- a/phi1/__init__.py
+++ b/phi1/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+PHI1 model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/phi1/pytorch/__init__.py
+++ b/phi1/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Phi1 PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/phi1/pytorch/loader.py
+++ b/phi1/pytorch/loader.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Phi1 model loader implementation
+"""
+
+from transformers import PhiForTokenClassification, AutoTokenizer
+from ...base import ForgeModel
+
+
+class ModelLoader(ForgeModel):
+    """Loads Phi1 model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "microsoft/phi-1"
+    input_prompt = "HuggingFace is a company based in Paris and New York"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load Phi1 model from Hugging Face."""
+
+        # Initialize tokenizer first with default or overridden dtype
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        cls.tokenizer = AutoTokenizer.from_pretrained(
+            cls.model_name, **tokenizer_kwargs
+        )
+
+        # Load pre-trained model from HuggingFace
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = PhiForTokenClassification.from_pretrained(
+            cls.model_name, return_dict=False, use_cache=False, **model_kwargs
+        )
+        model.eval()
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Phi1 model"""
+
+        # Data preprocessing
+        inputs = cls.tokenizer(cls.input_prompt, return_tensors="pt")
+
+        return inputs

--- a/phi1_5/__init__.py
+++ b/phi1_5/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Phi1_5 model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/phi1_5/pytorch/__init__.py
+++ b/phi1_5/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Phi1_5 PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/phi1_5/pytorch/loader.py
+++ b/phi1_5/pytorch/loader.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Phi1_5 model loader implementation
+"""
+
+from transformers import PhiForTokenClassification, AutoTokenizer
+from ...base import ForgeModel
+
+
+class ModelLoader(ForgeModel):
+    """Loads Phi1_5 model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "microsoft/phi-1_5"
+    input_prompt = "HuggingFace is a company based in Paris and New York"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load Phi1_5 model from Hugging Face."""
+
+        # Initialize tokenizer first with default or overridden dtype
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        cls.tokenizer = AutoTokenizer.from_pretrained(
+            cls.model_name, **tokenizer_kwargs
+        )
+
+        # Load pre-trained model from HuggingFace
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = PhiForTokenClassification.from_pretrained(
+            cls.model_name, return_dict=False, use_cache=False, **model_kwargs
+        )
+        model.eval()
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Phi1_5 model"""
+
+        # input_prompt
+        inputs = cls.tokenizer(cls.input_prompt, return_tensors="pt")
+
+        return inputs

--- a/swin/__init__.py
+++ b/swin/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Swin model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/swin/pytorch/__init__.py
+++ b/swin/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Swin PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/swin/pytorch/loader.py
+++ b/swin/pytorch/loader.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Swin model loader implementation
+"""
+
+from ...base import ForgeModel
+from torchvision import models
+import torch
+from PIL import Image
+from torchvision import models
+from ...tools.utils import get_file
+
+
+class ModelLoader(ForgeModel):
+    """Loads Swin model and sample input."""
+
+    # Shared configuration parameters
+    model_name = "swin_t"
+    weight_name = "Swin_T_Weights"
+
+    @classmethod
+    def load_model(cls, dtype_override=None):
+        """Load pretrained Swin model."""
+        weights = getattr(models, cls.weight_name).DEFAULT
+        model = getattr(models, cls.model_name)(weights=weights)
+        model.eval()
+
+        cls._weights = weights
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    @classmethod
+    def load_inputs(cls, dtype_override=None):
+        """Prepare sample input for Swin model"""
+
+        preprocess = cls._weights.transforms()
+        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
+        image = Image.open(image_file).convert("RGB")
+        img_t = preprocess(image)
+        batch_t = torch.unsqueeze(img_t, 0)
+        inputs = batch_t.contiguous()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs


### PR DESCRIPTION
This PR adds demos for below pytorch models(ported from tt-forge-fe)

- Distilbert
- DLA
- Mnist
- MobilenetV1
- MobilenetV2
- Monodepth2
- NanoGPT
- phi1
- phi1_5
- Swin