### PR TITLE
Fix few model issues and bring back 7x passing vgg variants

### DIFF
--- a/bert/sentence_embedding_generation/pytorch/loader.py
+++ b/bert/sentence_embedding_generation/pytorch/loader.py
@@ -72,7 +72,7 @@ class ModelLoader(ForgeModel):
             model="BERT-SentenceEmbeddingGeneration",
             variant=variant_name,
             group=ModelGroup.RED,
-            task=ModelTask.SENTENCE_EMBEDDING_GENERATION,
+            task=ModelTask.NLP_TEXT_CLS,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )

--- a/centernet/onnx/loader.py
+++ b/centernet/onnx/loader.py
@@ -52,9 +52,9 @@ class ModelLoader(ForgeModel):
             variant_name = "dla1x_od"  # Default variant is object detection
         # Determine task based on variant name
         if "hpe" in variant_name:
-            task = ModelTask.CV_POSE_ESTIMATION
+            task = ModelTask.CV_KEYPOINT_DET
         elif "3d" in variant_name.lower():
-            task = ModelTask.CV_3D_DETECTION
+            task = ModelTask.CV_OBJECT_DET
         else:
             task = ModelTask.CV_OBJECT_DET
         return ModelInfo(

--- a/falcon/pytorch/loader.py
+++ b/falcon/pytorch/loader.py
@@ -59,7 +59,8 @@ class ModelLoader(ForgeModel):
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant

--- a/mamba/pytorch/loader.py
+++ b/mamba/pytorch/loader.py
@@ -55,7 +55,8 @@ class ModelLoader(ForgeModel):
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant

--- a/openpose/v2/pytorch/loader.py
+++ b/openpose/v2/pytorch/loader.py
@@ -47,7 +47,7 @@ class ModelLoader(ForgeModel):
         if variant_name is None:
             variant_name = "base"
         return ModelInfo(
-            model="OpenPose V2",
+            model="openpose_v2",
             variant=variant_name,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_KEYPOINT_DET,

--- a/phi1/sequence_classification/pytorch/loader.py
+++ b/phi1/sequence_classification/pytorch/loader.py
@@ -68,7 +68,7 @@ class ModelLoader(ForgeModel):
             model="phi1",
             variant=variant,
             group=ModelGroup.RED,
-            task=ModelTask.NLP_SEQUENCE_CLASSIFICATION,
+            task=ModelTask.NLP_TEXT_CLS,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )

--- a/phi1/token_classification/pytorch/loader.py
+++ b/phi1/token_classification/pytorch/loader.py
@@ -68,7 +68,7 @@ class ModelLoader(ForgeModel):
             model="phi1",
             variant=variant,
             group=ModelGroup.RED,
-            task=ModelTask.NLP_TOKEN_CLASSIFICATION,
+            task=ModelTask.NLP_TOKEN_CLS,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )

--- a/retinanet/pytorch/loader.py
+++ b/retinanet/pytorch/loader.py
@@ -90,7 +90,7 @@ class ModelLoader(ForgeModel):
             model="retinanet",
             variant=variant,
             group=ModelGroup.RED,
-            task=ModelTask.CV_OBJECT_DETECTION,
+            task=ModelTask.CV_OBJECT_DET,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )

--- a/vgg/pytorch/loader.py
+++ b/vgg/pytorch/loader.py
@@ -26,6 +26,13 @@ from torchvision import transforms
 class ModelVariant(StrEnum):
     """Available VGG model variants."""
 
+    VGG11 = "vgg11"
+    VGG11_BN = "vgg11_bn"
+    VGG13 = "vgg13"
+    VGG13_BN = "vgg13_bn"
+    VGG16 = "vgg16"
+    VGG16_BN = "vgg16_bn"
+    VGG19 = "vgg19"
     VGG19_BN = "vgg19_bn"
 
 
@@ -34,6 +41,27 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
+        ModelVariant.VGG11: ModelConfig(
+            pretrained_model_name="vgg11",
+        ),
+        ModelVariant.VGG11_BN: ModelConfig(
+            pretrained_model_name="vgg11_bn",
+        ),
+        ModelVariant.VGG13: ModelConfig(
+            pretrained_model_name="vgg13",
+        ),
+        ModelVariant.VGG13_BN: ModelConfig(
+            pretrained_model_name="vgg13_bn",
+        ),
+        ModelVariant.VGG16: ModelConfig(
+            pretrained_model_name="vgg16",
+        ),
+        ModelVariant.VGG16_BN: ModelConfig(
+            pretrained_model_name="vgg16_bn",
+        ),
+        ModelVariant.VGG19: ModelConfig(
+            pretrained_model_name="vgg19",
+        ),
         ModelVariant.VGG19_BN: ModelConfig(
             pretrained_model_name="vgg19_bn",
         ),

--- a/vit/pytorch/loader.py
+++ b/vit/pytorch/loader.py
@@ -48,7 +48,8 @@ class ModelLoader(ForgeModel):
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
 
         Returns:
             ModelInfo: Information about the model and variant

--- a/wide_resnet/pytorch/loader.py
+++ b/wide_resnet/pytorch/loader.py
@@ -57,11 +57,9 @@ class ModelLoader(ForgeModel):
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="wide_resnet",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.TORCH_HUB,


### PR DESCRIPTION
### Ticket
None

### Problem description
- Hit some errors running phi1, wide_resnet, bert, retinanet due to typos
- Some passing VGG variants were removed in https://github.com/tenstorrent/tt-forge-models/pull/55

### What's changed
- Bring 7 vgg variants back as per my request in that PR
- Fix invalid ModelTask in phi1 models, bert, retinanet, centernet
- Fix wide_resnet typo and fix vit, mamba, falcon docs
- Also, fix a model name that had a space in it (OpenPose V2)
### Checklist
- [x] They pass in tt-torch
