### PR TITLE
Remove unnecessary llama dtype_override

### DIFF
--- a/llama/causal_lm/pytorch/loader.py
+++ b/llama/causal_lm/pytorch/loader.py
@@ -240,9 +240,4 @@ class ModelLoader(ForgeModel):
         for key in inputs:
             inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
-        # Only convert dtype if explicitly requested
-        if dtype_override is not None:
-            for key in inputs:
-                inputs[key] = inputs[key].to(dtype_override)
-
         return inputs

--- a/llama/sequence_classification/pytorch/loader.py
+++ b/llama/sequence_classification/pytorch/loader.py
@@ -225,11 +225,6 @@ class ModelLoader(ForgeModel):
         for key in inputs:
             inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
-        # Only convert dtype if explicitly requested
-        if dtype_override is not None:
-            for key in inputs:
-                inputs[key] = inputs[key].to(dtype_override)
-
         return inputs
 
     def decode_output(self, outputs, inputs=None):


### PR DESCRIPTION
### Problem description
Setting overriding the type of all the input keys like this:

            if dtype_override is not None:
                        for key in inputs:
                            inputs[key] = inputs[key].to(dtype_override)
                            
Causes an error in tt-torch tests since not all input keys can be set to `torch.bfloat16`. Since this is an error in the forward pass and not in the tt-torch model tester, this must be changed in order for the model to pass with `dtype_override=torch.bfloat16`.

            E       RuntimeError: Expected tensor for argument #1 'indices' to have one of the following scalar types: Long, Int; but                         
            got CPUBFloat16Type instead (while checking arguments for embedding)

### What's changed
Removed these lines to allow the llama models to pass in tt-torch without error.

### Checklist
- [x] New/Existing tests provide coverage for changes
