### PR TITLE
update yolov10 load_input function to load dataset

### DIFF
--- a/yolov10/pytorch/loader.py
+++ b/yolov10/pytorch/loader.py
@@ -5,9 +5,9 @@
 YOLOv10 model loader implementation
 """
 import torch
-import cv2
-import numpy as np
-from ...tools.utils import get_file
+from torchvision import transforms
+from datasets import load_dataset
+
 from ...config import (
     ModelInfo,
     ModelGroup,
@@ -93,15 +93,24 @@ class ModelLoader(ForgeModel):
             torch.Tensor: Sample input tensor that can be fed to the model.
         """
 
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        img = cv2.imread(str(image_file), cv2.IMREAD_COLOR)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # Convert BGR to RGB
+        # Load dataset
+        dataset = load_dataset(
+            "cppe-5", split="test"
+        )  # cppe-5 is a dataset of 5 classes for Combined Personal Protective Equipment
 
-        img = cv2.resize(img, (640, 480))  # Resize to model input size
-        img = img / 255.0  # Normalize to [0,1]
-        img = np.transpose(img, (2, 0, 1))  # HWC to CHW format
-        img = [torch.from_numpy(img).float().unsqueeze(0)]  # Add batch dimension
-        batch_tensor = torch.cat(img, dim=0)
+        # Get first image from dataset
+        image = dataset[0]["image"]
+
+        # Preprocess the image
+        transform = transforms.Compose(
+            [
+                transforms.Resize((480, 640)),
+                transforms.ToTensor(),
+            ]
+        )
+
+        img_tensor = [transform(image).unsqueeze(0)]  # Add batch dimension
+        batch_tensor = torch.cat(img_tensor, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:


### PR DESCRIPTION
### Problem description
Currently, `yolo` models retrieve input image from an url. To make it more robust, huggingface `datasets` package can be used. If this change is accepted, the same will be changed for remaining yolo models

### What's changed
* `load_inputs()` is modified to use the datasets library to load an input image
* `cppe-5` dataset is used from datasets package
* removed import statements of cv2, numpy and get_file as they are not used now

### Checklist
- [x] New/Existing tests provide coverage for changes

Tested these changes in tt-xla repo and attached the logs below

[yolov10data.log](https://github.com/user-attachments/files/21366851/yolov10data.log)
[Shape of the image before and after the change](https://github.com/user-attachments/files/21371773/shape_yolo.log)

