### PR TITLE
Refactor model loading for better demo performance

### DIFF
--- a/albert/masked_lm/pytorch/loader.py
+++ b/albert/masked_lm/pytorch/loader.py
@@ -171,7 +171,7 @@ class ModelLoader(ForgeModel):
             inputs = self.load_inputs()
 
         # Get the prediction for the masked token
-        logits = outputs.logits
+        logits = outputs[0]
         mask_token_index = (inputs.input_ids == self.tokenizer.mask_token_id)[
             0
         ].nonzero(as_tuple=True)[0]

--- a/hardnet/pytorch/loader.py
+++ b/hardnet/pytorch/loader.py
@@ -20,6 +20,7 @@ from ...config import (
 )
 from ...base import ForgeModel
 from ...tools.utils import print_compiled_model_results
+from ...tools.utils import get_file
 
 
 class ModelLoader(ForgeModel):
@@ -91,8 +92,8 @@ class ModelLoader(ForgeModel):
             dict: Input tensors and attention masks that can be fed to the model.
         """
 
-        url = "https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png"
-        input_image = Image.open(requests.get(url, stream=True).raw)
+        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
+        input_image = Image.open(file_path)
         preprocess = transforms.Compose(
             [
                 transforms.Resize(256),

--- a/vovnet/pytorch/loader.py
+++ b/vovnet/pytorch/loader.py
@@ -4,9 +4,8 @@
 """
 Vovnet model loader implementation for question answering
 """
-import torch
 from pytorchcv.model_provider import get_model as ptcv_get_model
-import requests
+from torchvision import transforms
 from PIL import Image
 
 from ...config import (
@@ -18,6 +17,7 @@ from ...config import (
 )
 from ...base import ForgeModel
 from ...tools.utils import print_compiled_model_results
+from ...tools.utils import get_file
 
 
 class ModelLoader(ForgeModel):
@@ -69,8 +69,20 @@ class ModelLoader(ForgeModel):
     def load_inputs(self, dtype_override=None):
         """Generate sample inputs for Vovnet models."""
 
-        # Create a random input tensor with the correct shape, using default dtype
-        inputs = torch.rand(1, *self.input_shape)
+        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
+        input_image = Image.open(file_path).convert("RGB")
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        img_tensor = preprocess(input_image)
+        inputs = img_tensor.unsqueeze(0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:

--- a/yolox/pytorch/src/utils.py
+++ b/yolox/pytorch/src/utils.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import cv2
+import numpy as np
+import torch
+from yolox.data.datasets import COCO_CLASSES
+from yolox.utils import demo_postprocess, multiclass_nms
+
+
+def print_detection_results(co_out, ratio, input_shape):
+    """
+    Post-processes raw model outputs and prints detected object information.
+
+    This function converts model outputs into bounding boxes, applies non-maximum suppression (NMS),
+    and prints the class name, confidence score, and bounding box coordinates for each detected object.
+    """
+    for i in range(len(co_out)):
+        co_out[i] = co_out[i].detach().float().numpy()
+
+    predictions = demo_postprocess(co_out[0], input_shape)[0]
+    boxes = predictions[:, :4]
+    scores = predictions[:, 4:5] * predictions[:, 5:]
+    boxes_xyxy = np.ones_like(boxes)
+    boxes_xyxy[:, 0] = boxes[:, 0] - boxes[:, 2] / 2.0
+    boxes_xyxy[:, 1] = boxes[:, 1] - boxes[:, 3] / 2.0
+    boxes_xyxy[:, 2] = boxes[:, 0] + boxes[:, 2] / 2.0
+    boxes_xyxy[:, 3] = boxes[:, 1] + boxes[:, 3] / 2.0
+    boxes_xyxy /= ratio
+    dets = multiclass_nms(boxes_xyxy, scores, nms_thr=0.45, score_thr=0.1)
+
+    if dets is not None:
+        final_boxes, final_scores, final_cls_inds = dets[:, :4], dets[:, 4], dets[:, 5]
+        for box, score, cls_ind in zip(final_boxes, final_scores, final_cls_inds):
+            class_name = COCO_CLASSES[int(cls_ind)]
+            x_min, y_min, x_max, y_max = box
+            print(
+                f"Class: {class_name}, Confidence: {score}, Coordinates: ({x_min}, {y_min}, {x_max}, {y_max})"
+            )


### PR DESCRIPTION
### Problem description
This PR includes changes in model loaders of few models to get better demo performance.

### What's changed

- Correct image is used for hardnet model. 
- Random tensor inputs was replaced with actual image for vovnet model
- Weight file is being loaded using get_file for yolox model and cleaned up at end of demo.
- Post-processing steps are added for yolox model