### PR TITLE
Restructure loaders to support multiple model sources 

### DIFF
--- a/dla/pytorch/loader.py
+++ b/dla/pytorch/loader.py
@@ -8,6 +8,10 @@ DLA model loader implementation
 from typing import Optional
 from PIL import Image
 from torchvision import transforms
+from dataclasses import dataclass
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
 
 from ...config import (
     ModelConfig,
@@ -23,9 +27,17 @@ from ...tools.utils import get_file, print_compiled_model_results
 from .src import dla_model
 
 
+@dataclass
+class DLAConfig(ModelConfig):
+    """Configuration specific to DLA models"""
+
+    source: ModelSource
+
+
 class ModelVariant(StrEnum):
     """Available DLA model variants."""
 
+    # Torchvision variants
     DLA34 = "dla34"
     DLA46_C = "dla46_c"
     DLA46X_C = "dla46x_c"
@@ -37,41 +49,59 @@ class ModelVariant(StrEnum):
     DLA102X2 = "dla102x2"
     DLA169 = "dla169"
 
+    # Timm variants
+    DLA34_IN1K = "dla34.in1k"
+
 
 class ModelLoader(ForgeModel):
     """DLA model loader implementation."""
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        ModelVariant.DLA34: ModelConfig(
+        # Torchvision variants
+        ModelVariant.DLA34: DLAConfig(
             pretrained_model_name="dla34",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA46_C: ModelConfig(
+        ModelVariant.DLA46_C: DLAConfig(
             pretrained_model_name="dla46_c",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA46X_C: ModelConfig(
+        ModelVariant.DLA46X_C: DLAConfig(
             pretrained_model_name="dla46x_c",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA60: ModelConfig(
+        ModelVariant.DLA60: DLAConfig(
             pretrained_model_name="dla60",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA60X: ModelConfig(
+        ModelVariant.DLA60X: DLAConfig(
             pretrained_model_name="dla60x",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA60X_C: ModelConfig(
+        ModelVariant.DLA60X_C: DLAConfig(
             pretrained_model_name="dla60x_c",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA102: ModelConfig(
+        ModelVariant.DLA102: DLAConfig(
             pretrained_model_name="dla102",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA102X: ModelConfig(
+        ModelVariant.DLA102X: DLAConfig(
             pretrained_model_name="dla102x",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA102X2: ModelConfig(
+        ModelVariant.DLA102X2: DLAConfig(
             pretrained_model_name="dla102x2",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.DLA169: ModelConfig(
+        ModelVariant.DLA169: DLAConfig(
             pretrained_model_name="dla169",
+            source=ModelSource.TORCH_HUB,
+        ),
+        ModelVariant.DLA34_IN1K: DLAConfig(
+            pretrained_model_name="dla34.in1k",
+            source=ModelSource.TIMM,
         ),
     }
 
@@ -86,6 +116,7 @@ class ModelLoader(ForgeModel):
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
+        self._cached_model = None
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -100,12 +131,16 @@ class ModelLoader(ForgeModel):
         """
         if variant is None:
             variant = cls.DEFAULT_VARIANT
+
+        # Get source from variant config
+        source = cls._VARIANTS[variant].source
+
         return ModelInfo(
             model="dla",
             variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
+            source=source,
             framework=Framework.TORCH,
         )
 
@@ -121,11 +156,20 @@ class ModelLoader(ForgeModel):
         """
         # Get the pretrained model name from the instance's variant config
         model_name = self._variant_config.pretrained_model_name
+        source = self._variant_config.source
 
-        # Load model using the dla_model module
-        func = getattr(dla_model, model_name)
-        model = func(pretrained=None)
+        if source == ModelSource.TIMM:
+            # Load model using timm
+            model = timm.create_model(model_name, pretrained=True)
+        else:
+            # Load model using the dla_model module (torchvision style)
+            func = getattr(dla_model, model_name)
+            model = func(pretrained=None)
+
         model.eval()
+
+        # Cache model for use in load_inputs (to avoid reloading)
+        self._cached_model = model
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -148,20 +192,34 @@ class ModelLoader(ForgeModel):
         image_file = get_file(
             "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
         )
-        image = Image.open(image_file)
+        image = Image.open(image_file).convert("RGB")
 
-        # Preprocess image
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        inputs = preprocess(image).unsqueeze(0)
+        source = self._variant_config.source
+
+        if source == ModelSource.TIMM:
+            # Use cached model if available, otherwise load it
+            if hasattr(self, "_cached_model") and self._cached_model is not None:
+                model_for_config = self._cached_model
+            else:
+                model_for_config = self.load_model(dtype_override)
+
+            # Preprocess image using model's data config
+            data_config = resolve_data_config({}, model=model_for_config)
+            timm_transforms = create_transform(**data_config)
+            inputs = timm_transforms(image).unsqueeze(0)
+        else:
+            # Use standard torchvision preprocessing
+            preprocess = transforms.Compose(
+                [
+                    transforms.Resize(256),
+                    transforms.CenterCrop(224),
+                    transforms.ToTensor(),
+                    transforms.Normalize(
+                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                    ),
+                ]
+            )
+            inputs = preprocess(image).unsqueeze(0)
 
         # Replicate tensors for batch size
         inputs = inputs.repeat_interleave(batch_size, dim=0)


### PR DESCRIPTION
### Problem description

vision models (like DLA), the system depends on separate loaders or folder structures to distinguish between models from different sources such as torchvision or timm.

### What's changed

- Generalized CV Model Loader for DLA by merging multiple model sources (torchvision/timm) into a single ModelLoader class:
        a. ModelSource.TORCH_HUB 
        b. ModelSource.TIMM 

