### PR TITLE
Add missing dtype_override to load_inputs() of nlp models

### DIFF
--- a/dpr/pytorch/loader.py
+++ b/dpr/pytorch/loader.py
@@ -41,7 +41,7 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, dtype_override=None):
         """Generate sample inputs for DPR model."""
 
         # Ensure tokenizer is initialized

--- a/llama/pytorch/loader.py
+++ b/llama/pytorch/loader.py
@@ -40,7 +40,7 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, dtype_override=None):
         """Generate sample inputs for Llama3 model."""
 
         # Ensure tokenizer is initialized

--- a/mamba/pytorch/loader.py
+++ b/mamba/pytorch/loader.py
@@ -40,7 +40,7 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, dtype_override=None):
         """Generate sample inputs for Mamba model."""
 
         # Ensure tokenizer is initialized

--- a/roberta/pytorch/loader.py
+++ b/roberta/pytorch/loader.py
@@ -41,7 +41,7 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, dtype_override=None):
         """Generate sample inputs for RoBERTa model."""
 
         # Ensure tokenizer is initialized

--- a/squeezebert/pytorch/loader.py
+++ b/squeezebert/pytorch/loader.py
@@ -41,7 +41,7 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, dtype_override=None):
         """Generate sample inputs for SqueezeBERT model."""
 
         # Ensure tokenizer is initialized

--- a/t5/pytorch/loader.py
+++ b/t5/pytorch/loader.py
@@ -40,7 +40,7 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, dtype_override=None):
         """Generate sample inputs for T5 model."""
 
         # Ensure tokenizer is initialized

--- a/whisper/pytorch/loader.py
+++ b/whisper/pytorch/loader.py
@@ -40,7 +40,7 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, dtype_override=None):
         """Generate sample inputs for Whisper model."""
 
         # Ensure processor is initialized

--- a/xglm/pytorch/loader.py
+++ b/xglm/pytorch/loader.py
@@ -41,7 +41,7 @@ class ModelLoader(ForgeModel):
         return model
 
     @classmethod
-    def load_inputs(cls):
+    def load_inputs(cls, dtype_override=None):
         """Generate sample inputs for XGLM model."""
 
         # Ensure tokenizer is initialized


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-models/issues/29

### Summary 
This PR fixes https://github.com/tenstorrent/tt-forge-models/issues/29 by adding missing dtype_override to load_inputs() of nlp models added in [this PR](https://github.com/tenstorrent/tt-forge-models/pull/19)