### PR TITLE
Update yolov3 for yolov3_coco_01.h5 in s3 bucket

### DIFF
--- a/yolov3/pytorch/loader.py
+++ b/yolov3/pytorch/loader.py
@@ -37,7 +37,7 @@ class ModelLoader(ForgeModel):
     # Dictionary of available model variants
     _VARIANTS = {
         ModelVariant.BASE: ModelConfig(
-            pretrained_model_name="https://www.ollihuotari.com/data/yolov3_pytorch/yolov3_coco_01.h5",
+            pretrained_model_name="test_files/pytorch/yolov3/yolov3_coco_01.h5",
         )
     }
 


### PR DESCRIPTION
### Ticket
#46 

### Problem description
Weights file for yolov3 fetched from URL, not accessible on CiV2

### What's changed
- Put weight in s3 bucket and use path from s3 bucket mirror instead of URL

### Checklist
- [x] Run test locally
