### PR TITLE
Use variant enums instead of variant_name strings in existing models and apply BASE variant to few models

### DIFF
--- a/albert/masked_lm/pytorch/__init__.py
+++ b/albert/masked_lm/pytorch/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .loader import ModelLoader
+from .loader import ModelLoader, Variant

--- a/albert/masked_lm/pytorch/loader.py
+++ b/albert/masked_lm/pytorch/loader.py
@@ -16,7 +16,17 @@ from ....config import (
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
+
+
+class Variant(StrEnum):
+    """Available ALBERT model variants."""
+
+    BASE = "albert-base-v2"
+    LARGE = "albert-large-v2"
+    XLARGE = "albert-xlarge-v2"
+    XXLARGE = "albert-xxlarge-v2"
 
 
 class ModelLoader(ForgeModel):
@@ -24,54 +34,54 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        "albert-base-v2": LLMModelConfig(
+        Variant.BASE: LLMModelConfig(
             pretrained_model_name="albert/albert-base-v2",
             max_length=128,
         ),
-        "albert-large-v2": LLMModelConfig(
+        Variant.LARGE: LLMModelConfig(
             pretrained_model_name="albert/albert-large-v2",
             max_length=128,
         ),
-        "albert-xlarge-v2": LLMModelConfig(
+        Variant.XLARGE: LLMModelConfig(
             pretrained_model_name="albert/albert-xlarge-v2",
             max_length=128,
         ),
-        "albert-xxlarge-v2": LLMModelConfig(
+        Variant.XXLARGE: LLMModelConfig(
             pretrained_model_name="albert/albert-xxlarge-v2",
-            max_length=128,  # Added default max length
+            max_length=128,
         ),
     }
 
     # Default variant to use
-    DEFAULT_VARIANT = "albert-base-v2"
+    DEFAULT_VARIANT = Variant.BASE
 
     # Shared configuration parameters
     sample_text = "The capital of [MASK] is Paris."
 
-    def __init__(self, variant=None):
+    def __init__(self, variant: Optional[StrEnum] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional StrEnum specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
         self.tokenizer = None
 
     @classmethod
-    def _get_model_info(cls, variant_name: Optional[str]) -> ModelInfo:
+    def _get_model_info(cls, variant: Optional[StrEnum] = None) -> ModelInfo:
         """Implementation method for getting model info with validated variant.
 
         Args:
-            variant_name: Validated variant name string (or None if model has no variants).
-                         For models that support variants, this will never be None.
+            variant: Optional StrEnum specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
         return ModelInfo(
             model="albert_v2",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.NLP_MASKED_LM,
             source=ModelSource.HUGGING_FACE,

--- a/base.py
+++ b/base.py
@@ -17,7 +17,7 @@ class ForgeModel(ABC):
     """Base class for all TT-Forge model loaders."""
 
     # This is intended to be overridden by subclasses to define available model variants
-    # Format: {Variants.NAME: ModelConfig(...), ...}
+    # Format: {Variant.NAME: ModelConfig(...), ...}
     _VARIANTS: Dict[
         StrEnum, ModelConfig
     ] = {}  # Empty by default for models without variants

--- a/base.py
+++ b/base.py
@@ -9,7 +9,7 @@ for loading models, inputs, etc.
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Union, Type, Any
 
-from .config import ModelConfig, ModelInfo
+from .config import ModelConfig, ModelInfo, StrEnum
 import torch
 
 
@@ -17,9 +17,9 @@ class ForgeModel(ABC):
     """Base class for all TT-Forge model loaders."""
 
     # This is intended to be overridden by subclasses to define available model variants
-    # Format: {"variant_name": ModelConfig(...), ...}
+    # Format: {Variants.NAME: ModelConfig(...), ...}
     _VARIANTS: Dict[
-        str, ModelConfig
+        StrEnum, ModelConfig
     ] = {}  # Empty by default for models without variants
     DEFAULT_VARIANT = None
 
@@ -27,7 +27,7 @@ class ForgeModel(ABC):
         """Initialize a ForgeModel instance.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional StrEnum value specifying which variant to use.
                     If None, the default variant will be used.
         """
         # Validate and store the variant for this instance
@@ -37,30 +37,35 @@ class ForgeModel(ABC):
         self._variant_config = self.get_variant_config(variant)
 
     @classmethod
-    def query_available_variants(cls):
+    def query_available_variants(cls) -> Dict[StrEnum, ModelConfig]:
         """Returns a dictionary of available model variants and their configs.
 
         Returns:
-            dict: Dictionary mapping variant names to their configuration objects, or empty dict if
-                  the model doesn't support variants.
+            Dict[StrEnum, ModelConfig]:
+                Mapping of variant enum members to their ModelConfig,
+                or an empty dict if the model doesn't support variants.
+
         """
         if not cls._VARIANTS:
             return {}
         return cls._VARIANTS
 
     @classmethod
-    def _validate_variant(cls, variant=None):
+    def _validate_variant(cls, variant: Optional[StrEnum] = None) -> Optional[StrEnum]:
         """Validates and returns the variant to use.
 
         Args:
-            variant: Optional string specifying which variant to validate.
+            variant: Optional StrEnum specifying which variant to validate.
 
         Returns:
-            str or None: Validated variant name, or None for models without variants.
+            StrEnum or None: Validated variant, or None for models without variants.
 
         Raises:
+            TypeError: If caller passed something other than StrEnum/Variants
             ValueError: If the specified variant doesn't exist.
+
         """
+
         # If model doesn't support variants, return None
         if not cls._VARIANTS:
             return None
@@ -69,9 +74,15 @@ class ForgeModel(ABC):
         if variant is None:
             variant = cls.DEFAULT_VARIANT
 
+        # Enforce user provided correct variant type (same as default variant)
+        if not isinstance(variant, type(cls.DEFAULT_VARIANT)):
+            raise TypeError(
+                f"variant must be a {type(cls.DEFAULT_VARIANT).__name__}, not {type(variant).__name__}"
+            )
+
         # Validate the variant exists
         if variant not in cls._VARIANTS:
-            valid_variants = list(cls._VARIANTS.keys())
+            valid_variants = [v.value for v in cls._VARIANTS.keys()]
             raise ValueError(
                 f"Invalid variant '{variant}'. Available variants: {valid_variants}"
             )
@@ -79,11 +90,13 @@ class ForgeModel(ABC):
         return variant
 
     @classmethod
-    def get_variant_config(cls, variant=None) -> Optional[ModelConfig]:
+    def get_variant_config(
+        cls, variant: Optional[StrEnum] = None
+    ) -> Optional[ModelConfig]:
         """Get configuration for a specific variant after validation.
 
         Args:
-            variant: Optional string specifying which variant to get config for.
+            variant: Optional StrEnum specifying which variant to get config for.
 
         Returns:
             ModelConfig or None: Variant configuration object, or None for models without variants.
@@ -95,25 +108,27 @@ class ForgeModel(ABC):
         return cls._VARIANTS[variant]
 
     @classmethod
-    def get_model_info(cls, variant=None) -> ModelInfo:
+    def get_model_info(cls, variant: Optional[StrEnum] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant: Optional string specifying which variant to get info for.
+            variant: Optional StrEnum specifying which variant to get info for.
+                     If None, DEFAULT_VARIANT is used.
+
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        variant_name = cls._validate_variant(variant)
-        return cls._get_model_info(variant_name)
+        variant_enum = cls._validate_variant(variant)
+        return cls._get_model_info(variant_enum)
 
     @classmethod
     @abstractmethod
-    def _get_model_info(cls, variant_name: Optional[str]) -> ModelInfo:
+    def _get_model_info(cls, variant: Optional[StrEnum] = None) -> ModelInfo:
         """Implementation method for getting model info with validated variant.
 
         Args:
-            variant_name: Validated variant name string (or None if model has no variants).
+            variant: Optional StrEnum specifying which variant to get info for.
 
         Returns:
             ModelInfo: Information about the model and variant

--- a/bert/pytorch/__init__.py
+++ b/bert/pytorch/__init__.py
@@ -4,4 +4,4 @@
 """
 BERT PyTorch model implementation for Tenstorrent projects.
 """
-from .loader import ModelLoader
+from .loader import ModelLoader, Variant

--- a/bert/pytorch/loader.py
+++ b/bert/pytorch/loader.py
@@ -16,7 +16,15 @@ from ...config import (
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
+
+
+class Variant(StrEnum):
+    """Available BERT model variants."""
+
+    BASE = "base"
+    LARGE = "large"
 
 
 class ModelLoader(ForgeModel):
@@ -24,47 +32,47 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants
     _VARIANTS = {
-        "base": LLMModelConfig(
+        Variant.BASE: LLMModelConfig(
             pretrained_model_name="phiyodr/bert-base-finetuned-squad2",
             max_length=256,
         ),
-        "large": LLMModelConfig(
+        Variant.LARGE: LLMModelConfig(
             pretrained_model_name="phiyodr/bert-large-finetuned-squad2",
             max_length=256,
         ),
     }
 
     # Default variant to use
-    DEFAULT_VARIANT = "large"
+    DEFAULT_VARIANT = Variant.LARGE
 
     # Shared configuration parameters
     context = 'Johann Joachim Winckelmann was a German art historian and archaeologist. He was a pioneering Hellenist who first articulated the difference between Greek, Greco-Roman and Roman art. "The prophet and founding hero of modern archaeology", Winckelmann was one of the founders of scientific archaeology and first applied the categories of style on a large, systematic basis to the history of art. '
     question = "What discipline did Winkelmann create?"
 
-    def __init__(self, variant=None):
+    def __init__(self, variant: Optional[StrEnum] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional StrEnum specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
         self.tokenizer = None
 
     @classmethod
-    def _get_model_info(cls, variant_name: Optional[str]) -> ModelInfo:
+    def _get_model_info(cls, variant: Optional[StrEnum] = None) -> ModelInfo:
         """Implementation method for getting model info with validated variant.
 
         Args:
-            variant_name: Validated variant name string (or None if model has no variants).
-                         For models that support variants, this will never be None.
+            variant: Optional StrEnum specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
         return ModelInfo(
             model="bert",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.NLP_QA,
             source=ModelSource.HUGGING_FACE,

--- a/config.py
+++ b/config.py
@@ -95,11 +95,18 @@ class ModelInfo:
     """
 
     model: str
-    variant: str
+    variant: StrEnum
     group: ModelGroup
     task: ModelTask
     source: ModelSource
     framework: Framework
+
+    def __post_init__(self):
+        if not isinstance(self.variant, StrEnum):
+            # TODO - Change to raise TypeError once all models updated.
+            print(
+                f"Warning: ModelInfo.variant should be a StrEnum, not {type(self.variant).__name__}"
+            )
 
     @property
     def name(self) -> str:
@@ -113,7 +120,7 @@ class ModelInfo:
             "source": str(self.source),
             "framework": str(self.framework),
             "model_arch": self.model,
-            "variant_name": self.variant,
+            "variant_name": str(self.variant),
         }
 
 

--- a/yolov3/pytorch/loader.py
+++ b/yolov3/pytorch/loader.py
@@ -9,48 +9,66 @@ Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv
 import torch
 from PIL import Image
 from torchvision import transforms
+from typing import Optional
 
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
 from .src.yolov3 import Yolov3
 from ...tools.utils import get_file
 
 
+class Variant(StrEnum):
+    """Available YOLOv3 model variants."""
+
+    BASE = "base"
+
+
 class ModelLoader(ForgeModel):
     """YOLOv3 model loader implementation."""
 
+    # Dictionary of available model variants
+    _VARIANTS = {
+        Variant.BASE: ModelConfig(
+            pretrained_model_name="https://www.ollihuotari.com/data/yolov3_pytorch/yolov3_coco_01.h5",
+        )
+    }
+
+    DEFAULT_VARIANT = Variant.BASE
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[StrEnum] = None):
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional StrEnum specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+
         return ModelInfo(
             model="yolov3",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_OBJECT_DET,
             source=ModelSource.CUSTOM,
             framework=Framework.TORCH,
         )
 
-    def __init__(self, variant=None):
+    def __init__(self, variant: Optional[StrEnum] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional StrEnum specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
@@ -66,9 +84,7 @@ class ModelLoader(ForgeModel):
             torch.nn.Module: The YOLOv3 model instance.
         """
         num_classes = 80
-        weights_file = get_file(
-            "https://www.ollihuotari.com/data/yolov3_pytorch/yolov3_coco_01.h5"
-        )
+        weights_file = get_file(self._variant_config.pretrained_model_name)
 
         # Create model and load weights
         model = Yolov3(num_classes=num_classes)

--- a/yolov4/pytorch/loader.py
+++ b/yolov4/pytorch/loader.py
@@ -7,46 +7,64 @@ YOLOv4 model loader implementation
 import torch
 import cv2
 import numpy as np
+from typing import Optional
 from ...tools.utils import get_file
 
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
 from .src.yolov4 import Yolov4
 
 
+class Variant(StrEnum):
+    """Available YOLOv4 model variants."""
+
+    BASE = "base"
+
+
 class ModelLoader(ForgeModel):
     """YOLOv4 model loader implementation."""
 
-    def __init__(self, variant=None):
+    # Dictionary of available model variants
+    _VARIANTS = {
+        Variant.BASE: ModelConfig(
+            pretrained_model_name="",  # Not used
+        )
+    }
+
+    DEFAULT_VARIANT = Variant.BASE
+
+    def __init__(self, variant: Optional[StrEnum] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional StrEnum specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
 
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[StrEnum] = None):
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional StrEnum specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+
         return ModelInfo(
             model="yolov4",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.RED,
             task=ModelTask.CV_OBJECT_DET,
             source=ModelSource.CUSTOM,


### PR DESCRIPTION
### Ticket
#27 

### Problem description

- We want to switch to use variant enums for type safety in models 
- We want to roll out variant support in more models

### What's changed

Here are some initial changes for review/discussion (@mrakitaTT @nvukobratTT plz take a quick peak) before rolling out to wider set of models

- Replace variant str with Variant(StrEnum) class in bunch of places, update doc strings
- Update models that have variants today (Bert, Albert) w/ changes
- get_model_info() taking str variant is still allowed for now to preserve back-compat until all models updated w/ this change
- Can run tests modified here (or those not modified) without any changes in tt-torch, backwards compatible
- Update yolov3, yolov4 to have variant support, single BASE variant for now, as illustrative example before rolling out similar change to all models.

I propose to submit this batch first then someone can pick up wholesale update of all models to add variant support with appropriate details.

### Checklist
- [x] Run tests locally in tt-torch (albert, bert, yolov3, yolov3 and unmodified model oft)
