### PR TITLE
Bringup tt-forge-fe models - set5

### DIFF
--- a/perceiverio_vision/__init__.py
+++ b/perceiverio_vision/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+PerceiverIO Vision model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/perceiverio_vision/pytorch/__init__.py
+++ b/perceiverio_vision/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+PerceiverIO Vision PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/perceiverio_vision/pytorch/loader.py
+++ b/perceiverio_vision/pytorch/loader.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+PerceiverIO Vision model loader implementation for image classification
+"""
+import torch
+from loguru import logger
+from PIL import Image
+from transformers import (
+    AutoImageProcessor,
+    PerceiverForImageClassificationConvProcessing,
+    PerceiverForImageClassificationFourier,
+    PerceiverForImageClassificationLearned,
+)
+from typing import Optional
+from ...config import (
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    ModelConfig,
+)
+from ...base import ForgeModel
+from ...tools.utils import print_compiled_model_results
+from ...tools.utils import get_file
+
+
+class ModelVariant(StrEnum):
+    """Available PerceiverIO Vision model variants."""
+
+    VISION_PERCEIVER_CONV = "deepmind/vision-perceiver-conv"
+    VISION_PERCEIVER_LEARNED = "deepmind/vision-perceiver-learned"
+    VISION_PERCEIVER_FOURIER = "deepmind/vision-perceiver-fourier"
+
+
+class ModelLoader(ForgeModel):
+    """PerceiverIO Vision model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.VISION_PERCEIVER_CONV: ModelConfig(
+            pretrained_model_name="deepmind/vision-perceiver-conv",
+        ),
+        ModelVariant.VISION_PERCEIVER_LEARNED: ModelConfig(
+            pretrained_model_name="deepmind/vision-perceiver-learned",
+        ),
+        ModelVariant.VISION_PERCEIVER_FOURIER: ModelConfig(
+            pretrained_model_name="deepmind/vision-perceiver-fourier",
+        ),
+    }
+
+    # Mapping of variants to their corresponding model classes
+    _MODEL_CLASSES = {
+        ModelVariant.VISION_PERCEIVER_CONV: PerceiverForImageClassificationConvProcessing,
+        ModelVariant.VISION_PERCEIVER_LEARNED: PerceiverForImageClassificationLearned,
+        ModelVariant.VISION_PERCEIVER_FOURIER: PerceiverForImageClassificationFourier,
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.VISION_PERCEIVER_CONV
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None):
+        """Get model information for dashboard and metrics reporting.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="perceiverio_vision",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def __init__(self, variant=None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional string specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+
+        # Configuration parameters
+        self.image_processor = None
+
+    def load_model(self, dtype_override=None):
+        """Load a PerceiverIO Vision model from HuggingFace."""
+
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        # Get the appropriate model class for this variant
+        model_class = self._MODEL_CLASSES[self._variant]
+
+        # Load the model using the appropriate class
+        model = model_class.from_pretrained(pretrained_model_name, return_dict=False)
+        model.eval()
+
+        # Initialize image processor for this variant
+        self.image_processor = AutoImageProcessor.from_pretrained(pretrained_model_name)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Generate sample inputs for PerceiverIO Vision models."""
+
+        if self.image_processor is None:
+            raise RuntimeError(
+                "Model must be loaded first before loading inputs. Call load_model() first."
+            )
+
+        try:
+            input_image = get_file(
+                "http://images.cocodataset.org/val2017/000000039769.jpg"
+            )
+            image = Image.open(str(input_image))
+            pixel_values = self.image_processor(
+                images=image, return_tensors="pt"
+            ).pixel_values
+        except Exception as e:
+            logger.warning(
+                f"Failed to download the image file ({e}), replacing input with random tensor. "
+                "Please check if the URL is up to date"
+            )
+            height = self.image_processor.to_dict()["size"]["height"]
+            width = self.image_processor.to_dict()["size"]["width"]
+            pixel_values = torch.rand(1, 3, height, width).to(torch.float32)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            pixel_values = pixel_values.to(dtype_override)
+
+        return pixel_values
+
+    def print_cls_results(self, compiled_model_out):
+        print_compiled_model_results(compiled_model_out)

--- a/retinanet/__init__.py
+++ b/retinanet/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Retinanet model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/retinanet/pytorch/__init__.py
+++ b/retinanet/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Retinanet PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/retinanet/pytorch/loader.py
+++ b/retinanet/pytorch/loader.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+RetinaNet model loader implementation
+"""
+import os
+import shutil
+import zipfile
+import requests
+import torch
+from PIL import Image
+from torchvision import transforms, models
+from typing import Optional
+from ...config import (
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    ModelConfig,
+)
+from ...base import ForgeModel
+from .src.model import Model
+from ...tools.utils import get_file
+
+
+class ModelVariant(StrEnum):
+    """Available RetinaNet model variants."""
+
+    # NVIDIA variants (custom model implementation)
+    RETINANET_RN18FPN = "retinanet_rn18fpn"
+    RETINANET_RN34FPN = "retinanet_rn34fpn"
+    RETINANET_RN50FPN = "retinanet_rn50fpn"
+    RETINANET_RN101FPN = "retinanet_rn101fpn"
+    RETINANET_RN152FPN = "retinanet_rn152fpn"
+
+    # Torchvision variants
+    RETINANET_RESNET50_FPN_V2 = "retinanet_resnet50_fpn_v2"
+
+
+class ModelLoader(ForgeModel):
+    """RetinaNet model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.RETINANET_RN18FPN: ModelConfig(
+            pretrained_model_name="retinanet_rn18fpn",
+        ),
+        ModelVariant.RETINANET_RN34FPN: ModelConfig(
+            pretrained_model_name="retinanet_rn34fpn",
+        ),
+        ModelVariant.RETINANET_RN50FPN: ModelConfig(
+            pretrained_model_name="retinanet_rn50fpn",
+        ),
+        ModelVariant.RETINANET_RN101FPN: ModelConfig(
+            pretrained_model_name="retinanet_rn101fpn",
+        ),
+        ModelVariant.RETINANET_RN152FPN: ModelConfig(
+            pretrained_model_name="retinanet_rn152fpn",
+        ),
+        ModelVariant.RETINANET_RESNET50_FPN_V2: ModelConfig(
+            pretrained_model_name="retinanet_resnet50_fpn_v2",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.RETINANET_RN50FPN
+
+    # Weight mappings for torchvision variants
+    _TORCHVISION_WEIGHTS = {
+        ModelVariant.RETINANET_RESNET50_FPN_V2: "RetinaNet_ResNet50_FPN_V2_Weights",
+    }
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None):
+        """Get model information for dashboard and metrics reporting.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="retinanet",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.CV_OBJECT_DETECTION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def __init__(self, variant=None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional string specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+
+        # Configuration parameters
+        self._cleanup_files = []  # Track files to cleanup
+
+    def _download_nvidia_model(self, variant_name):
+        """Download and extract NVIDIA RetinaNet model."""
+        url = f"https://github.com/NVIDIA/retinanet-examples/releases/download/19.04/{variant_name}.zip"
+        local_zip_path = f"{variant_name}.zip"
+
+        # Download the model
+        response = requests.get(url)
+        with open(local_zip_path, "wb") as f:
+            f.write(response.content)
+
+        # Extract the zip file
+        extracted_path = variant_name
+        with zipfile.ZipFile(local_zip_path, "r") as zip_ref:
+            zip_ref.extractall(".")
+
+        # Find the .pth file
+        checkpoint_path = ""
+        for root, _, files in os.walk(extracted_path):
+            for file in files:
+                if file.endswith(".pth"):
+                    checkpoint_path = os.path.join(root, file)
+                    break
+
+        # Track files for cleanup
+        self._cleanup_files.extend([local_zip_path, extracted_path])
+
+        return checkpoint_path
+
+    def _is_torchvision_variant(self, variant):
+        """Check if variant is a torchvision variant."""
+        return variant in self._TORCHVISION_WEIGHTS
+
+    def load_model(self, dtype_override=None):
+        """Load RetinaNet model based on variant type."""
+
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self._is_torchvision_variant(self._variant):
+            # Load torchvision model
+            weight_name = self._TORCHVISION_WEIGHTS[self._variant]
+            weights = getattr(models.detection, weight_name).DEFAULT
+            model = getattr(models.detection, pretrained_model_name)(weights=weights)
+        else:
+            # Load NVIDIA custom model
+            checkpoint_path = self._download_nvidia_model(pretrained_model_name)
+
+            model = Model.load(checkpoint_path)
+
+        model.eval()
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Prepare sample input for RetinaNet model"""
+
+        if self._is_torchvision_variant(self._variant):
+            # Use torchvision preprocessing
+            weight_name = self._TORCHVISION_WEIGHTS[self._variant]
+            weights = getattr(models.detection, weight_name).DEFAULT
+            preprocess = weights.transforms()
+
+            # Load COCO image
+            input_image = get_file(
+                "http://images.cocodataset.org/val2017/000000039769.jpg"
+            )
+            image = Image.open(str(input_image)).convert("RGB")
+            img_t = preprocess(image)
+            batch_t = torch.unsqueeze(img_t, 0).contiguous()
+        else:
+            # Use NVIDIA custom preprocessing (similar to img_preprocess function)
+            url = "https://i.ytimg.com/vi/q71MCWAEfL8/maxresdefault.jpg"
+            pil_img = Image.open(requests.get(url, stream=True).raw)
+            new_size = (640, 480)
+            pil_img = pil_img.resize(new_size, resample=Image.BICUBIC)
+
+            preprocess = transforms.Compose(
+                [
+                    transforms.ToTensor(),
+                    transforms.Normalize(
+                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                    ),
+                ]
+            )
+
+            img = preprocess(pil_img)
+            batch_t = img.unsqueeze(0)
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            batch_t = batch_t.to(dtype_override)
+
+        return batch_t
+
+    def cleanup(self):
+        """Clean up downloaded files."""
+        for file_path in self._cleanup_files:
+            try:
+                if os.path.isfile(file_path):
+                    os.remove(file_path)
+                elif os.path.isdir(file_path):
+                    shutil.rmtree(file_path)
+            except Exception as e:
+                print(f"Warning: Could not clean up {file_path}: {e}")
+        self._cleanup_files.clear()
+
+    def __del__(self):
+        """Destructor to ensure cleanup."""
+        self.cleanup()

--- a/retinanet/pytorch/src/backbone.py
+++ b/retinanet/pytorch/src/backbone.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+"""
+# code apapted from :
+# https://github.com/NVIDIA/retinanet-examples/tree/main/odtk
+
+Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+import sys
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.utils.model_zoo as model_zoo
+from torchvision.models import resnet as vrn
+from torchvision.models.resnet import (
+    ResNet18_Weights,
+    ResNet34_Weights,
+    ResNet50_Weights,
+    ResNet101_Weights,
+    ResNet152_Weights,
+)
+
+
+def register(f):
+    all = sys.modules[f.__module__].__dict__.setdefault("__all__", [])
+    if f.__name__ in all:
+        raise RuntimeError("{} already exist!".format(f.__name__))
+    all.append(f.__name__)
+    return f
+
+
+class ResNet(vrn.ResNet):
+    "Deep Residual Network - https://arxiv.org/abs/1512.03385"
+
+    def __init__(
+        self,
+        layers=[3, 4, 6, 3],
+        bottleneck=vrn.Bottleneck,
+        outputs=[5],
+        groups=1,
+        width_per_group=64,
+        url=None,
+    ):
+        self.stride = 128
+        self.bottleneck = bottleneck
+        self.outputs = outputs
+        self.url = url
+
+        kwargs = {
+            "block": bottleneck,
+            "layers": layers,
+            "groups": groups,
+            "width_per_group": width_per_group,
+        }
+        super().__init__(**kwargs)
+        self.unused_modules = ["fc"]
+
+    def initialize(self):
+        if self.url:
+            self.load_state_dict(model_zoo.load_url(self.url))
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+
+        outputs = []
+        for i, layer in enumerate([self.layer1, self.layer2, self.layer3, self.layer4]):
+            level = i + 2
+            if level > max(self.outputs):
+                break
+            x = layer(x)
+            if level in self.outputs:
+                outputs.append(x)
+
+        return outputs
+
+
+class FPN(nn.Module):
+    "Feature Pyramid Network - https://arxiv.org/abs/1612.03144"
+
+    def __init__(self, features):
+        super().__init__()
+
+        self.stride = 128
+        self.features = features
+
+        if isinstance(features, ResNet):
+            is_light = features.bottleneck == vrn.BasicBlock
+            channels = [128, 256, 512] if is_light else [512, 1024, 2048]
+
+        self.lateral3 = nn.Conv2d(channels[0], 256, 1)
+        self.lateral4 = nn.Conv2d(channels[1], 256, 1)
+        self.lateral5 = nn.Conv2d(channels[2], 256, 1)
+        self.pyramid6 = nn.Conv2d(channels[2], 256, 3, stride=2, padding=1)
+        self.pyramid7 = nn.Conv2d(256, 256, 3, stride=2, padding=1)
+        self.smooth3 = nn.Conv2d(256, 256, 3, padding=1)
+        self.smooth4 = nn.Conv2d(256, 256, 3, padding=1)
+        self.smooth5 = nn.Conv2d(256, 256, 3, padding=1)
+
+    def initialize(self):
+        def init_layer(layer):
+            if isinstance(layer, nn.Conv2d):
+                nn.init.xavier_uniform_(layer.weight)
+                if layer.bias is not None:
+                    nn.init.constant_(layer.bias, val=0)
+
+        self.apply(init_layer)
+
+        self.features.initialize()
+
+    def forward(self, x):
+        c3, c4, c5 = self.features(x)
+
+        p5 = self.lateral5(c5)
+        p4 = self.lateral4(c4)
+        p4 = F.interpolate(p5, scale_factor=2) + p4
+        p3 = self.lateral3(c3)
+        p3 = F.interpolate(p4, scale_factor=2) + p3
+
+        p6 = self.pyramid6(c5)
+        p7 = self.pyramid7(F.relu(p6))
+
+        p3 = self.smooth3(p3)
+        p4 = self.smooth4(p4)
+        p5 = self.smooth5(p5)
+
+        return [p3, p4, p5, p6, p7]
+
+
+@register
+def ResNet18FPN():
+    return FPN(
+        ResNet(
+            layers=[2, 2, 2, 2],
+            bottleneck=vrn.BasicBlock,
+            outputs=[3, 4, 5],
+            url=torch.utils.model_zoo.load_url(ResNet18_Weights.IMAGENET1K_V1.url),
+        )
+    )
+
+
+@register
+def ResNet34FPN():
+    return FPN(
+        ResNet(
+            layers=[3, 4, 6, 3],
+            bottleneck=vrn.BasicBlock,
+            outputs=[3, 4, 5],
+            url=torch.utils.model_zoo.load_url(ResNet34_Weights.IMAGENET1K_V1.url),
+        )
+    )
+
+
+@register
+def ResNet50FPN():
+    return FPN(
+        ResNet(
+            layers=[3, 4, 6, 3],
+            bottleneck=vrn.Bottleneck,
+            outputs=[3, 4, 5],
+            url=torch.utils.model_zoo.load_url(ResNet50_Weights.IMAGENET1K_V2.url),
+        )
+    )
+
+
+@register
+def ResNet101FPN():
+    return FPN(
+        ResNet(
+            layers=[3, 4, 23, 3],
+            bottleneck=vrn.Bottleneck,
+            outputs=[3, 4, 5],
+            url=torch.utils.model_zoo.load_url(ResNet101_Weights.IMAGENET1K_V2.url),
+        )
+    )
+
+
+@register
+def ResNet152FPN():
+    return FPN(
+        ResNet(
+            layers=[3, 8, 36, 3],
+            bottleneck=vrn.Bottleneck,
+            outputs=[3, 4, 5],
+            url=torch.utils.model_zoo.load_url(ResNet152_Weights.IMAGENET1K_V2.url),
+        )
+    )

--- a/retinanet/pytorch/src/model.py
+++ b/retinanet/pytorch/src/model.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+"""
+# code apapted from :
+# https://github.com/NVIDIA/retinanet-examples/tree/main/odtk
+
+Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+import math
+import os.path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from . import backbone as backbones_mod
+
+
+class FocalLoss(nn.Module):
+    "Focal Loss - https://arxiv.org/abs/1708.02002"
+
+    def __init__(self, alpha=0.25, gamma=2):
+        super().__init__()
+        self.alpha = alpha
+        self.gamma = gamma
+
+    def forward(self, pred_logits, target):
+        pred = pred_logits.sigmoid()
+        ce = F.binary_cross_entropy_with_logits(pred_logits, target, reduction="none")
+        alpha = target * self.alpha + (1.0 - target) * (1.0 - self.alpha)
+        pt = torch.where(target == 1, pred, 1 - pred)
+        return alpha * (1.0 - pt) ** self.gamma * ce
+
+
+class SmoothL1Loss(nn.Module):
+    "Smooth L1 Loss"
+
+    def __init__(self, beta=0.11):
+        super().__init__()
+        self.beta = beta
+
+    def forward(self, pred, target):
+        x = (pred - target).abs()
+        l1 = x - 0.5 * self.beta
+        l2 = 0.5 * x**2 / self.beta
+        return torch.where(x >= self.beta, l1, l2)
+
+
+class Model(nn.Module):
+    "RetinaNet - https://arxiv.org/abs/1708.02002"
+
+    def __init__(
+        self,
+        backbones="ResNet50FPN",
+        classes=80,
+        ratios=[1.0, 2.0, 0.5],
+        scales=[4 * 2 ** (i / 3) for i in range(3)],
+        angles=None,
+        rotated_bbox=False,
+        anchor_ious=[0.4, 0.5],
+        config={},
+    ):
+        super().__init__()
+
+        if not isinstance(backbones, list):
+            backbones = [backbones]
+
+        self.backbones = nn.ModuleDict(
+            {b: getattr(backbones_mod, b)() for b in backbones}
+        )
+        self.name = "RetinaNet"
+        self.unused_modules = []
+        for b in backbones:
+            self.unused_modules.extend(
+                getattr(self.backbones, b).features.unused_modules
+            )
+        self.exporting = False
+        self.rotated_bbox = rotated_bbox
+        self.anchor_ious = anchor_ious
+
+        self.ratios = ratios
+        self.scales = scales
+        self.angles = (
+            angles
+            if angles is not None
+            else [-np.pi / 6, 0, np.pi / 6]
+            if self.rotated_bbox
+            else None
+        )
+        self.anchors = {}
+        self.classes = classes
+
+        self.threshold = config.get("threshold", 0.05)
+        self.top_n = config.get("top_n", 1000)
+        self.nms = config.get("nms", 0.5)
+        self.detections = config.get("detections", 100)
+
+        self.stride = max([b.stride for _, b in self.backbones.items()])
+
+        # classification and box regression heads
+        def make_head(out_size):
+            layers = []
+            for _ in range(4):
+                layers += [nn.Conv2d(256, 256, 3, padding=1), nn.ReLU()]
+            layers += [nn.Conv2d(256, out_size, 3, padding=1)]
+            return nn.Sequential(*layers)
+
+        self.num_anchors = len(self.ratios) * len(self.scales)
+        self.num_anchors = (
+            self.num_anchors
+            if not self.rotated_bbox
+            else (self.num_anchors * len(self.angles))
+        )
+        self.cls_head = make_head(classes * self.num_anchors)
+        self.box_head = (
+            make_head(4 * self.num_anchors)
+            if not self.rotated_bbox
+            else make_head(6 * self.num_anchors)
+        )  # theta -> cos(theta), sin(theta)
+
+        self.cls_criterion = FocalLoss()
+        self.box_criterion = SmoothL1Loss(beta=0.11)
+
+    def __repr__(self):
+        return "\n".join(
+            [
+                "     model: {}".format(self.name),
+                "  backbone: {}".format(
+                    ", ".join([k for k, _ in self.backbones.items()])
+                ),
+                "   classes: {}, anchors: {}".format(self.classes, self.num_anchors),
+            ]
+        )
+
+    def initialize(self, pre_trained):
+        if pre_trained:
+            # Initialize using weights from pre-trained model
+            if not os.path.isfile(pre_trained):
+                raise ValueError("No checkpoint {}".format(pre_trained))
+
+            print(
+                "Fine-tuning weights from {}...".format(os.path.basename(pre_trained))
+            )
+            state_dict = self.state_dict()
+            chk = torch.load(pre_trained, map_location=lambda storage, loc: storage)
+            ignored = ["cls_head.8.bias", "cls_head.8.weight"]
+            if self.rotated_bbox:
+                ignored += ["box_head.8.bias", "box_head.8.weight"]
+            weights = {k: v for k, v in chk["state_dict"].items() if k not in ignored}
+            state_dict.update(weights)
+            self.load_state_dict(state_dict)
+
+            del chk, weights
+            torch.cuda.empty_cache()
+
+        else:
+            # Initialize backbone(s)
+            for _, backbone in self.backbones.items():
+                backbone.initialize()
+
+            # Initialize heads
+            def initialize_layer(layer):
+                if isinstance(layer, nn.Conv2d):
+                    nn.init.normal_(layer.weight, std=0.01)
+                    if layer.bias is not None:
+                        nn.init.constant_(layer.bias, val=0)
+
+            self.cls_head.apply(initialize_layer)
+            self.box_head.apply(initialize_layer)
+
+        # Initialize class head prior
+        def initialize_prior(layer):
+            pi = 0.01
+            b = -math.log((1 - pi) / pi)
+            nn.init.constant_(layer.bias, b)
+            nn.init.normal_(layer.weight, std=0.01)
+
+        self.cls_head[-1].apply(initialize_prior)
+        if self.rotated_bbox:
+            self.box_head[-1].apply(initialize_prior)
+
+    def forward(self, x):
+
+        # Backbones forward pass
+        features = []
+        for _, backbone in self.backbones.items():
+            features.extend(backbone(x))
+
+        # Heads forward pass
+        cls_heads = [self.cls_head(t) for t in features]
+        box_heads = [self.box_head(t) for t in features]
+
+        cls_heads = [cls_head.sigmoid() for cls_head in cls_heads]
+
+        combined_heads = cls_heads + box_heads
+
+        return combined_heads
+
+    @classmethod
+    def load(cls, filename, rotated_bbox=False):
+        if not os.path.isfile(filename):
+            raise ValueError("No checkpoint {}".format(filename))
+
+        checkpoint = torch.load(filename, map_location=lambda storage, loc: storage)
+        kwargs = {}
+        for i in ["ratios", "scales", "angles"]:
+            if i in checkpoint:
+                kwargs[i] = checkpoint[i]
+        if ("angles" in checkpoint) or rotated_bbox:
+            kwargs["rotated_bbox"] = True
+        # Recreate model from checkpoint instead of from individual backbones
+        model = cls(
+            backbones=checkpoint["backbone"], classes=checkpoint["classes"], **kwargs
+        )
+        model.load_state_dict(checkpoint["state_dict"])
+
+        return model

--- a/vovnet/pytorch/__init__.py
+++ b/vovnet/pytorch/__init__.py
@@ -4,4 +4,4 @@
 """
 Vovnet PyTorch model implementation for Tenstorrent projects.
 """
-from .loader import ModelLoader
+from .loader import ModelLoader, ModelVariant

--- a/vovnet/pytorch/loader.py
+++ b/vovnet/pytorch/loader.py
@@ -7,35 +7,64 @@ Vovnet model loader implementation for question answering
 from pytorchcv.model_provider import get_model as ptcv_get_model
 from torchvision import transforms
 from PIL import Image
-
+from typing import Optional
 from ...config import (
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
+    ModelConfig,
 )
 from ...base import ForgeModel
 from ...tools.utils import print_compiled_model_results
 from ...tools.utils import get_file
 
 
+class ModelVariant(StrEnum):
+    """Available WideResnet model variants."""
+
+    VOVNET27S = "vovnet27s"
+    VOVNET39 = "vovnet39"
+    VOVNET57 = "vovnet57"
+
+
 class ModelLoader(ForgeModel):
+    """WideResnet model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.VOVNET27S: ModelConfig(
+            pretrained_model_name="vovnet27s",
+        ),
+        ModelVariant.VOVNET39: ModelConfig(
+            pretrained_model_name="vovnet39",
+        ),
+        ModelVariant.VOVNET57: ModelConfig(
+            pretrained_model_name="vovnet57",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.VOVNET27S
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None):
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="vovnet",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.RED,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.TORCH_HUB,
@@ -52,12 +81,14 @@ class ModelLoader(ForgeModel):
         super().__init__(variant)
 
         # Configuration parameters
-        self.model_name = "vovnet27s"
         self.input_shape = (3, 224, 224)
 
     def load_model(self, dtype_override=None):
         """Load a Vovnet model from Pytorch CV Model Provider."""
-        model = ptcv_get_model(self.model_name, pretrained=True)
+
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+        model = ptcv_get_model(pretrained_model_name, pretrained=True)
         model.eval()
 
         # Only convert dtype if explicitly requested

--- a/wide_resnet/pytorch/__init__.py
+++ b/wide_resnet/pytorch/__init__.py
@@ -4,4 +4,4 @@
 """
 WideResnet PyTorch model implementation for Tenstorrent projects.
 """
-from .loader import ModelLoader
+from .loader import ModelLoader, ModelVariant

--- a/wide_resnet/pytorch/loader.py
+++ b/wide_resnet/pytorch/loader.py
@@ -6,6 +6,7 @@ WideResnet model loader implementation for question answering
 """
 import torch
 from PIL import Image
+from typing import Optional
 from torchvision import transforms
 from ...config import (
     ModelInfo,
@@ -13,25 +14,51 @@ from ...config import (
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
+    ModelConfig,
 )
 from ...base import ForgeModel
 from ...tools.utils import get_file
 from ...tools.utils import print_compiled_model_results
+from typing import Optional
+
+
+class ModelVariant(StrEnum):
+    """Available WideResnet model variants."""
+
+    WIDE_RESNET50_2 = "wide_resnet50_2"
+    WIDE_RESNET101_2 = "wide_resnet101_2"
 
 
 class ModelLoader(ForgeModel):
+    """WideResnet model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.WIDE_RESNET50_2: ModelConfig(
+            pretrained_model_name="wide_resnet50_2",
+        ),
+        ModelVariant.WIDE_RESNET101_2: ModelConfig(
+            pretrained_model_name="wide_resnet101_2",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.WIDE_RESNET50_2
+
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None):
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
         if variant_name is None:
-            variant_name = "base"
+            variant_name = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="wide_resnet",
             variant=variant_name,
@@ -52,8 +79,12 @@ class ModelLoader(ForgeModel):
 
     def load_model(self, dtype_override=None):
         """Load a WideResnet model from Torch Hub."""
-        model_name = "wide_resnet50_2"
-        model = torch.hub.load("pytorch/vision:v0.10.0", model_name, pretrained=True)
+
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+        model = torch.hub.load(
+            "pytorch/vision:v0.10.0", pretrained_model_name, pretrained=True
+        )
         model.eval()
 
         # Only convert dtype if explicitly requested
@@ -89,5 +120,14 @@ class ModelLoader(ForgeModel):
 
         return inputs
 
-    def print_cls_results(self, compiled_model_out):
-        print_compiled_model_results(compiled_model_out)
+    def post_processing(self, output, top_k=5):
+        probabilities = torch.nn.functional.softmax(output[0][0], dim=0)
+        class_file_path = get_file(
+            "https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt"
+        )
+
+        with open(class_file_path, "r") as f:
+            categories = [s.strip() for s in f.readlines()]
+        topk_prob, topk_catid = torch.topk(probabilities, top_k)
+        for i in range(topk_prob.size(0)):
+            print(categories[topk_catid[i]], topk_prob[i].item())


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-fe/issues/2666

### Problem description

- Add variant support for existing models and bring up tt-forge-fe models in tt-forge-models.

### What's changed

- Added support for ModelVariant in the ModelLoader class for the following models:
      a.Clip
      b.Monodepth2
      c.Perciever vision 
      d.Retinanet 
      e.Vovnet
      f.Whisper
     g.Wideresnet

### Logs
[clip_modified.log](https://github.com/user-attachments/files/21528495/clip_modified.log)
[monodepth2_1.log](https://github.com/user-attachments/files/21547493/monodepth2_1.log)
[perceiverio_vision_modified.log](https://github.com/user-attachments/files/21528516/perceiverio_vision_modified.log)
[retinanet_modified.log](https://github.com/user-attachments/files/21528521/retinanet_modified.log)
[vovnet_pytorch.log](https://github.com/user-attachments/files/21528526/vovnet_pytorch.log)
[whisper_modified.log](https://github.com/user-attachments/files/21528528/whisper_modified.log)