### PR TITLE
Add post-processing for e2e passing models

### DIFF
--- a/hardnet/pytorch/loader.py
+++ b/hardnet/pytorch/loader.py
@@ -19,6 +19,7 @@ from ...config import (
     Framework,
 )
 from ...base import ForgeModel
+from ...tools.utils import print_compiled_model_results
 
 
 class ModelLoader(ForgeModel):
@@ -111,3 +112,6 @@ class ModelLoader(ForgeModel):
             input_batch = input_batch.to(dtype_override)
 
         return input_batch
+
+    def print_cls_results(self, compiled_model_out):
+        print_compiled_model_results(compiled_model_out)

--- a/vgg/pytorch/loader.py
+++ b/vgg/pytorch/loader.py
@@ -16,7 +16,7 @@ from ...config import (
 from ...base import ForgeModel
 
 from PIL import Image
-from ...tools.utils import get_file
+from ...tools.utils import get_file, print_compiled_model_results
 from torchvision import transforms
 
 
@@ -93,3 +93,6 @@ class ModelLoader(ForgeModel):
             inputs = inputs.to(dtype_override)
 
         return inputs
+
+    def print_cls_results(self, compiled_model_out):
+        print_compiled_model_results(compiled_model_out)

--- a/vit/pytorch/loader.py
+++ b/vit/pytorch/loader.py
@@ -63,6 +63,7 @@ class ModelLoader(ForgeModel):
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             model = model.to(dtype_override)
+        self.model = model
 
         return model
 
@@ -84,3 +85,8 @@ class ModelLoader(ForgeModel):
             inputs = inputs.to(dtype_override)
 
         return inputs
+
+    def post_processing(self, co_out):
+        logits = co_out[0]
+        predicted_class_idx = logits.argmax(-1).item()
+        print("Predicted class:", self.model.config.id2label[predicted_class_idx])

--- a/vovnet/pytorch/loader.py
+++ b/vovnet/pytorch/loader.py
@@ -17,6 +17,7 @@ from ...config import (
     Framework,
 )
 from ...base import ForgeModel
+from ...tools.utils import print_compiled_model_results
 
 
 class ModelLoader(ForgeModel):
@@ -76,3 +77,6 @@ class ModelLoader(ForgeModel):
             inputs = inputs.to(dtype_override)
 
         return inputs
+
+    def print_cls_results(self, compiled_model_out):
+        print_compiled_model_results(compiled_model_out)

--- a/wide_resnet/pytorch/loader.py
+++ b/wide_resnet/pytorch/loader.py
@@ -16,6 +16,7 @@ from ...config import (
 )
 from ...base import ForgeModel
 from ...tools.utils import get_file
+from ...tools.utils import print_compiled_model_results
 
 
 class ModelLoader(ForgeModel):
@@ -87,3 +88,6 @@ class ModelLoader(ForgeModel):
             inputs = inputs.to(dtype_override)
 
         return inputs
+
+    def print_cls_results(self, compiled_model_out):
+        print_compiled_model_results(compiled_model_out)

--- a/xception/pytorch/loader.py
+++ b/xception/pytorch/loader.py
@@ -18,6 +18,7 @@ from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 from PIL import Image
 from ...tools.utils import get_file
+from ...tools.utils import print_compiled_model_results
 
 
 class ModelLoader(ForgeModel):
@@ -87,3 +88,6 @@ class ModelLoader(ForgeModel):
             inputs = inputs.to(dtype_override)
 
         return inputs
+
+    def print_cls_results(self, compiled_model_out):
+        print_compiled_model_results(compiled_model_out)


### PR DESCRIPTION
This PR adds post-processing for the following models:

- Hardnet
- VGG
- Vit
- Vovnet
- Wideresnet
- Xception
