### PR TITLE
Add decoder_input_ids to t5 and Whisper models

### DIFF
--- a/t5/pytorch/loader.py
+++ b/t5/pytorch/loader.py
@@ -88,4 +88,8 @@ class ModelLoader(ForgeModel):
             return_tensors="pt",
         )
 
+        # T5 requires decoder input ids also an input
+        decoder_input_ids = torch.tensor([[self.tokenizer.pad_token_id]])
+        inputs["decoder_input_ids"] = decoder_input_ids
+
         return inputs

--- a/whisper/pytorch/loader.py
+++ b/whisper/pytorch/loader.py
@@ -89,5 +89,10 @@ class ModelLoader(ForgeModel):
         sample = ds[0]["audio"]
         inputs = self.processor(
             sample["array"], sampling_rate=sample["sampling_rate"], return_tensors="pt"
-        ).input_features
+        )
+
+        # Whisper requires decoder input ids also an input
+        decoder_input_ids = torch.tensor([[self.processor.tokenizer.pad_token_id]])
+        inputs["decoder_input_ids"] = decoder_input_ids
+
         return inputs


### PR DESCRIPTION
### Problem description
Sequence to Sequnce models like T5 requires decoder_input_ids also as an input to be passed to the model. An error is faced while loading the inputs of the model as below

>   ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds

We are facing this error in t5 & whisper model


### What's changed

In load_inputs() function of loader classes in t5 & whisper,

`decoder_input_ids` is passed along with input_ids

### Checklist
- [x] New/Existing tests provide coverage for changes


Attaching the logs

Error in t5 before the change : [t5.log](https://github.com/user-attachments/files/21232656/t5.log)

Error resolved after this change in t5 : [t5_decode_inps.log](https://github.com/user-attachments/files/21232677/t5_decode_inps.log)

Error in whisper before the change : [whisper_tiny.log](https://github.com/user-attachments/files/21232666/whisper_tiny.log)

Error resolved after this change in whisper : [whisper_decode.log](https://github.com/user-attachments/files/21232680/whisper_decode.log)

