### PR TITLE
update yolo models load_input functions to use datasets

### DIFF
--- a/yolos/pytorch/loader.py
+++ b/yolos/pytorch/loader.py
@@ -4,9 +4,9 @@
 """
 YOLOS model loader implementation
 """
-from PIL import Image
-from transformers import AutoImageProcessor, AutoModelForObjectDetection
 
+from transformers import AutoImageProcessor, AutoModelForObjectDetection
+from datasets import load_dataset
 from ...config import (
     ModelInfo,
     ModelGroup,
@@ -86,8 +86,13 @@ class ModelLoader(ForgeModel):
             torch.Tensor: Sample input tensor that can be fed to the model.
         """
 
-        input_image = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        image = Image.open(str(input_image))
+        # Load dataset
+        dataset = load_dataset(
+            "huggingface/cats-image", split="test"
+        )  # cats-image is a dataset of 1000 images of cats
+
+        # Get first image from dataset
+        image = dataset[0]["image"]
         image_processor = AutoImageProcessor.from_pretrained(self.model_variant)
         inputs = image_processor(images=image, return_tensors="pt")
         batch_tensor = inputs["pixel_values"]

--- a/yolov3/pytorch/loader.py
+++ b/yolov3/pytorch/loader.py
@@ -7,9 +7,9 @@ YOLOv3 model loader implementation
 Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/yolo_v3/pytorch_yolov3_holli.py
 """
 import torch
-from PIL import Image
 from torchvision import transforms
 from typing import Optional
+from datasets import load_dataset
 
 from ...config import (
     ModelConfig,
@@ -113,12 +113,10 @@ class ModelLoader(ForgeModel):
             torch.Tensor: Sample input tensor that can be fed to the model.
         """
         # Original image used in test
-        image_file = get_file(
-            "https://raw.githubusercontent.com/pytorch/hub/master/images/dog.jpg"
-        )
+        dataset = load_dataset("chrismontes/dog_images", split="train")
 
         # Download and load image
-        image = Image.open(image_file)
+        image = dataset[0]["image"]
 
         # Preprocess the image
         transform = transforms.Compose(

--- a/yolov4/pytorch/loader.py
+++ b/yolov4/pytorch/loader.py
@@ -5,8 +5,8 @@
 YOLOv4 model loader implementation
 """
 import torch
-import cv2
-import numpy as np
+from datasets import load_dataset
+from torchvision import transforms
 from typing import Optional
 import os
 from ...tools.utils import get_file
@@ -117,14 +117,24 @@ class ModelLoader(ForgeModel):
             torch.Tensor: Sample input tensor that can be fed to the model.
         """
 
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        img = cv2.imread(str(image_file), cv2.IMREAD_COLOR)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # Convert BGR to RGB
-        img = cv2.resize(img, (640, 480))  # Resize to model input size
-        img = img / 255.0  # Normalize to [0,1]
-        img = np.transpose(img, (2, 0, 1))  # HWC to CHW format
-        img = [torch.from_numpy(img).float().unsqueeze(0)]  # Add batch dimension
-        batch_tensor = torch.cat(img, dim=0)
+        # Load dataset
+        dataset = load_dataset(
+            "huggingface/cats-image", split="test"
+        )  # cats-image is a dataset of 1000 images of cats
+
+        # Get first image from dataset
+        image = dataset[0]["image"]
+
+        # Preprocess the image
+        transform = transforms.Compose(
+            [
+                transforms.Resize((480, 640)),
+                transforms.ToTensor(),
+            ]
+        )
+
+        img_tensor = [transform(image).unsqueeze(0)]  # Add batch dimension
+        batch_tensor = torch.cat(img_tensor, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -153,8 +163,12 @@ class ModelLoader(ForgeModel):
                     f"Class: {class_name}, Score: {score:.2f}, Box: [{x1:.1f}, {y1:.1f}, {x2:.1f}, {y2:.1f}]"
                 )
 
-        image_path = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        img_cv = cv2.imread(str(image_path))
+        # Load dataset
+        dataset = load_dataset("huggingface/cats-image", split="test").with_format(
+            "np"
+        )  # get the image as an numpy array
+
+        img_cv = dataset[0]["image"]
         output_dir = "yolov4_predictions"
         os.makedirs(output_dir, exist_ok=True)
         output_filename = f"yolov4_predicted.jpg"

--- a/yolox/pytorch/loader.py
+++ b/yolox/pytorch/loader.py
@@ -12,7 +12,7 @@ subprocess.run(
 )  # Install yolox==0.3.0 without installing its dependencies
 
 import torch
-import cv2
+from datasets import load_dataset
 import os
 from typing import Optional
 
@@ -163,8 +163,10 @@ class ModelLoader(ForgeModel):
         else:
             input_shape = (640, 640)
 
-        image_path = get_file("http://images.cocodataset.org/val2017/000000397133.jpg")
-        img = cv2.imread(str(image_path))
+        ds = load_dataset("mpnikhil/kitchen-classifier", split="train").with_format(
+            "np"
+        )  # to get the image as an numpy array
+        img = ds[200]["image"]
         img_tensor, ratio = preprocess(img, input_shape)
         self.ratio = ratio
         self.input_shape = input_shape  # Store for post_processing


### PR DESCRIPTION
### Ticket
Similar to this [PR](https://github.com/tenstorrent/tt-forge-models/pull/48), where yolov10 load_inputs() is updated to use datasets package instead of url

### Problem description
HuggingFace datasets package can be used instead of getting images from url

### What's changed
* load_inputs() function is updated to use huggingface datasets library instead of url
* similar image to the previous image is fetched from the datasets
* In some places, where numpy array is expected for postprocessing, image from the dataset is retrieved in numpy format

### Checklist
- [x] New/Existing tests provide coverage for changes

tested some of the yolo models after these changes and logs are attached below

[yolov3.log](https://github.com/user-attachments/files/21487655/yolov3.log)
[yolov4.log](https://github.com/user-attachments/files/21487659/yolov4.log)

