### PR TITLE
Add optional dtype conversion for input in deit model

### DIFF
--- a/deit/pytorch/loader.py
+++ b/deit/pytorch/loader.py
@@ -136,6 +136,11 @@ class ModelLoader(ForgeModel):
         for key in inputs:
             inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            for key in inputs:
+                inputs[key] = inputs[key].to(dtype_override)
+
         return inputs
 
     def post_processing(self, co_out, model):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/2695

### Problem description
Deit model faced below error in tt-forge-fe due to the absence of optional dtype conversion of input in deit

```
RuntimeError: TT_ASSERT @ /proj_sw/user_dev/kkannan/jul29_bgd25/tt-forge-fe/forge/csrc/passes/dataformat.cpp:98: node->output_df() == default_df_override || node_is_int
E       info:
E       Non integer Input activations should have output_df same as dataformat override which is: Float16_b, but node output_df is: Float32
```

### What's changed
Added optional dtype conversion of input in deit

### Checklist
- [x] New/Existing tests provide coverage for changes
