### PR TITLE
Change batch_input generation

### DIFF
--- a/bloom/pytorch/loader.py
+++ b/bloom/pytorch/loader.py
@@ -66,7 +66,7 @@ class ModelLoader(ForgeModel):
             )  # This will initialize the tokenizer
 
         # Create batch of sample inputs
-        cls.test_input = ["This is a sample text from "] * batch_size
+        cls.test_input = "This is a sample text from "
 
         inputs = cls.tokenizer(
             cls.test_input,
@@ -76,6 +76,10 @@ class ModelLoader(ForgeModel):
             add_special_tokens=True,
             truncation=True,
         )
+
+         # Replicate tensors for batch size
+        for key in inputs:
+            inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
         return inputs
 
@@ -95,5 +99,4 @@ class ModelLoader(ForgeModel):
         # Get logits for the last token in each batch
         next_token_logits = outputs.logits[:, -1]
         next_tokens = next_token_logits.softmax(dim=-1).argmax(dim=-1)
-
         return [cls.tokenizer.decode([token.item()]) for token in next_tokens]

--- a/bloom/pytorch/loader.py
+++ b/bloom/pytorch/loader.py
@@ -77,7 +77,7 @@ class ModelLoader(ForgeModel):
             truncation=True,
         )
 
-         # Replicate tensors for batch size
+        # Replicate tensors for batch size
         for key in inputs:
             inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 

--- a/clip/pytorch/loader.py
+++ b/clip/pytorch/loader.py
@@ -67,17 +67,19 @@ class ModelLoader(ForgeModel):
 
         image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
         image = Image.open(str(image_file))
-        batch_images = [image] * batch_size  # Create a batch of images
 
         text = ["a photo of a cat", "a photo of a dog"]
-        batch_text = [text] * batch_size  # Create a batch of text
 
         inputs = cls.processor(
-            text=batch_text,
-            images=batch_images,
+            text=text,
+            images=image,
             return_tensors="pt",
             padding=True,
         )
+
+        # Replicate tensors for batch size
+        for key in inputs:
+            inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
         if dtype_override is not None:
             inputs["pixel_values"] = inputs["pixel_values"].to(dtype_override)

--- a/codegen/pytorch/loader.py
+++ b/codegen/pytorch/loader.py
@@ -60,7 +60,7 @@ class ModelLoader(ForgeModel):
         text = "def hello_world():"
         inputs = cls.tokenizer(text, return_tensors="pt")
 
-         # Replicate tensors for batch size
+        # Replicate tensors for batch size
         for key in inputs:
             inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
@@ -79,9 +79,9 @@ class ModelLoader(ForgeModel):
         # Ensure tokenizer is initialized
         if not hasattr(cls, "tokenizer"):
             cls.load_model()
-            
+
         # Get logits for the last token in each batch
         next_token_logits = outputs.logits[:, -1]
         next_tokens = next_token_logits.softmax(dim=-1).argmax(dim=-1)
-        
+
         return [cls.tokenizer.decode([token.item()]) for token in next_tokens]

--- a/codegen/pytorch/loader.py
+++ b/codegen/pytorch/loader.py
@@ -80,8 +80,11 @@ class ModelLoader(ForgeModel):
         if not hasattr(cls, "tokenizer"):
             cls.load_model()
 
+        # Handle both structured outputs and raw tensors
+        logits = outputs.logits if hasattr(outputs, "logits") else outputs
+
         # Get logits for the last token in each batch
-        next_token_logits = outputs.logits[:, -1]
+        next_token_logits = logits[:, -1]
         next_tokens = next_token_logits.softmax(dim=-1).argmax(dim=-1)
 
         return [cls.tokenizer.decode([token.item()]) for token in next_tokens]

--- a/deit/pytorch/loader.py
+++ b/deit/pytorch/loader.py
@@ -62,7 +62,10 @@ class ModelLoader(ForgeModel):
 
         image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
         image = Image.open(str(image_file))
-        batch_images = [image] * batch_size  # Create a batch of images
-        inputs = cls.feature_extractor(images=batch_images, return_tensors="pt")
+        inputs = cls.feature_extractor(images=image, return_tensors="pt")
+
+        # Replicate tensors for batch size
+        for key in inputs:
+            inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
         return inputs


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/920

### Problem description
An alternative way to increase batch_size was suggested.

### What's changed
5 Models added in https://github.com/tenstorrent/tt-forge-models/pull/12 are updated to use the follow batch increase method (autoencoder_linear didn't require changes). 

        self.test_input = "This is a sample text from "
        inputs = self.tokenizer.encode_plus(
            self.test_input,
            return_tensors="pt",
            max_length=32,
            padding="max_length",
            truncation=True,
        )
        inputs["input_ids"] = inputs["input_ids"].repeat_interleave(batch, dim=0)
        inputs["attention_mask"] = inputs["attention_mask"].repeat_interleave(batch, dim=0)
        
This requires no changes to tt-torch tests.

### Checklist
- [x] New/Existing tests provide coverage for changes
