### PR TITLE
Bringup tt-forge-fe pytorch models - set1

### DIFF
--- a/bart/__init__.py
+++ b/bart/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+BART model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/bart/pytorch/__init__.py
+++ b/bart/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Bart PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/bart/pytorch/loader.py
+++ b/bart/pytorch/loader.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+BART model loader implementation for Sequence Classification.
+"""
+from transformers import BartForSequenceClassification, BartTokenizer
+from typing import Optional
+
+from ...base import ForgeModel
+from ...config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from transformers.models.bart.modeling_bart import shift_tokens_right
+
+
+class ModelVariant(StrEnum):
+    """Available BART model variants."""
+
+    LARGE = "large"
+
+
+class ModelLoader(ForgeModel):
+    """BART model loader implementation for sequence classification tasks."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.LARGE: LLMModelConfig(
+            pretrained_model_name="facebook/bart-large-mnli",
+            max_length=256,
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.LARGE
+
+    # Shared configuration parameters
+    hypothesis = "Most of Mrinal Sen's work can be found in European collections."
+    premise = "Calcutta seems to be the only other production center having any pretensions to artistic creativity at all, but ironically you're actually more likely to see the works of Satyajit Ray or Mrinal Sen shown in Europe or North America than in India itself."
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        return ModelInfo(
+            model="bart",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_TEXT_CLS,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+
+        # Initialize tokenizer with dtype override if specified
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        # Load the tokenizer
+        self.tokenizer = BartTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name,
+            pad_to_max_length=True,
+            **tokenizer_kwargs
+        )
+
+        return self.tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the BART model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The BART model instance for sequence classification.
+        """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        # Ensure tokenizer is loaded
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        # Load the model with dtype override if specified
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = BartForSequenceClassification.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Load and return sample inputs for the BART model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        # Ensure tokenizer is initialized
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        # Create tokenized inputs for the sequence classification task
+        inputs_dict = self.tokenizer(
+            self.premise,
+            self.hypothesis,
+            truncation="only_first",
+            padding="max_length",
+            max_length=256,
+            return_tensors="pt",
+        )
+
+        model = self.load_model()
+        decoder_input_ids = shift_tokens_right(
+            inputs_dict["input_ids"],
+            model.config.pad_token_id,
+            model.config.decoder_start_token_id,
+        )
+        inputs = [
+            inputs_dict["input_ids"],
+            inputs_dict["attention_mask"],
+            decoder_input_ids,
+        ]
+        return inputs

--- a/config.py
+++ b/config.py
@@ -68,6 +68,8 @@ class ModelSource(StrEnum):
     HUGGING_FACE = "huggingface"
     TORCH_HUB = "torch_hub"
     CUSTOM = "custom"
+    TORCHVISION = "torchvision"
+    TIMM = "timm"
 
 
 class Framework(StrEnum):

--- a/deit/pytorch/loader.py
+++ b/deit/pytorch/loader.py
@@ -5,51 +5,80 @@
 Deit model loader implementation
 """
 
+from typing import Optional
+from PIL import Image
+from transformers import AutoFeatureExtractor, ViTForImageClassification
 
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
-from PIL import Image
-from transformers import AutoFeatureExtractor, ViTForImageClassification
 from ...tools.utils import get_file
+
+
+class ModelVariant(StrEnum):
+    """Available DeiT model variants."""
+
+    BASE = "base"
+    BASE_DISTILLED = "base_distilled"
+    SMALL = "small"
+    TINY = "tiny"
 
 
 class ModelLoader(ForgeModel):
     """Deit model loader implementation."""
 
-    def __init__(self, variant=None):
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.BASE: ModelConfig(
+            pretrained_model_name="facebook/deit-base-patch16-224",
+        ),
+        ModelVariant.BASE_DISTILLED: ModelConfig(
+            pretrained_model_name="facebook/deit-base-distilled-patch16-224",
+        ),
+        ModelVariant.SMALL: ModelConfig(
+            pretrained_model_name="facebook/deit-small-patch16-224",
+        ),
+        ModelVariant.TINY: ModelConfig(
+            pretrained_model_name="facebook/deit-tiny-patch16-224",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.BASE
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
-
-        # Configuration parameters
-        self.model_name = "facebook/deit-base-patch16-224"
         self.feature_extractor = None
 
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="deit",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.HUGGING_FACE,
@@ -57,7 +86,7 @@ class ModelLoader(ForgeModel):
         )
 
     def load_model(self, dtype_override=None):
-        """Load and return the Deit model instance with default settings.
+        """Load and return the Deit model instance for this instance's variant.
 
         Args:
             dtype_override: Optional torch.dtype to override the model's default dtype.
@@ -66,18 +95,23 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.nn.Module: The Deit model instance.
         """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
         # Initialize feature extractor first
-        self.feature_extractor = AutoFeatureExtractor.from_pretrained(self.model_name)
+        self.feature_extractor = AutoFeatureExtractor.from_pretrained(
+            pretrained_model_name
+        )
 
         # Load pre-trained model from HuggingFace
-        model = ViTForImageClassification.from_pretrained(self.model_name)
+        model = ViTForImageClassification.from_pretrained(pretrained_model_name)
 
         if dtype_override is not None:
             model = model.to(dtype_override)
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):
-        """Load and return sample inputs for the Deit model with default settings.
+        """Load and return sample inputs for the Deit model with this instance's variant settings.
 
         Args:
             dtype_override: Optional torch.dtype to override the model's default dtype.
@@ -105,6 +139,15 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def post_processing(self, co_out, model):
+        """Post-process the model outputs.
+
+        Args:
+            co_out: Compiled model outputs
+            model: The model instance for accessing configuration
+
+        Returns:
+            None: Prints the predicted class
+        """
         logits = co_out[0]
         predicted_class_idx = logits.argmax(-1).item()
         print("Predicted class:", model.config.id2label[predicted_class_idx])

--- a/densenet/pytorch/loader.py
+++ b/densenet/pytorch/loader.py
@@ -6,57 +6,99 @@ Densenet model loader implementation
 """
 
 import torch
+from typing import Optional
+from PIL import Image
+from torchvision import transforms
+
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
-
-from PIL import Image
 from ...tools.utils import get_file, print_compiled_model_results
-from torchvision import transforms
+
+
+class ModelVariant(StrEnum):
+    """Available DenseNet model variants."""
+
+    DENSENET121 = "densenet121"
+    DENSENET161 = "densenet161"
+    DENSENET169 = "densenet169"
+    DENSENET201 = "densenet201"
 
 
 class ModelLoader(ForgeModel):
+    """DenseNet model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.DENSENET121: ModelConfig(
+            pretrained_model_name="densenet121",
+        ),
+        ModelVariant.DENSENET161: ModelConfig(
+            pretrained_model_name="densenet161",
+        ),
+        ModelVariant.DENSENET169: ModelConfig(
+            pretrained_model_name="densenet169",
+        ),
+        ModelVariant.DENSENET201: ModelConfig(
+            pretrained_model_name="densenet201",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.DENSENET121
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="densenet",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.TORCH_HUB,
             framework=Framework.TORCH,
         )
 
-    """Loads Densenet model and sample input."""
-
-    def __init__(self, variant=None):
-        """Initialize ModelLoader with specified variant.
+    def load_model(self, dtype_override=None):
+        """Load pretrained DenseNet model for this instance's variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
-                     If None, DEFAULT_VARIANT is used.
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The DenseNet model instance.
         """
-        super().__init__(variant)
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
 
-    def load_model(self, dtype_override=None):
-        """Load pretrained Densenet model."""
-
-        model_name = "densenet121"
+        # Load model from torch hub
         model = torch.hub.load("pytorch/vision:v0.10.0", model_name, pretrained=True)
         model.eval()
 
@@ -66,9 +108,17 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Prepare sample input for Densenet model"""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Prepare sample input for DenseNet model with this instance's variant settings.
 
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for DenseNet.
+        """
         # Get the Image
         image_file = get_file(
             "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
@@ -88,6 +138,9 @@ class ModelLoader(ForgeModel):
         )
         inputs = preprocess(image).unsqueeze(0)
 
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
+
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             inputs = inputs.to(dtype_override)
@@ -95,4 +148,9 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def print_cls_results(self, compiled_model_out):
+        """Print classification results.
+
+        Args:
+            compiled_model_out: Output from the compiled model
+        """
         print_compiled_model_results(compiled_model_out)

--- a/dla/pytorch/loader.py
+++ b/dla/pytorch/loader.py
@@ -5,60 +5,125 @@
 DLA model loader implementation
 """
 
+from typing import Optional
+from PIL import Image
+from torchvision import transforms
+
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
-
-from PIL import Image
 from ...tools.utils import get_file, print_compiled_model_results
-from torchvision import transforms
 from .src import dla_model
 
 
+class ModelVariant(StrEnum):
+    """Available DLA model variants."""
+
+    DLA34 = "dla34"
+    DLA46_C = "dla46_c"
+    DLA46X_C = "dla46x_c"
+    DLA60 = "dla60"
+    DLA60X = "dla60x"
+    DLA60X_C = "dla60x_c"
+    DLA102 = "dla102"
+    DLA102X = "dla102x"
+    DLA102X2 = "dla102x2"
+    DLA169 = "dla169"
+
+
 class ModelLoader(ForgeModel):
+    """DLA model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.DLA34: ModelConfig(
+            pretrained_model_name="dla34",
+        ),
+        ModelVariant.DLA46_C: ModelConfig(
+            pretrained_model_name="dla46_c",
+        ),
+        ModelVariant.DLA46X_C: ModelConfig(
+            pretrained_model_name="dla46x_c",
+        ),
+        ModelVariant.DLA60: ModelConfig(
+            pretrained_model_name="dla60",
+        ),
+        ModelVariant.DLA60X: ModelConfig(
+            pretrained_model_name="dla60x",
+        ),
+        ModelVariant.DLA60X_C: ModelConfig(
+            pretrained_model_name="dla60x_c",
+        ),
+        ModelVariant.DLA102: ModelConfig(
+            pretrained_model_name="dla102",
+        ),
+        ModelVariant.DLA102X: ModelConfig(
+            pretrained_model_name="dla102x",
+        ),
+        ModelVariant.DLA102X2: ModelConfig(
+            pretrained_model_name="dla102x2",
+        ),
+        ModelVariant.DLA169: ModelConfig(
+            pretrained_model_name="dla169",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.DLA34
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="dla",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.TORCH_HUB,
             framework=Framework.TORCH,
         )
 
-    """Loads DLA model and sample input."""
-
-    def __init__(self, variant=None):
-        """Initialize ModelLoader with specified variant.
+    def load_model(self, dtype_override=None):
+        """Load pretrained DLA model for this instance's variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
-                     If None, DEFAULT_VARIANT is used.
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The DLA model instance.
         """
-        super().__init__(variant)
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
 
-        # Configuration parameters
-        self.model_name = "dla34"
-
-    def load_model(self, dtype_override=None):
-        """Load pretrained DLA model."""
-        func = getattr(dla_model, self.model_name)
+        # Load model using the dla_model module
+        func = getattr(dla_model, model_name)
         model = func(pretrained=None)
         model.eval()
 
@@ -68,9 +133,17 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Prepare sample input for DLA model"""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Prepare sample input for DLA model with this instance's variant settings.
 
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for DLA.
+        """
         # Get the Image
         image_file = get_file(
             "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
@@ -90,6 +163,9 @@ class ModelLoader(ForgeModel):
         )
         inputs = preprocess(image).unsqueeze(0)
 
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
+
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             inputs = inputs.to(dtype_override)
@@ -97,4 +173,9 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def print_cls_results(self, compiled_model_out):
+        """Print classification results.
+
+        Args:
+            compiled_model_out: Output from the compiled model
+        """
         print_compiled_model_results(compiled_model_out)

--- a/efficientnet/pytorch/loader.py
+++ b/efficientnet/pytorch/loader.py
@@ -4,77 +4,166 @@
 """
 EfficientNet model loader implementation
 """
+
 import torch
+from typing import Optional
+from dataclasses import dataclass
+from PIL import Image
 
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
-from torchvision.models import EfficientNet_B0_Weights, efficientnet_b0
+import torchvision.models as models
 from torchvision.models._api import WeightsEnum
-from torch.hub import load_state_dict_from_url
-from ...tools.utils import print_compiled_model_results
+from ...tools.utils import get_file, print_compiled_model_results, get_state_dict
+from torchvision import transforms
 
 
-def get_state_dict(self, *args, **kwargs):
-    kwargs.pop("check_hash")
-    return load_state_dict_from_url(self.url, *args, **kwargs)
+@dataclass
+class EfficientNetConfig(ModelConfig):
+    """Configuration specific to EfficientNet models"""
+
+    model_function: str = None
+    weights_class: str = None
+
+
+class ModelVariant(StrEnum):
+    """Available EfficientNet model variants."""
+
+    B0 = "efficientnet_b0"
+    B1 = "efficientnet_b1"
+    B2 = "efficientnet_b2"
+    B3 = "efficientnet_b3"
+    B4 = "efficientnet_b4"
+    B5 = "efficientnet_b5"
+    B6 = "efficientnet_b6"
+    B7 = "efficientnet_b7"
 
 
 class ModelLoader(ForgeModel):
-    @classmethod
-    def _get_model_info(cls, variant_name: str = None):
-        """Get model information for dashboard and metrics reporting.
+    """EfficientNet model loader implementation."""
 
-        Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+    # Static dataclass instances for each variant
+    B0_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b0",
+        model_function="efficientnet_b0",
+        weights_class="EfficientNet_B0_Weights",
+    )
 
-        Returns:
-            ModelInfo: Information about the model and variant
-        """
-        if variant_name is None:
-            variant_name = "base"
-        return ModelInfo(
-            model="efficientnet",
-            variant=variant_name,
-            group=ModelGroup.RED,
-            task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
-            framework=Framework.TORCH,
-        )
+    B1_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b1",
+        model_function="efficientnet_b1",
+        weights_class="EfficientNet_B1_Weights",
+    )
 
-    """Efficientnet model loader implementation."""
+    B2_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b2",
+        model_function="efficientnet_b2",
+        weights_class="EfficientNet_B2_Weights",
+    )
 
-    def __init__(self, variant=None):
+    B3_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b3",
+        model_function="efficientnet_b3",
+        weights_class="EfficientNet_B3_Weights",
+    )
+
+    B4_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b4",
+        model_function="efficientnet_b4",
+        weights_class="EfficientNet_B4_Weights",
+    )
+
+    B5_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b5",
+        model_function="efficientnet_b5",
+        weights_class="EfficientNet_B5_Weights",
+    )
+
+    B6_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b6",
+        model_function="efficientnet_b6",
+        weights_class="EfficientNet_B6_Weights",
+    )
+
+    B7_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b7",
+        model_function="efficientnet_b7",
+        weights_class="EfficientNet_B7_Weights",
+    )
+
+    # Dictionary using the static dataclass instances (for compatibility with existing tests)
+    _VARIANTS = {
+        ModelVariant.B0: B0_CONFIG,
+        ModelVariant.B1: B1_CONFIG,
+        ModelVariant.B2: B2_CONFIG,
+        ModelVariant.B3: B3_CONFIG,
+        ModelVariant.B4: B4_CONFIG,
+        ModelVariant.B5: B5_CONFIG,
+        ModelVariant.B6: B6_CONFIG,
+        ModelVariant.B7: B7_CONFIG,
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.B0
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
 
-        # Configuration parameters
-        self.input_shape = (3, 224, 224)
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="efficientnet",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.TORCHVISION,
+            framework=Framework.TORCH,
+        )
 
     def load_model(self, dtype_override=None):
-        """Load and return the Efficientnet model instance with default settings.
+        """Load and return the EfficientNet model instance for this instance's variant.
 
         Args:
             dtype_override: Optional torch.dtype to override the model's default dtype.
                            If not provided, the model will use its default dtype (typically float32).
 
         Returns:
-            torch.nn.Module: The Efficientnet model instance.
+            torch.nn.Module: The EfficientNet model instance.
         """
-
+        # Setup state dict function
         WeightsEnum.get_state_dict = get_state_dict
-        # Load model with defaults
-        model = efficientnet_b0(weights=EfficientNet_B0_Weights.IMAGENET1K_V1)
+
+        # Get model function and weights class from dataclass config
+        model_fn = getattr(models, self._variant_config.model_function)
+        weights_class = getattr(models, self._variant_config.weights_class)
+
+        # Load model with appropriate weights
+        model = model_fn(weights=weights_class.IMAGENET1K_V1)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -82,18 +171,38 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Load and return sample inputs for the Efficientnet model with default settings.
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the EfficientNet model with this instance's variant settings.
 
         Args:
             dtype_override: Optional torch.dtype to override the inputs' default dtype.
                            If not provided, inputs will use the default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
 
         Returns:
-            torch.Tensor: Sample input tensor that can be fed to the model.
+            torch.Tensor: Preprocessed input tensor suitable for EfficientNet.
         """
-        # Create a random input tensor with the correct shape, using default dtype
-        inputs = torch.rand(1, *self.input_shape)
+        # Get the Image
+        image_file = get_file(
+            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        )
+        image = Image.open(image_file)
+
+        # Preprocess image
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        inputs = preprocess(image).unsqueeze(0)
+
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -102,4 +211,9 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def print_cls_results(self, compiled_model_out):
+        """Print classification results.
+
+        Args:
+            compiled_model_out: Output from the compiled model
+        """
         print_compiled_model_results(compiled_model_out)

--- a/googlenet/__init__.py
+++ b/googlenet/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+GoogleNet model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/googlenet/pytorch/__init__.py
+++ b/googlenet/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+GoogleNet PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/hrnet/pytorch/loader.py
+++ b/hrnet/pytorch/loader.py
@@ -5,82 +5,167 @@
 HRNet model loader implementation
 """
 
+import timm
+from typing import Optional
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+from PIL import Image
+
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
-import timm
-from timm.data import resolve_data_config
-from timm.data.transforms_factory import create_transform
-from PIL import Image
 from ...tools.utils import get_file, print_compiled_model_results
 
 
+class ModelVariant(StrEnum):
+    """Available HRNet model variants."""
+
+    HRNET_W18_SMALL = "hrnet_w18_small"
+    HRNET_W18_SMALL_V2 = "hrnet_w18_small_v2"
+    HRNET_W18 = "hrnet_w18"
+    HRNET_W30 = "hrnet_w30"
+    HRNET_W32 = "hrnet_w32"
+    HRNET_W40 = "hrnet_w40"
+    HRNET_W44 = "hrnet_w44"
+    HRNET_W48 = "hrnet_w48"
+    HRNET_W64 = "hrnet_w64"
+    HRNET_W18_MS_AUG_IN1K = "hrnet_w18.ms_aug_in1k"
+
+
 class ModelLoader(ForgeModel):
-    @classmethod
-    def _get_model_info(cls, variant_name: str = None):
-        """Get model information for dashboard and metrics reporting.
+    """HRNet model loader implementation."""
 
-        Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.HRNET_W18_SMALL: ModelConfig(
+            pretrained_model_name="hrnet_w18_small",
+        ),
+        ModelVariant.HRNET_W18_SMALL_V2: ModelConfig(
+            pretrained_model_name="hrnet_w18_small_v2",
+        ),
+        ModelVariant.HRNET_W18: ModelConfig(
+            pretrained_model_name="hrnet_w18",
+        ),
+        ModelVariant.HRNET_W30: ModelConfig(
+            pretrained_model_name="hrnet_w30",
+        ),
+        ModelVariant.HRNET_W32: ModelConfig(
+            pretrained_model_name="hrnet_w32",
+        ),
+        ModelVariant.HRNET_W40: ModelConfig(
+            pretrained_model_name="hrnet_w40",
+        ),
+        ModelVariant.HRNET_W44: ModelConfig(
+            pretrained_model_name="hrnet_w44",
+        ),
+        ModelVariant.HRNET_W48: ModelConfig(
+            pretrained_model_name="hrnet_w48",
+        ),
+        ModelVariant.HRNET_W64: ModelConfig(
+            pretrained_model_name="hrnet_w64",
+        ),
+        ModelVariant.HRNET_W18_MS_AUG_IN1K: ModelConfig(
+            pretrained_model_name="hrnet_w18.ms_aug_in1k",
+        ),
+    }
 
-        Returns:
-            ModelInfo: Information about the model and variant
-        """
-        if variant_name is None:
-            variant_name = "base"
-        return ModelInfo(
-            model="hrnet",
-            variant=variant_name,
-            group=ModelGroup.GENERALITY,
-            task=ModelTask.CV_KEYPOINT_DET,
-            source=ModelSource.TORCH_HUB,
-            framework=Framework.TORCH,
-        )
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.HRNET_W18_SMALL
 
-    """Loads HRNet model and sample input."""
-
-    def __init__(self, variant=None):
+    def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
 
-        # Configuration parameters
-        self.model_name = "hrnet_w18_small"
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="hrnet",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_KEYPOINT_DET,
+            source=ModelSource.TIMM,
+            framework=Framework.TORCH,
+        )
 
     def load_model(self, dtype_override=None):
-        """Load pretrained HRNet model."""
+        """Load pretrained HRNet model for this instance's variant.
 
-        model = timm.create_model(self.model_name, pretrained=True)
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The HRNet model instance.
+        """
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
+
+        # Load model using timm
+        model = timm.create_model(model_name, pretrained=True)
         model.eval()
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             model = model.to(dtype_override)
 
+        # Store model for use in load_inputs (to avoid reloading)
+        self._cached_model = model
+
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Prepare sample input for HRNet model"""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Prepare sample input for HRNet model with this instance's variant settings.
 
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for HRNet.
+        """
         # Get the Image
         image_file = get_file(
             "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
         )
         image = Image.open(image_file)
 
-        # Preprocess image
-        data_config = resolve_data_config({}, model=self.load_model())
+        # Use cached model if available, otherwise load it
+        if hasattr(self, "_cached_model") and self._cached_model is not None:
+            model_for_config = self._cached_model
+        else:
+            model_for_config = self.load_model(dtype_override)
+
+        # Preprocess image using model's data config
+        data_config = resolve_data_config({}, model=model_for_config)
         transforms = create_transform(**data_config)
         inputs = transforms(image).unsqueeze(0)
+
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -89,4 +174,9 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def print_cls_results(self, compiled_model_out):
+        """Print classification results.
+
+        Args:
+            compiled_model_out: Output from the compiled model
+        """
         print_compiled_model_results(compiled_model_out)

--- a/inception/__init__.py
+++ b/inception/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Inception model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/inception/pytorch/__init__.py
+++ b/inception/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Inception PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/mlp_mixer/pytorch/loader.py
+++ b/mlp_mixer/pytorch/loader.py
@@ -5,83 +5,211 @@
 MLP-Mixer model loader implementation
 """
 
+import timm
+from typing import Optional
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+from PIL import Image
+from dataclasses import dataclass
+
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
-import timm
-from timm.data import resolve_data_config
-from timm.data.transforms_factory import create_transform
-from PIL import Image
 from ...tools.utils import get_file, print_compiled_model_results
 
 
+@dataclass
+class MLPMixerConfig(ModelConfig):
+    """Configuration specific to MLP Mixer models"""
+
+    weights_available: bool = True
+    use_21k_labels: bool = False
+
+
+class ModelVariant(StrEnum):
+    """Available MLP Mixer model variants."""
+
+    MIXER_B16_224 = "mixer_b16_224"
+    MIXER_B16_224_IN21K = "mixer_b16_224_in21k"
+    MIXER_B16_224_MIIL = "mixer_b16_224_miil"
+    MIXER_B16_224_MIIL_IN21K = "mixer_b16_224_miil_in21k"
+    MIXER_B32_224 = "mixer_b32_224"
+    MIXER_L16_224 = "mixer_l16_224"
+    MIXER_L16_224_IN21K = "mixer_l16_224_in21k"
+    MIXER_L32_224 = "mixer_l32_224"
+    MIXER_S16_224 = "mixer_s16_224"
+    MIXER_S32_224 = "mixer_s32_224"
+    MIXER_B16_224_GOOG_IN21K = "mixer_b16_224.goog_in21k"
+
+
 class ModelLoader(ForgeModel):
-    @classmethod
-    def _get_model_info(cls, variant_name: str = None):
-        """Get model information for dashboard and metrics reporting.
+    """MLP Mixer model loader implementation."""
 
-        Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.MIXER_B16_224: MLPMixerConfig(
+            pretrained_model_name="mixer_b16_224",
+            weights_available=True,
+            use_21k_labels=False,
+        ),
+        ModelVariant.MIXER_B16_224_IN21K: MLPMixerConfig(
+            pretrained_model_name="mixer_b16_224_in21k",
+            weights_available=True,
+            use_21k_labels=True,
+        ),
+        ModelVariant.MIXER_B16_224_MIIL: MLPMixerConfig(
+            pretrained_model_name="mixer_b16_224_miil",
+            weights_available=True,
+            use_21k_labels=False,
+        ),
+        ModelVariant.MIXER_B16_224_MIIL_IN21K: MLPMixerConfig(
+            pretrained_model_name="mixer_b16_224_miil_in21k",
+            weights_available=True,
+            use_21k_labels=True,
+        ),
+        ModelVariant.MIXER_B32_224: MLPMixerConfig(
+            pretrained_model_name="mixer_b32_224",
+            weights_available=False,
+            use_21k_labels=False,
+        ),
+        ModelVariant.MIXER_L16_224: MLPMixerConfig(
+            pretrained_model_name="mixer_l16_224",
+            weights_available=True,
+            use_21k_labels=False,
+        ),
+        ModelVariant.MIXER_L16_224_IN21K: MLPMixerConfig(
+            pretrained_model_name="mixer_l16_224_in21k",
+            weights_available=True,
+            use_21k_labels=True,
+        ),
+        ModelVariant.MIXER_L32_224: MLPMixerConfig(
+            pretrained_model_name="mixer_l32_224",
+            weights_available=False,
+            use_21k_labels=False,
+        ),
+        ModelVariant.MIXER_S16_224: MLPMixerConfig(
+            pretrained_model_name="mixer_s16_224",
+            weights_available=False,
+            use_21k_labels=False,
+        ),
+        ModelVariant.MIXER_S32_224: MLPMixerConfig(
+            pretrained_model_name="mixer_s32_224",
+            weights_available=False,
+            use_21k_labels=False,
+        ),
+        ModelVariant.MIXER_B16_224_GOOG_IN21K: MLPMixerConfig(
+            pretrained_model_name="mixer_b16_224.goog_in21k",
+            weights_available=True,
+            use_21k_labels=True,
+        ),
+    }
 
-        Returns:
-            ModelInfo: Information about the model and variant
-        """
-        if variant_name is None:
-            variant_name = "base"
-        return ModelInfo(
-            model="mlp_mixer",
-            variant=variant_name,
-            group=ModelGroup.GENERALITY,
-            task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
-            framework=Framework.TORCH,
-        )
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.MIXER_S32_224
 
-    """Loads MLP-Mixer model and sample input."""
-
-    def __init__(self, variant=None):
+    def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
 
-        # Configuration parameters
-        self.model_name = "mixer_s32_224"
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="mlp_mixer",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.TIMM,
+            framework=Framework.TORCH,
+        )
 
     def load_model(self, dtype_override=None):
-        """Load pretrained MLP-Mixer model."""
+        """Load pretrained MLP Mixer model for this instance's variant.
 
-        # To avoid RuntimeError: No pretrained weights exist for mixer_s32_224. Use `pretrained=False` for random init.
-        model = timm.create_model(self.model_name, pretrained=False)
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The MLP Mixer model instance.
+        """
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
+        weights_available = self._variant_config.weights_available
+
+        # Load model using timm with appropriate pretrained weights setting
+        model = timm.create_model(model_name, pretrained=weights_available)
         model.eval()
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             model = model.to(dtype_override)
 
+        # Store model for use in load_inputs (to avoid reloading)
+        self._cached_model = model
+
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Prepare sample input for MLP-Mixer model"""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Prepare sample input for MLP Mixer model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for MLP Mixer.
+        """
+        # Determine which image to use based on variant
+        use_21k_labels = self._variant_config.use_21k_labels
+
+        if use_21k_labels:
+            # Use different image for 21K variants
+            image_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
+        else:
+            # Use standard image for 1K variants
+            image_url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
 
         # Get the Image
-        image_file = get_file(
-            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
-        )
-        image = Image.open(image_file)
+        image_file = get_file(image_url)
+        image = Image.open(str(image_file)).convert("RGB")
 
-        # Preprocess image
-        data_config = resolve_data_config({}, model=self.load_model())
+        # Use cached model if available, otherwise load it
+        if hasattr(self, "_cached_model") and self._cached_model is not None:
+            model_for_config = self._cached_model
+        else:
+            model_for_config = self.load_model(dtype_override)
+
+        # Preprocess image using model's data config
+        data_config = resolve_data_config({}, model=model_for_config)
         transforms = create_transform(**data_config)
         inputs = transforms(image).unsqueeze(0)
+
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -90,4 +218,13 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def print_cls_results(self, compiled_model_out):
-        print_compiled_model_results(compiled_model_out)
+        """Print classification results.
+
+        Args:
+            compiled_model_out: Output from the compiled model
+        """
+        # Determine label set based on variant
+        use_21k_labels = self._variant_config.use_21k_labels
+        print_compiled_model_results(
+            compiled_model_out, use_1k_labels=not use_21k_labels
+        )

--- a/regnet/pytorch/loader.py
+++ b/regnet/pytorch/loader.py
@@ -2,15 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-Regnet model loader implementation
+RegNet model loader implementation
 """
 
+from typing import Optional
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
 from transformers import AutoFeatureExtractor, RegNetForImageClassification
@@ -18,49 +21,98 @@ from PIL import Image
 from ...tools.utils import get_file
 
 
+class ModelVariant(StrEnum):
+    """Available RegNet model variants."""
+
+    Y_040 = "regnet_y_040"
+    Y_064 = "regnet_y_064"
+    Y_080 = "regnet_y_080"
+    Y_120 = "regnet_y_120"
+    Y_160 = "regnet_y_160"
+    Y_320 = "regnet_y_320"
+
+
 class ModelLoader(ForgeModel):
+    """RegNet model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.Y_040: ModelConfig(
+            pretrained_model_name="facebook/regnet-y-040",
+        ),
+        ModelVariant.Y_064: ModelConfig(
+            pretrained_model_name="facebook/regnet-y-064",
+        ),
+        ModelVariant.Y_080: ModelConfig(
+            pretrained_model_name="facebook/regnet-y-080",
+        ),
+        ModelVariant.Y_120: ModelConfig(
+            pretrained_model_name="facebook/regnet-y-120",
+        ),
+        ModelVariant.Y_160: ModelConfig(
+            pretrained_model_name="facebook/regnet-y-160",
+        ),
+        ModelVariant.Y_320: ModelConfig(
+            pretrained_model_name="facebook/regnet-y-320",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.Y_040
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.feature_extractor = None
+        self.model = None
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="regnet",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
+            source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )
 
-    """Loads Regnet model and sample input."""
-
-    def __init__(self, variant=None):
-        """Initialize ModelLoader with specified variant.
+    def load_model(self, dtype_override=None):
+        """Load and return the RegNet model instance for this instance's variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
-                     If None, DEFAULT_VARIANT is used.
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The RegNet model instance.
         """
-        super().__init__(variant)
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
 
-        # Configuration parameters
-        self.model_name = "facebook/regnet-y-040"
-
-    def load_model(self, dtype_override=None):
-        """Load pretrained Regnet model."""
-
+        # Load model from HuggingFace
         model = RegNetForImageClassification.from_pretrained(
-            self.model_name, return_dict=False
+            model_name, return_dict=False
         )
         model.eval()
+
+        # Store model for potential use in post_processing
         self.model = model
 
         # Only convert dtype if explicitly requested
@@ -69,16 +121,33 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Prepare sample input for Regnet model"""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the RegNet model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the inputs' default dtype.
+                           If not provided, inputs will use the default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for RegNet.
+        """
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
 
         # Get the Image
         image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
         image = Image.open(image_file)
 
+        # Initialize feature extractor if not already done
+        if self.feature_extractor is None:
+            self.feature_extractor = AutoFeatureExtractor.from_pretrained(model_name)
+
         # Preprocess image
-        image_processor = AutoFeatureExtractor.from_pretrained(self.model_name)
-        inputs = image_processor(images=image, return_tensors="pt").pixel_values
+        inputs = self.feature_extractor(images=image, return_tensors="pt").pixel_values
+
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -87,6 +156,15 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def post_processing(self, co_out):
+        """Post-process the model outputs.
+
+        Args:
+            co_out: Compiled model outputs
+
+        Returns:
+            None: Prints the predicted class
+        """
+
         logits = co_out[0]
         predicted_label = logits.argmax(-1).item()
-        print(self.model.config.id2label[predicted_label])
+        print("Predicted class:", self.model.config.id2label[predicted_label])

--- a/resnext/pytorch/loader.py
+++ b/resnext/pytorch/loader.py
@@ -2,16 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-Resnext model loader implementation
+ResNeXt model loader implementation
 """
 
 import torch
+from typing import Optional
+from dataclasses import dataclass
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
 
@@ -20,44 +24,90 @@ from ...tools.utils import get_file, print_compiled_model_results
 from torchvision import transforms
 
 
+@dataclass
+class ResNeXtConfig(ModelConfig):
+    """Configuration specific to ResNeXt models"""
+
+    hub_source: str
+
+
+class ModelVariant(StrEnum):
+    """Available ResNeXt model variants."""
+
+    RESNEXT50_32X4D = "resnext50_32x4d"
+    RESNEXT101_32X8D = "resnext101_32x8d"
+    RESNEXT101_32X8D_WSL = "resnext101_32x8d_wsl"
+
+
 class ModelLoader(ForgeModel):
+    """ResNeXt model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.RESNEXT50_32X4D: ResNeXtConfig(
+            pretrained_model_name="resnext50_32x4d",
+            hub_source="pytorch/vision:v0.10.0",
+        ),
+        ModelVariant.RESNEXT101_32X8D: ResNeXtConfig(
+            pretrained_model_name="resnext101_32x8d",
+            hub_source="pytorch/vision:v0.10.0",
+        ),
+        ModelVariant.RESNEXT101_32X8D_WSL: ResNeXtConfig(
+            pretrained_model_name="resnext101_32x8d_wsl",
+            hub_source="facebookresearch/WSL-Images",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.RESNEXT50_32X4D
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="resnext",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.TORCH_HUB,
             framework=Framework.TORCH,
         )
 
-    """Loads Resnext model and sample input."""
-
-    def __init__(self, variant=None):
-        """Initialize ModelLoader with specified variant.
+    def load_model(self, dtype_override=None):
+        """Load and return the ResNeXt model instance for this instance's variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
-                     If None, DEFAULT_VARIANT is used.
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The ResNeXt model instance.
         """
-        super().__init__(variant)
+        # Get the pretrained model name and hub source from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
+        hub_source = self._variant_config.hub_source
 
-    def load_model(self, dtype_override=None):
-        """Load pretrained Resnext model."""
-
-        model_name = "resnext50_32x4d"
-        model = torch.hub.load("pytorch/vision:v0.10.0", model_name, pretrained=True)
+        # Load model using torch.hub
+        model = torch.hub.load(hub_source, model_name)
         model.eval()
 
         # Only convert dtype if explicitly requested
@@ -66,9 +116,17 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Prepare sample input for Resnext model"""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the ResNeXt model with this instance's variant settings.
 
+        Args:
+            dtype_override: Optional torch.dtype to override the inputs' default dtype.
+                           If not provided, inputs will use the default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for ResNeXt.
+        """
         # Get the Image
         image_file = get_file(
             "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
@@ -88,6 +146,9 @@ class ModelLoader(ForgeModel):
         )
         inputs = preprocess(image).unsqueeze(0)
 
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
+
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             inputs = inputs.to(dtype_override)
@@ -95,4 +156,9 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def print_cls_results(self, compiled_model_out):
+        """Print classification results.
+
+        Args:
+            compiled_model_out: Output from the compiled model
+        """
         print_compiled_model_results(compiled_model_out)

--- a/segformer/pytorch/loader.py
+++ b/segformer/pytorch/loader.py
@@ -2,71 +2,128 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-Segformer model loader implementation for question answering
+Segformer model loader implementation for image classification
 """
 import torch
+from typing import Optional
 from transformers import (
     SegformerConfig,
     SegformerForImageClassification,
+    AutoImageProcessor,
 )
 from PIL import Image
 
-from transformers import AutoImageProcessor
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
 from ...tools.utils import get_file
 
 
+class ModelVariant(StrEnum):
+    """Available Segformer model variants."""
+
+    MIT_B0 = "mit_b0"
+    MIT_B1 = "mit_b1"
+    MIT_B2 = "mit_b2"
+    MIT_B3 = "mit_b3"
+    MIT_B4 = "mit_b4"
+    MIT_B5 = "mit_b5"
+
+
 class ModelLoader(ForgeModel):
+    """Segformer model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.MIT_B0: ModelConfig(
+            pretrained_model_name="nvidia/mit-b0",
+        ),
+        ModelVariant.MIT_B1: ModelConfig(
+            pretrained_model_name="nvidia/mit-b1",
+        ),
+        ModelVariant.MIT_B2: ModelConfig(
+            pretrained_model_name="nvidia/mit-b2",
+        ),
+        ModelVariant.MIT_B3: ModelConfig(
+            pretrained_model_name="nvidia/mit-b3",
+        ),
+        ModelVariant.MIT_B4: ModelConfig(
+            pretrained_model_name="nvidia/mit-b4",
+        ),
+        ModelVariant.MIT_B5: ModelConfig(
+            pretrained_model_name="nvidia/mit-b5",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.MIT_B0
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.image_processor = None
+        self.model = None
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="segformer",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.RED,
-            task=ModelTask.CV_IMAGE_SEG,
+            task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )
 
-    def __init__(self, variant=None):
-        """Initialize ModelLoader with specified variant.
+    def load_model(self, dtype_override=None):
+        """Load and return the Segformer model instance for this instance's variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
-                     If None, DEFAULT_VARIANT is used.
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Segformer model instance.
         """
-        super().__init__(variant)
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
 
-        # Configuration parameters
-        self.model_name = "nvidia/mit-b0"
-
-    def load_model(self, dtype_override=None):
-        """Load a Segformer model from Hugging Face."""
-        config = SegformerConfig.from_pretrained(self.model_name)
+        # Load configuration
+        config = SegformerConfig.from_pretrained(model_name)
         config_dict = config.to_dict()
         config_dict["return_dict"] = False
         config = SegformerConfig(**config_dict)
+
+        # Load model from HuggingFace
         model = SegformerForImageClassification.from_pretrained(
-            self.model_name, config=config
+            model_name, config=config
         )
         model.eval()
+
+        # Store model for potential use in post_processing
         self.model = model
 
         # Only convert dtype if explicitly requested
@@ -75,17 +132,33 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Generate sample inputs for Segformer models."""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the Segformer model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the inputs' default dtype.
+                           If not provided, inputs will use the default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for Segformer.
+        """
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
+
         # Get the Image
         image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
         image = Image.open(image_file)
 
-        # Initialize tokenizer
-        image_processor = AutoImageProcessor.from_pretrained(self.model_name)
+        # Initialize image processor if not already done
+        if self.image_processor is None:
+            self.image_processor = AutoImageProcessor.from_pretrained(model_name)
 
         # Create tokenized inputs
-        inputs = image_processor(images=image, return_tensors="pt").pixel_values
+        inputs = self.image_processor(images=image, return_tensors="pt").pixel_values
+
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -94,6 +167,15 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def post_processing(self, co_out):
+        """Post-process the model outputs.
+
+        Args:
+            co_out: Compiled model outputs
+
+        Returns:
+            None: Prints the predicted class
+        """
+
         logits = co_out[0]
         predicted_label = logits.argmax(-1).item()
-        print("Predicted class: ", self.model.config.id2label[predicted_label])
+        print("Predicted class:", self.model.config.id2label[predicted_label])

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -9,6 +9,7 @@ import torch
 from tabulate import tabulate
 import json
 from pathlib import Path
+from torch.hub import load_state_dict_from_url
 
 
 def get_file(path):
@@ -155,3 +156,8 @@ def print_compiled_model_results(compiled_model_out, use_1k_labels: bool = True)
         ["Top 1 Predicted Class Probability", compiled_model_top1_class_prob],
     ]
     print(tabulate(table, headers="firstrow", tablefmt="grid"))
+
+
+def get_state_dict(self, *args, **kwargs):
+    kwargs.pop("check_hash")
+    return load_state_dict_from_url(self.url, *args, **kwargs)

--- a/vgg/pytorch/loader.py
+++ b/vgg/pytorch/loader.py
@@ -2,16 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-Vgg model loader implementation
+VGG model loader implementation
 """
 
 import torch
+from typing import Optional
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
 
@@ -20,43 +23,98 @@ from ...tools.utils import get_file, print_compiled_model_results
 from torchvision import transforms
 
 
+class ModelVariant(StrEnum):
+    """Available VGG model variants."""
+
+    VGG11 = "vgg11"
+    VGG11_BN = "vgg11_bn"
+    VGG13 = "vgg13"
+    VGG13_BN = "vgg13_bn"
+    VGG16 = "vgg16"
+    VGG16_BN = "vgg16_bn"
+    VGG19 = "vgg19"
+    VGG19_BN = "vgg19_bn"
+
+
 class ModelLoader(ForgeModel):
+    """VGG model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.VGG11: ModelConfig(
+            pretrained_model_name="vgg11",
+        ),
+        ModelVariant.VGG11_BN: ModelConfig(
+            pretrained_model_name="vgg11_bn",
+        ),
+        ModelVariant.VGG13: ModelConfig(
+            pretrained_model_name="vgg13",
+        ),
+        ModelVariant.VGG13_BN: ModelConfig(
+            pretrained_model_name="vgg13_bn",
+        ),
+        ModelVariant.VGG16: ModelConfig(
+            pretrained_model_name="vgg16",
+        ),
+        ModelVariant.VGG16_BN: ModelConfig(
+            pretrained_model_name="vgg16_bn",
+        ),
+        ModelVariant.VGG19: ModelConfig(
+            pretrained_model_name="vgg19",
+        ),
+        ModelVariant.VGG19_BN: ModelConfig(
+            pretrained_model_name="vgg19_bn",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.VGG19_BN
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="vgg",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.TORCH_HUB,
             framework=Framework.TORCH,
         )
 
-    """Loads Vgg model and sample input."""
-
-    def __init__(self, variant=None):
-        """Initialize ModelLoader with specified variant.
+    def load_model(self, dtype_override=None):
+        """Load and return the VGG model instance for this instance's variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
-                     If None, DEFAULT_VARIANT is used.
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The VGG model instance.
         """
-        super().__init__(variant)
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
 
-    def load_model(self, dtype_override=None):
-        """Load pretrained Vgg model."""
-
-        model_name = "vgg19_bn"
+        # Load model using torch.hub
         model = torch.hub.load("pytorch/vision:v0.10.0", model_name, pretrained=True)
         model.eval()
 
@@ -66,9 +124,17 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Prepare sample input for Vgg model"""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the VGG model with this instance's variant settings.
 
+        Args:
+            dtype_override: Optional torch.dtype to override the inputs' default dtype.
+                           If not provided, inputs will use the default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for VGG.
+        """
         # Get the Image
         image_file = get_file(
             "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
@@ -88,6 +154,9 @@ class ModelLoader(ForgeModel):
         )
         inputs = preprocess(image).unsqueeze(0)
 
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
+
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             inputs = inputs.to(dtype_override)
@@ -95,4 +164,9 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def print_cls_results(self, compiled_model_out):
+        """Print classification results.
+
+        Args:
+            compiled_model_out: Output from the compiled model
+        """
         print_compiled_model_results(compiled_model_out)

--- a/xception/pytorch/loader.py
+++ b/xception/pytorch/loader.py
@@ -5,63 +5,106 @@
 Xception model loader implementation
 """
 
+from typing import Optional
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
 import timm
 from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 from PIL import Image
-from ...tools.utils import get_file
-from ...tools.utils import print_compiled_model_results
+from ...tools.utils import get_file, print_compiled_model_results
+
+
+class ModelVariant(StrEnum):
+    """Available Xception model variants."""
+
+    XCEPTION41 = "xception41"
+    XCEPTION65 = "xception65"
+    XCEPTION71 = "xception71"
+    XCEPTION71_TF_IN1K = "xception71.tf_in1k"
 
 
 class ModelLoader(ForgeModel):
+    """Xception model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.XCEPTION41: ModelConfig(
+            pretrained_model_name="xception41",
+        ),
+        ModelVariant.XCEPTION65: ModelConfig(
+            pretrained_model_name="xception65",
+        ),
+        ModelVariant.XCEPTION71: ModelConfig(
+            pretrained_model_name="xception71",
+        ),
+        ModelVariant.XCEPTION71_TF_IN1K: ModelConfig(
+            pretrained_model_name="xception71.tf_in1k",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.XCEPTION65
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self._cached_model = None
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="xception",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
+            source=ModelSource.TIMM,
             framework=Framework.TORCH,
         )
 
-    """Loads Xception model and sample input."""
-
-    def __init__(self, variant=None):
-        """Initialize ModelLoader with specified variant.
+    def load_model(self, dtype_override=None):
+        """Load and return the Xception model instance for this instance's variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
-                     If None, DEFAULT_VARIANT is used.
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Xception model instance.
         """
-        super().__init__(variant)
+        # Get the pretrained model name from the instance's variant config
+        model_name = self._variant_config.pretrained_model_name
 
-        # Configuration parameters
-        self.model_name = "xception65"
-
-    def load_model(self, dtype_override=None):
-        """Load pretrained Xception model."""
-
-        model = timm.create_model(self.model_name, pretrained=True)
+        # Load model using timm
+        model = timm.create_model(model_name, pretrained=True)
         model.eval()
+
+        # Cache model for use in load_inputs (to avoid reloading)
+        self._cached_model = model
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -69,19 +112,36 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Prepare sample input for Xception model"""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the Xception model with this instance's variant settings.
 
+        Args:
+            dtype_override: Optional torch.dtype to override the inputs' default dtype.
+                           If not provided, inputs will use the default dtype (typically float32).
+            batch_size: Optional batch size to override the default batch size of 1.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor suitable for Xception.
+        """
         # Get the Image
         image_file = get_file(
             "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
         )
         image = Image.open(image_file).convert("RGB")
 
-        # Preprocess image
-        data_config = resolve_data_config({}, model=self.load_model())
+        # Use cached model if available, otherwise load it
+        if hasattr(self, "_cached_model") and self._cached_model is not None:
+            model_for_config = self._cached_model
+        else:
+            model_for_config = self.load_model(dtype_override)
+
+        # Preprocess image using model's data config
+        data_config = resolve_data_config({}, model=model_for_config)
         transforms = create_transform(**data_config)
         inputs = transforms(image).unsqueeze(0)
+
+        # Replicate tensors for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -90,4 +150,9 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def print_cls_results(self, compiled_model_out):
+        """Print classification results.
+
+        Args:
+            compiled_model_out: Output from the compiled model
+        """
         print_compiled_model_results(compiled_model_out)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-fe/issues/2652

### Problem description

- Add variant support for existing models and bring up tt-forge-fe models in tt-forge-models.

### What's changed
- Added support for Inception,Bart and GoogleNet models from scratch.
- Added variant support for the following models:  

  -  deit
  -  densenet
  -  dla
  -  ghostnet
  -  efficientnet
  -  hrnet
  -  mlp_mixer
  -  regnet
  -  resnext
  -  segformer
  -   Vgg
  -   xception

### Checklist
- [x] New/Existing tests provide coverage for changes

### Logs

- Test scripts and corresponding logs are attached. [set1_check.zip](https://github.com/user-attachments/files/21414087/set1_check.zip)




