### PR TITLE
Fix flan_t5 ValueError

### DIFF
--- a/flan_t5/pytorch/loader.py
+++ b/flan_t5/pytorch/loader.py
@@ -75,22 +75,6 @@ class ModelLoader(ForgeModel):
             model_kwargs["torch_dtype"] = dtype_override
 
         model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name, **model_kwargs)
-
-        class FlanT5(torch.nn.Module):
-            def __init__(self, model):
-                super().__init__()
-                self.model = model
-
-            def forward(self, input_ids, decoder_input_ids, attention_mask=None):
-                inputs = {
-                    "input_ids": input_ids,
-                    "decoder_input_ids": decoder_input_ids,
-                    "attention_mask": attention_mask,
-                }
-                output = self.model(**inputs)
-                return output
-
-        model = FlanT5(model)
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):

--- a/flan_t5/pytorch/loader.py
+++ b/flan_t5/pytorch/loader.py
@@ -70,11 +70,27 @@ class ModelLoader(ForgeModel):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
 
         # Load pre-trained model from HuggingFace
-        model_kwargs = {}
+        model_kwargs = {"return_dict": False, "use_cache": False}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
         model = AutoModelForSeq2SeqLM.from_pretrained(self.model_name, **model_kwargs)
+
+        class FlanT5(torch.nn.Module):
+            def __init__(self, model):
+                super().__init__()
+                self.model = model
+
+            def forward(self, input_ids, decoder_input_ids, attention_mask=None):
+                inputs = {
+                    "input_ids": input_ids,
+                    "decoder_input_ids": decoder_input_ids,
+                    "attention_mask": attention_mask,
+                }
+                output = self.model(**inputs)
+                return output
+
+        model = FlanT5(model)
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):

--- a/flan_t5/pytorch/loader.py
+++ b/flan_t5/pytorch/loader.py
@@ -70,7 +70,7 @@ class ModelLoader(ForgeModel):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
 
         # Load pre-trained model from HuggingFace
-        model_kwargs = {"return_dict": False, "use_cache": False}
+        model_kwargs = {"return_dict": False}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 


### PR DESCRIPTION
### Description
This PR includes a fix for the FlanT5 model to enable support for Forge compilation.Initialy it is blocked by the ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds during the compilation
