### PR TITLE
Bringup tt-forge-fe models - set11

### DIFF
--- a/alexnet/pytorch/__init__.py
+++ b/alexnet/pytorch/__init__.py
@@ -4,4 +4,4 @@
 """
 AlexNet PyTorch model implementation for Tenstorrent projects.
 """
-from .loader import ModelLoader
+from .loader import ModelLoader, ModelVariant

--- a/alexnet/pytorch/loader.py
+++ b/alexnet/pytorch/loader.py
@@ -6,59 +6,111 @@ AlexNet model loader implementation
 """
 
 import torch
+from typing import Optional
+from dataclasses import dataclass
+from PIL import Image
+from torchvision import transforms
+from pytorchcv.model_provider import get_model as ptcv_get_model
+
 from ...config import (
+    ModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
     ModelSource,
     Framework,
+    StrEnum,
 )
 from ...base import ForgeModel
-
-from PIL import Image
 from ...tools.utils import get_file, print_compiled_model_results
-from torchvision import transforms
+
+
+@dataclass
+class AlexNetConfig(ModelConfig):
+    """Configuration specific to AlexNet models"""
+
+    source: ModelSource
+
+
+class ModelVariant(StrEnum):
+    """Available AlexNet model variants across different sources."""
+
+    ALEXNET_TORCH_HUB = "alexnet"
+
+    ALEXNET_OSMR_B = "alexnetb"
 
 
 class ModelLoader(ForgeModel):
     @classmethod
-    def _get_model_info(cls, variant_name: str = None):
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None):
         """Get model information for dashboard and metrics reporting.
 
         Args:
-            variant_name: Optional variant name string. If None, uses 'base'.
+            variant: Optional variant name string. If None, uses 'base'.
 
         Returns:
             ModelInfo: Information about the model and variant
         """
-        if variant_name is None:
-            variant_name = "base"
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        source = cls._VARIANTS[variant].source
+
         return ModelInfo(
             model="alexnet",
-            variant=variant_name,
+            variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
+            source=source,
             framework=Framework.TORCH,
         )
 
     """Loads AlexNet model and sample input."""
 
-    def __init__(self, variant=None):
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        # Torch Hub / Torchvision
+        ModelVariant.ALEXNET_TORCH_HUB: AlexNetConfig(
+            pretrained_model_name="alexnet",
+            source=ModelSource.TORCH_HUB,
+        ),
+        # OSMR variant
+        ModelVariant.ALEXNET_OSMR_B: AlexNetConfig(
+            pretrained_model_name="alexnetb",
+            source=ModelSource.OSMR,
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.ALEXNET_TORCH_HUB
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
-            variant: Optional string specifying which variant to use.
+            variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
+        self._cached_model = None
 
     def load_model(self, dtype_override=None):
-        """Load pretrained AlexNet model."""
+        """Load pretrained AlexNet model for this instance's variant."""
 
-        model_name = "alexnet"
-        model = torch.hub.load("pytorch/vision:v0.10.0", model_name, pretrained=True)
+        model_name = self._variant_config.pretrained_model_name
+        source = self._variant_config.source
+
+        if source == ModelSource.OSMR:
+            model = ptcv_get_model(model_name, pretrained=True)
+        else:
+            model = torch.hub.load(
+                "pytorch/vision:v0.10.0", model_name, pretrained=True
+            )
+
         model.eval()
+
+        # Cache model for use in load_inputs (to avoid reloading)
+        self._cached_model = model
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -66,16 +118,13 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
+    def load_inputs(self, dtype_override=None, batch_size=1):
         """Prepare sample input for AlexNet model"""
 
-        # Get the Image
         image_file = get_file(
             "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
         )
-        image = Image.open(image_file)
-
-        # Preprocess image
+        image = Image.open(image_file).convert("RGB")
         preprocess = transforms.Compose(
             [
                 transforms.Resize(256),

--- a/dla/pytorch/loader.py
+++ b/dla/pytorch/loader.py
@@ -197,7 +197,6 @@ class ModelLoader(ForgeModel):
         source = self._variant_config.source
 
         if source == ModelSource.TIMM:
-            # Use cached model if available, otherwise load it
             if hasattr(self, "_cached_model") and self._cached_model is not None:
                 model_for_config = self._cached_model
             else:
@@ -220,9 +219,6 @@ class ModelLoader(ForgeModel):
                 ]
             )
             inputs = preprocess(image).unsqueeze(0)
-
-        # Replicate tensors for batch size
-        inputs = inputs.repeat_interleave(batch_size, dim=0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:

--- a/efficientnet/pytorch/loader.py
+++ b/efficientnet/pytorch/loader.py
@@ -20,10 +20,14 @@ from ...config import (
     StrEnum,
 )
 from ...base import ForgeModel
+from loguru import logger
 import torchvision.models as models
 from torchvision.models._api import WeightsEnum
 from ...tools.utils import get_file, print_compiled_model_results, get_state_dict
 from torchvision import transforms
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
 
 
 @dataclass
@@ -32,11 +36,14 @@ class EfficientNetConfig(ModelConfig):
 
     model_function: str = None
     weights_class: str = None
+    use_1k_labels: bool = False
+    source: ModelSource = ModelSource.TORCHVISION
 
 
 class ModelVariant(StrEnum):
     """Available EfficientNet model variants."""
 
+    # Torchvision variants
     B0 = "efficientnet_b0"
     B1 = "efficientnet_b1"
     B2 = "efficientnet_b2"
@@ -45,6 +52,16 @@ class ModelVariant(StrEnum):
     B5 = "efficientnet_b5"
     B6 = "efficientnet_b6"
     B7 = "efficientnet_b7"
+
+    # TIMM variants (values are identifiers for reporting; pretrained model names live in config)
+    TIMM_EFFICIENTNET_B0 = "timm_efficientnet_b0"
+    TIMM_EFFICIENTNET_B4 = "timm_efficientnet_b4"
+    HF_TIMM_EFFICIENTNET_B0_RA_IN1K = "hf_hub_timm_efficientnet_b0_ra_in1k"
+    HF_TIMM_EFFICIENTNET_B4_RA2_IN1K = "hf_hub_timm_efficientnet_b4_ra2_in1k"
+    HF_TIMM_EFFICIENTNET_B5_IN12K_FT_IN1K = "hf_hub_timm_efficientnet_b5_in12k_ft_in1k"
+    HF_TIMM_TF_EFFICIENTNET_B0_AA_IN1K = "hf_hub_timm_tf_efficientnet_b0_aa_in1k"
+    HF_TIMM_EFFICIENTNETV2_RW_S_RA2_IN1K = "hf_hub_timm_efficientnetv2_rw_s_ra2_in1k"
+    HF_TIMM_TF_EFFICIENTNETV2_S_IN21K = "hf_hub_timm_tf_efficientnetv2_s_in21k"
 
 
 class ModelLoader(ForgeModel):
@@ -55,52 +72,111 @@ class ModelLoader(ForgeModel):
         pretrained_model_name="efficientnet_b0",
         model_function="efficientnet_b0",
         weights_class="EfficientNet_B0_Weights",
+        source=ModelSource.TORCHVISION,
+        use_1k_labels=True,
     )
 
     B1_CONFIG = EfficientNetConfig(
         pretrained_model_name="efficientnet_b1",
         model_function="efficientnet_b1",
         weights_class="EfficientNet_B1_Weights",
+        source=ModelSource.TORCHVISION,
+        use_1k_labels=True,
     )
 
     B2_CONFIG = EfficientNetConfig(
         pretrained_model_name="efficientnet_b2",
         model_function="efficientnet_b2",
         weights_class="EfficientNet_B2_Weights",
+        source=ModelSource.TORCHVISION,
+        use_1k_labels=True,
     )
 
     B3_CONFIG = EfficientNetConfig(
         pretrained_model_name="efficientnet_b3",
         model_function="efficientnet_b3",
         weights_class="EfficientNet_B3_Weights",
+        source=ModelSource.TORCHVISION,
+        use_1k_labels=True,
     )
 
     B4_CONFIG = EfficientNetConfig(
         pretrained_model_name="efficientnet_b4",
         model_function="efficientnet_b4",
         weights_class="EfficientNet_B4_Weights",
+        source=ModelSource.TORCHVISION,
+        use_1k_labels=True,
     )
 
     B5_CONFIG = EfficientNetConfig(
         pretrained_model_name="efficientnet_b5",
         model_function="efficientnet_b5",
         weights_class="EfficientNet_B5_Weights",
+        source=ModelSource.TORCHVISION,
+        use_1k_labels=True,
     )
 
     B6_CONFIG = EfficientNetConfig(
         pretrained_model_name="efficientnet_b6",
         model_function="efficientnet_b6",
         weights_class="EfficientNet_B6_Weights",
+        source=ModelSource.TORCHVISION,
+        use_1k_labels=True,
     )
 
     B7_CONFIG = EfficientNetConfig(
         pretrained_model_name="efficientnet_b7",
         model_function="efficientnet_b7",
         weights_class="EfficientNet_B7_Weights",
+        source=ModelSource.TORCHVISION,
+        use_1k_labels=True,
+    )
+
+    # TIMM config instances
+    TIMM_EFFICIENTNET_B0_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b0",
+        source=ModelSource.TIMM,
+        use_1k_labels=True,
+    )
+    TIMM_EFFICIENTNET_B4_CONFIG = EfficientNetConfig(
+        pretrained_model_name="efficientnet_b4",
+        source=ModelSource.TIMM,
+        use_1k_labels=True,
+    )
+    HF_TIMM_EFFICIENTNET_B0_RA_IN1K_CONFIG = EfficientNetConfig(
+        pretrained_model_name="hf_hub:timm/efficientnet_b0.ra_in1k",
+        source=ModelSource.TIMM,
+        use_1k_labels=True,
+    )
+    HF_TIMM_EFFICIENTNET_B4_RA2_IN1K_CONFIG = EfficientNetConfig(
+        pretrained_model_name="hf_hub:timm/efficientnet_b4.ra2_in1k",
+        source=ModelSource.TIMM,
+        use_1k_labels=True,
+    )
+    HF_TIMM_EFFICIENTNET_B5_IN12K_FT_IN1K_CONFIG = EfficientNetConfig(
+        pretrained_model_name="hf_hub:timm/efficientnet_b5.in12k_ft_in1k",
+        source=ModelSource.TIMM,
+        use_1k_labels=True,
+    )
+    HF_TIMM_TF_EFFICIENTNET_B0_AA_IN1K_CONFIG = EfficientNetConfig(
+        pretrained_model_name="hf_hub:timm/tf_efficientnet_b0.aa_in1k",
+        source=ModelSource.TIMM,
+        use_1k_labels=True,
+    )
+    HF_TIMM_EFFICIENTNETV2_RW_S_RA2_IN1K_CONFIG = EfficientNetConfig(
+        pretrained_model_name="hf_hub:timm/efficientnetv2_rw_s.ra2_in1k",
+        source=ModelSource.TIMM,
+        use_1k_labels=True,
+    )
+    HF_TIMM_TF_EFFICIENTNETV2_S_IN21K_CONFIG = EfficientNetConfig(
+        pretrained_model_name="hf_hub:timm/tf_efficientnetv2_s.in21k",
+        source=ModelSource.TIMM,
+        use_1k_labels=False,
     )
 
     # Dictionary using the static dataclass instances (for compatibility with existing tests)
     _VARIANTS = {
+        # Torchvision variants
         ModelVariant.B0: B0_CONFIG,
         ModelVariant.B1: B1_CONFIG,
         ModelVariant.B2: B2_CONFIG,
@@ -109,6 +185,15 @@ class ModelLoader(ForgeModel):
         ModelVariant.B5: B5_CONFIG,
         ModelVariant.B6: B6_CONFIG,
         ModelVariant.B7: B7_CONFIG,
+        # TIMM variants
+        ModelVariant.TIMM_EFFICIENTNET_B0: TIMM_EFFICIENTNET_B0_CONFIG,
+        ModelVariant.TIMM_EFFICIENTNET_B4: TIMM_EFFICIENTNET_B4_CONFIG,
+        ModelVariant.HF_TIMM_EFFICIENTNET_B0_RA_IN1K: HF_TIMM_EFFICIENTNET_B0_RA_IN1K_CONFIG,
+        ModelVariant.HF_TIMM_EFFICIENTNET_B4_RA2_IN1K: HF_TIMM_EFFICIENTNET_B4_RA2_IN1K_CONFIG,
+        ModelVariant.HF_TIMM_EFFICIENTNET_B5_IN12K_FT_IN1K: HF_TIMM_EFFICIENTNET_B5_IN12K_FT_IN1K_CONFIG,
+        ModelVariant.HF_TIMM_TF_EFFICIENTNET_B0_AA_IN1K: HF_TIMM_TF_EFFICIENTNET_B0_AA_IN1K_CONFIG,
+        ModelVariant.HF_TIMM_EFFICIENTNETV2_RW_S_RA2_IN1K: HF_TIMM_EFFICIENTNETV2_RW_S_RA2_IN1K_CONFIG,
+        ModelVariant.HF_TIMM_TF_EFFICIENTNETV2_S_IN21K: HF_TIMM_TF_EFFICIENTNETV2_S_IN21K_CONFIG,
     }
 
     # Default variant to use
@@ -122,6 +207,7 @@ class ModelLoader(ForgeModel):
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
+        self._cached_model = None
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -136,12 +222,15 @@ class ModelLoader(ForgeModel):
         """
         if variant is None:
             variant = cls.DEFAULT_VARIANT
+        source = cls._VARIANTS[variant].source
         return ModelInfo(
             model="efficientnet",
             variant=variant,
-            group=ModelGroup.RED,
+            group=ModelGroup.RED
+            if variant == ModelVariant.B0
+            else ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCHVISION,
+            source=source,
             framework=Framework.TORCH,
         )
 
@@ -155,15 +244,26 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.nn.Module: The EfficientNet model instance.
         """
-        # Setup state dict function
-        WeightsEnum.get_state_dict = get_state_dict
+        source = self._variant_config.source
 
-        # Get model function and weights class from dataclass config
-        model_fn = getattr(models, self._variant_config.model_function)
-        weights_class = getattr(models, self._variant_config.weights_class)
+        if source == ModelSource.TORCHVISION:
+            # Setup state dict function
+            WeightsEnum.get_state_dict = get_state_dict
 
-        # Load model with appropriate weights
-        model = model_fn(weights=weights_class.IMAGENET1K_V1)
+            # Get model function and weights class from dataclass config
+            model_fn = getattr(models, self._variant_config.model_function)
+            weights_class = getattr(models, self._variant_config.weights_class)
+
+            # Load model with appropriate weights
+            model = model_fn(weights=weights_class.IMAGENET1K_V1)
+        else:
+            # Load using timm
+            model_name = self._variant_config.pretrained_model_name
+            model = timm.create_model(model_name, pretrained=True)
+
+        model.eval()
+        # Cache model for use in load_inputs (to avoid reloading for timm transforms)
+        self._cached_model = model
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -182,27 +282,53 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.Tensor: Preprocessed input tensor suitable for EfficientNet.
         """
-        # Get the Image
-        image_file = get_file(
-            "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
-        )
-        image = Image.open(image_file)
+        # Determine which image to use based on variant
+        use_1k_labels = self._variant_config.use_1k_labels
+        source = self._variant_config.source
 
-        # Preprocess image
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        inputs = preprocess(image).unsqueeze(0)
+        if source == ModelSource.TIMM:
+            # Use cached model if available, otherwise load it
+            if hasattr(self, "_cached_model") and self._cached_model is not None:
+                model_for_config = self._cached_model
+            else:
+                model_for_config = self.load_model(dtype_override)
+            try:
+                if use_1k_labels:
+                    file_path = get_file(
+                        "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
+                    )
+                    img = Image.open(file_path).convert("RGB")
+                else:
+                    file_path = get_file(
+                        "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+                    )
+                    img = Image.open(file_path).convert("RGB")
+                config = resolve_data_config({}, model=model_for_config)
+                timm_transforms = create_transform(**config)
+                inputs = timm_transforms(img).unsqueeze(0)
+            except:
+                logger.warning(
+                    "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
+                )
+                inputs = torch.rand(1, 3, 224, 224)
+        else:
+            image_file = get_file(
+                "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+            )
+            image = Image.open(image_file)
 
-        # Replicate tensors for batch size
-        inputs = inputs.repeat_interleave(batch_size, dim=0)
+            # Use standard torchvision preprocessing
+            preprocess = transforms.Compose(
+                [
+                    transforms.Resize(256),
+                    transforms.CenterCrop(224),
+                    transforms.ToTensor(),
+                    transforms.Normalize(
+                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                    ),
+                ]
+            )
+            inputs = preprocess(image).unsqueeze(0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -216,4 +342,6 @@ class ModelLoader(ForgeModel):
         Args:
             compiled_model_out: Output from the compiled model
         """
-        print_compiled_model_results(compiled_model_out)
+        # Determine label set based on variant
+        use_1k_labels = self._variant_config.use_1k_labels
+        print_compiled_model_results(compiled_model_out, use_1k_labels=use_1k_labels)

--- a/vgg/pytorch/loader.py
+++ b/vgg/pytorch/loader.py
@@ -21,19 +21,51 @@ from ...base import ForgeModel
 from PIL import Image
 from ...tools.utils import get_file, print_compiled_model_results
 from torchvision import transforms
+from dataclasses import dataclass
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+from pytorchcv.model_provider import get_model as ptcv_get_model
+from vgg_pytorch import VGG as HFVGG
+from torchvision import models as tv_models
+
+
+@dataclass
+class VGGConfig(ModelConfig):
+    source: ModelSource
+    model_function: Optional[str] = None  # for torchvision
+    weights_class: Optional[str] = None  # for torchvision
 
 
 class ModelVariant(StrEnum):
     """Available VGG model variants."""
 
+    # OSMR (pytorchcv) image classification variants
     VGG11 = "vgg11"
-    VGG11_BN = "vgg11_bn"
     VGG13 = "vgg13"
-    VGG13_BN = "vgg13_bn"
     VGG16 = "vgg16"
-    VGG16_BN = "vgg16_bn"
     VGG19 = "vgg19"
+    VGG19_BN_OSMR = "bn_vgg19"
+    VGG19_BNB_OSMR = "bn_vgg19b"
+
+    # TorchHub variant
     VGG19_BN = "vgg19_bn"
+
+    # TIMM variant
+    TIMM_VGG19_BN = "timm_vgg19_bn"
+
+    # Torchvision variants
+    TV_VGG11 = "torchvision_vgg11"
+    TV_VGG11_BN = "torchvision_vgg11_bn"
+    TV_VGG13 = "torchvision_vgg13"
+    TV_VGG13_BN = "torchvision_vgg13_bn"
+    TV_VGG16 = "torchvision_vgg16"
+    TV_VGG16_BN = "torchvision_vgg16_bn"
+    TV_VGG19 = "torchvision_vgg19"
+    TV_VGG19_BN = "torchvision_vgg19_bn"
+
+    # HuggingFace vgg-pytorch
+    HF_VGG19 = "hf_vgg19"
 
 
 class ModelLoader(ForgeModel):
@@ -41,34 +73,90 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        ModelVariant.VGG11: ModelConfig(
+        # OSMR variants
+        ModelVariant.VGG11: VGGConfig(
+            pretrained_model_name="vgg11", source=ModelSource.OSMR
+        ),
+        ModelVariant.VGG13: VGGConfig(
+            pretrained_model_name="vgg13", source=ModelSource.OSMR
+        ),
+        ModelVariant.VGG16: VGGConfig(
+            pretrained_model_name="vgg16", source=ModelSource.OSMR
+        ),
+        ModelVariant.VGG19: VGGConfig(
+            pretrained_model_name="vgg19", source=ModelSource.OSMR
+        ),
+        ModelVariant.VGG19_BN_OSMR: VGGConfig(
+            pretrained_model_name="bn_vgg19", source=ModelSource.OSMR
+        ),
+        ModelVariant.VGG19_BNB_OSMR: VGGConfig(
+            pretrained_model_name="bn_vgg19b", source=ModelSource.OSMR
+        ),
+        # TorchHub
+        ModelVariant.VGG19_BN: VGGConfig(
+            pretrained_model_name="vgg19_bn", source=ModelSource.TORCH_HUB
+        ),
+        # TIMM
+        ModelVariant.TIMM_VGG19_BN: VGGConfig(
+            pretrained_model_name="vgg19_bn", source=ModelSource.TIMM
+        ),
+        # Torchvision
+        ModelVariant.TV_VGG11: VGGConfig(
             pretrained_model_name="vgg11",
+            source=ModelSource.TORCHVISION,
+            model_function="vgg11",
+            weights_class="VGG11_Weights",
         ),
-        ModelVariant.VGG11_BN: ModelConfig(
+        ModelVariant.TV_VGG11_BN: VGGConfig(
             pretrained_model_name="vgg11_bn",
+            source=ModelSource.TORCHVISION,
+            model_function="vgg11_bn",
+            weights_class="VGG11_BN_Weights",
         ),
-        ModelVariant.VGG13: ModelConfig(
+        ModelVariant.TV_VGG13: VGGConfig(
             pretrained_model_name="vgg13",
+            source=ModelSource.TORCHVISION,
+            model_function="vgg13",
+            weights_class="VGG13_Weights",
         ),
-        ModelVariant.VGG13_BN: ModelConfig(
+        ModelVariant.TV_VGG13_BN: VGGConfig(
             pretrained_model_name="vgg13_bn",
+            source=ModelSource.TORCHVISION,
+            model_function="vgg13_bn",
+            weights_class="VGG13_BN_Weights",
         ),
-        ModelVariant.VGG16: ModelConfig(
+        ModelVariant.TV_VGG16: VGGConfig(
             pretrained_model_name="vgg16",
+            source=ModelSource.TORCHVISION,
+            model_function="vgg16",
+            weights_class="VGG16_Weights",
         ),
-        ModelVariant.VGG16_BN: ModelConfig(
+        ModelVariant.TV_VGG16_BN: VGGConfig(
             pretrained_model_name="vgg16_bn",
+            source=ModelSource.TORCHVISION,
+            model_function="vgg16_bn",
+            weights_class="VGG16_BN_Weights",
         ),
-        ModelVariant.VGG19: ModelConfig(
+        ModelVariant.TV_VGG19: VGGConfig(
             pretrained_model_name="vgg19",
+            source=ModelSource.TORCHVISION,
+            model_function="vgg19",
+            weights_class="VGG19_Weights",
         ),
-        ModelVariant.VGG19_BN: ModelConfig(
+        ModelVariant.TV_VGG19_BN: VGGConfig(
             pretrained_model_name="vgg19_bn",
+            source=ModelSource.TORCHVISION,
+            model_function="vgg19_bn",
+            weights_class="VGG19_BN_Weights",
+        ),
+        # HuggingFace
+        ModelVariant.HF_VGG19: VGGConfig(
+            pretrained_model_name="vgg19", source=ModelSource.HUGGING_FACE
         ),
     }
 
     # Default variant to use
-    DEFAULT_VARIANT = ModelVariant.VGG19_BN
+    DEFAULT_VARIANT = ModelVariant.TV_VGG19_BN
 
     def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
@@ -92,12 +180,13 @@ class ModelLoader(ForgeModel):
         """
         if variant is None:
             variant = cls.DEFAULT_VARIANT
+        source = cls._VARIANTS[variant].source
         return ModelInfo(
             model="vgg",
             variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
+            source=source,
             framework=Framework.TORCH,
         )
 
@@ -112,15 +201,36 @@ class ModelLoader(ForgeModel):
             torch.nn.Module: The VGG model instance.
         """
         # Get the pretrained model name from the instance's variant config
-        model_name = self._variant_config.pretrained_model_name
+        cfg = self._variant_config
+        model_name = cfg.pretrained_model_name
+        source = cfg.source
 
-        # Load model using torch.hub
-        model = torch.hub.load("pytorch/vision:v0.10.0", model_name, pretrained=True)
+        if source == ModelSource.TORCH_HUB:
+            model = torch.hub.load(
+                "pytorch/vision:v0.10.0", model_name, pretrained=True
+            )
+        elif source == ModelSource.TIMM:
+            model = timm.create_model(model_name, pretrained=True)
+        elif source == ModelSource.OSMR:
+            model = ptcv_get_model(model_name, pretrained=True)
+        elif source == ModelSource.HUGGING_FACE:
+            model = HFVGG.from_pretrained(model_name)
+        elif source == ModelSource.TORCHVISION:
+            weights = getattr(tv_models, self._variant_config.weights_class).DEFAULT
+            model = getattr(tv_models, self._variant_config.model_function)(
+                weights=weights
+            )
+        else:
+            raise ValueError(f"Unsupported source: {source}")
+
         model.eval()
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             model = model.to(dtype_override)
+
+        # Cache model for timm input config if needed
+        self._cached_model = model
 
         return model
 
@@ -135,24 +245,33 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.Tensor: Preprocessed input tensor suitable for VGG.
         """
-        # Get the Image
         image_file = get_file(
             "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
         )
-        image = Image.open(image_file)
+        image = Image.open(image_file).convert("RGB")
 
-        # Preprocess image
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        inputs = preprocess(image).unsqueeze(0)
+        if self._variant_config.source == ModelSource.TIMM:
+            # Use cached model if available, otherwise load it
+            if hasattr(self, "_cached_model") and self._cached_model is not None:
+                model_for_config = self._cached_model
+            else:
+                model_for_config = self.load_model(dtype_override)
+
+            data_config = resolve_data_config({}, model=model_for_config)
+            data_transforms = create_transform(**data_config)
+            inputs = data_transforms(image).unsqueeze(0)
+        else:
+            preprocess = transforms.Compose(
+                [
+                    transforms.Resize(256),
+                    transforms.CenterCrop(224),
+                    transforms.ToTensor(),
+                    transforms.Normalize(
+                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                    ),
+                ]
+            )
+            inputs = preprocess(image).unsqueeze(0)
 
         # Replicate tensors for batch size
         inputs = inputs.repeat_interleave(batch_size, dim=0)

--- a/vovnet/pytorch/loader.py
+++ b/vovnet/pytorch/loader.py
@@ -2,12 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-Vovnet model loader implementation for question answering
+VovNet model loader implementation
 """
-from pytorchcv.model_provider import get_model as ptcv_get_model
-from torchvision import transforms
-from PIL import Image
 from typing import Optional
+
+import torch
+from PIL import Image
+from torchvision import transforms
+
+from pytorchcv.model_provider import get_model as ptcv_get_model
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+from .src.utils import download_model, preprocess_steps, preprocess_timm_model
+from .src.src_vovnet_stigma import (
+    vovnet39 as stigma_vovnet39,
+    vovnet57 as stigma_vovnet57,
+)
 from ...config import (
     ModelInfo,
     ModelGroup,
@@ -20,34 +30,84 @@ from ...config import (
 from ...base import ForgeModel
 from ...tools.utils import print_compiled_model_results
 from ...tools.utils import get_file
+from dataclasses import dataclass
+from loguru import logger
+
+
+@dataclass
+class VovNetConfig(ModelConfig):
+    source: ModelSource
 
 
 class ModelVariant(StrEnum):
-    """Available WideResnet model variants."""
+    """Available VovNet model variants."""
 
+    # OSMR (pytorchcv) image classification variants
     VOVNET27S = "vovnet27s"
     VOVNET39 = "vovnet39"
     VOVNET57 = "vovnet57"
 
+    # TorchHub variant
+    VOVNET39_TORCHHUB = "vovnet39"
+    VOVNET57_TORCHHUB = "vovnet57"
+
+    # TIMM image classification variants (subset)
+    TIMM_VOVNET19B_DW = "ese_vovnet19b_dw"
+    TIMM_VOVNET39B = "ese_vovnet39b"
+    TIMM_VOVNET99B = "ese_vovnet99b"
+    TIMM_VOVNET19B_DW_RAIN1K = "ese_vovnet19b_dw.ra_in1k"
+
 
 class ModelLoader(ForgeModel):
-    """WideResnet model loader implementation."""
+    """VovNet model loader implementation."""
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        ModelVariant.VOVNET27S: ModelConfig(
-            pretrained_model_name="vovnet27s",
+        # OSMR variants
+        ModelVariant.VOVNET27S: VovNetConfig(
+            pretrained_model_name="vovnet27s", source=ModelSource.OSMR
         ),
-        ModelVariant.VOVNET39: ModelConfig(
-            pretrained_model_name="vovnet39",
+        ModelVariant.VOVNET39: VovNetConfig(
+            pretrained_model_name="vovnet39", source=ModelSource.OSMR
         ),
-        ModelVariant.VOVNET57: ModelConfig(
-            pretrained_model_name="vovnet57",
+        ModelVariant.VOVNET57: VovNetConfig(
+            pretrained_model_name="vovnet57", source=ModelSource.OSMR
+        ),
+        # TorchHub
+        ModelVariant.VOVNET39_TORCHHUB: VovNetConfig(
+            pretrained_model_name="vovnet39", source=ModelSource.TORCH_HUB
+        ),
+        ModelVariant.VOVNET57_TORCHHUB: VovNetConfig(
+            pretrained_model_name="vovnet57", source=ModelSource.TORCH_HUB
+        ),
+        # TIMM variants
+        ModelVariant.TIMM_VOVNET19B_DW: VovNetConfig(
+            pretrained_model_name="ese_vovnet19b_dw", source=ModelSource.TIMM
+        ),
+        ModelVariant.TIMM_VOVNET39B: VovNetConfig(
+            pretrained_model_name="ese_vovnet39b", source=ModelSource.TIMM
+        ),
+        ModelVariant.TIMM_VOVNET99B: VovNetConfig(
+            pretrained_model_name="ese_vovnet99b", source=ModelSource.TIMM
+        ),
+        ModelVariant.TIMM_VOVNET19B_DW_RAIN1K: VovNetConfig(
+            pretrained_model_name="ese_vovnet19b_dw.ra_in1k", source=ModelSource.TIMM
         ),
     }
 
     # Default variant to use
     DEFAULT_VARIANT = ModelVariant.VOVNET27S
+
+    def __init__(self, variant=None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional string specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.input_shape = (3, 224, 224)
+        self._cached_model = None
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None):
@@ -62,60 +122,99 @@ class ModelLoader(ForgeModel):
         """
         if variant is None:
             variant = cls.DEFAULT_VARIANT
+        source = cls._VARIANTS[variant].source
         return ModelInfo(
             model="vovnet",
             variant=variant,
             group=ModelGroup.RED,
             task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
+            source=source,
             framework=Framework.TORCH,
         )
 
-    def __init__(self, variant=None):
-        """Initialize ModelLoader with specified variant.
-
-        Args:
-            variant: Optional string specifying which variant to use.
-                     If None, DEFAULT_VARIANT is used.
-        """
-        super().__init__(variant)
-
-        # Configuration parameters
-        self.input_shape = (3, 224, 224)
-
     def load_model(self, dtype_override=None):
-        """Load a Vovnet model from Pytorch CV Model Provider."""
+        """Load a VovNet model based on the configured source for this variant."""
+        cfg = self._variant_config
+        model_name = cfg.pretrained_model_name
+        source = cfg.source
 
-        # Get the pretrained model name from the instance's variant config
-        pretrained_model_name = self._variant_config.pretrained_model_name
-        model = ptcv_get_model(pretrained_model_name, pretrained=True)
+        if source == ModelSource.OSMR:
+            model = ptcv_get_model(model_name, pretrained=True)
+        elif source == ModelSource.TIMM:
+            model, _ = download_model(preprocess_timm_model, model_name)
+        elif source == ModelSource.TORCH_HUB:
+            model_fn = stigma_vovnet39 if "39" in model_name else stigma_vovnet57
+            model, _ = download_model(preprocess_steps, model_fn)
+        else:
+            raise ValueError(f"Unsupported source: {source}")
+
         model.eval()
 
-        # Only convert dtype if explicitly requested
         if dtype_override is not None:
             model = model.to(dtype_override)
 
+        # Cache for TIMM preprocessing resolution
+        self._cached_model = model
         return model
 
-    def load_inputs(self, dtype_override=None):
-        """Generate sample inputs for Vovnet models."""
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Generate sample inputs for VovNet models.
 
+        Uses TIMM-specific preprocessing when the source is TIMM, otherwise
+        applies standard ImageNet preprocessing.
+        """
         file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
         input_image = Image.open(file_path).convert("RGB")
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        img_tensor = preprocess(input_image)
-        inputs = img_tensor.unsqueeze(0)
 
-        # Only convert dtype if explicitly requested
+        if self._variant_config.source == ModelSource.TIMM:
+            model_for_config = (
+                self._cached_model if self._cached_model is not None else None
+            )
+            if model_for_config is None:
+                # Ensure model is available to resolve preprocess
+                model_for_config = self.load_model(dtype_override)
+            try:
+                data_config = resolve_data_config({}, model=model_for_config)
+                data_transforms = create_transform(**data_config)
+                inputs = data_transforms(input_image).unsqueeze(0)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to resolve TIMM data config: {e}. Falling back to standard ImageNet preprocessing."
+                )
+                preprocess = transforms.Compose(
+                    [
+                        transforms.Resize(256),
+                        transforms.CenterCrop(224),
+                        transforms.ToTensor(),
+                        transforms.Normalize(
+                            mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                        ),
+                    ]
+                )
+                inputs = preprocess(input_image).unsqueeze(0)
+        elif self._variant_config.source == ModelSource.TORCH_HUB:
+            model_fn = (
+                stigma_vovnet39
+                if "39" in self._variant_config.pretrained_model_name
+                else stigma_vovnet57
+            )
+            _, inputs = download_model(preprocess_steps, model_fn)
+        else:
+            preprocess = transforms.Compose(
+                [
+                    transforms.Resize(256),
+                    transforms.CenterCrop(224),
+                    transforms.ToTensor(),
+                    transforms.Normalize(
+                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                    ),
+                ]
+            )
+            inputs = preprocess(input_image).unsqueeze(0)
+
+        # Replicate for batch size
+        inputs = inputs.repeat_interleave(batch_size, dim=0)
+
         if dtype_override is not None:
             inputs = inputs.to(dtype_override)
 

--- a/vovnet/pytorch/src/src_vovnet_stigma.py
+++ b/vovnet/pytorch/src/src_vovnet_stigma.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+## Source
+## https://github.com/stigma0617/VoVNet.pytorch/blob/039d9dcbd07de73fb5b8cc14bdde483a3807225c/models_vovnet/vovnet.py
+
+from collections import OrderedDict
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# from torch.hub import load_state_dict_from_url
+from torch.utils.model_zoo import load_url as load_state_dict_from_url
+
+__all__ = ["VoVNet", "vovnet27_slim", "vovnet39", "vovnet57"]
+
+
+model_urls = {
+    "vovnet39": "https://dl.dropbox.com/s/1lnzsgnixd8gjra/vovnet39_torchvision.pth?dl=1",
+    "vovnet57": "https://dl.dropbox.com/s/6bfu9gstbwfw31m/vovnet57_torchvision.pth?dl=1",
+}
+
+
+def conv3x3(
+    in_channels,
+    out_channels,
+    module_name,
+    postfix,
+    stride=1,
+    groups=1,
+    kernel_size=3,
+    padding=1,
+):
+    """3x3 convolution with padding"""
+    return [
+        (
+            "{}_{}".format(module_name, postfix) + "/conv",
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
+                groups=groups,
+                bias=False,
+            ),
+        ),
+        ("{}_{}".format(module_name, postfix) + "/norm", nn.BatchNorm2d(out_channels)),
+        ("{}_{}".format(module_name, postfix) + "/relu", nn.ReLU(inplace=True)),
+    ]
+
+
+def conv1x1(
+    in_channels,
+    out_channels,
+    module_name,
+    postfix,
+    stride=1,
+    groups=1,
+    kernel_size=1,
+    padding=0,
+):
+    """1x1 convolution"""
+    return [
+        (
+            "{}_{}".format(module_name, postfix) + "/conv",
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
+                groups=groups,
+                bias=False,
+            ),
+        ),
+        ("{}_{}".format(module_name, postfix) + "/norm", nn.BatchNorm2d(out_channels)),
+        ("{}_{}".format(module_name, postfix) + "/relu", nn.ReLU(inplace=True)),
+    ]
+
+
+class _OSA_module(nn.Module):
+    def __init__(
+        self, in_ch, stage_ch, concat_ch, layer_per_block, module_name, identity=False
+    ):
+        super(_OSA_module, self).__init__()
+
+        self.identity = identity
+        self.layers = nn.ModuleList()
+        in_channel = in_ch
+        for i in range(layer_per_block):
+            self.layers.append(
+                nn.Sequential(
+                    OrderedDict(conv3x3(in_channel, stage_ch, module_name, i))
+                )
+            )
+            in_channel = stage_ch
+
+        # feature aggregation
+        in_channel = in_ch + layer_per_block * stage_ch
+        self.concat = nn.Sequential(
+            OrderedDict(conv1x1(in_channel, concat_ch, module_name, "concat"))
+        )
+
+    def forward(self, x):
+        identity_feat = x
+        output = []
+        output.append(x)
+        for layer in self.layers:
+            x = layer(x)
+            output.append(x)
+
+        x = torch.cat(output, dim=1)
+        xt = self.concat(x)
+
+        if self.identity:
+            xt = xt + identity_feat
+
+        return xt
+
+
+class _OSA_stage(nn.Sequential):
+    def __init__(
+        self, in_ch, stage_ch, concat_ch, block_per_stage, layer_per_block, stage_num
+    ):
+        super(_OSA_stage, self).__init__()
+
+        if not stage_num == 2:
+            self.add_module(
+                "Pooling", nn.MaxPool2d(kernel_size=3, stride=2, ceil_mode=True)
+            )
+
+        module_name = f"OSA{stage_num}_1"
+        self.add_module(
+            module_name,
+            _OSA_module(in_ch, stage_ch, concat_ch, layer_per_block, module_name),
+        )
+        for i in range(block_per_stage - 1):
+            module_name = f"OSA{stage_num}_{i+2}"
+            self.add_module(
+                module_name,
+                _OSA_module(
+                    concat_ch,
+                    stage_ch,
+                    concat_ch,
+                    layer_per_block,
+                    module_name,
+                    identity=True,
+                ),
+            )
+
+
+class VoVNet(nn.Module):
+    def __init__(
+        self,
+        config_stage_ch,
+        config_concat_ch,
+        block_per_stage,
+        layer_per_block,
+        num_classes=1000,
+    ):
+        super(VoVNet, self).__init__()
+
+        # Stem module
+        stem = conv3x3(3, 64, "stem", "1", 2)
+        stem += conv3x3(64, 64, "stem", "2", 1)
+        stem += conv3x3(64, 128, "stem", "3", 2)
+        self.add_module("stem", nn.Sequential(OrderedDict(stem)))
+
+        stem_out_ch = [128]
+        in_ch_list = stem_out_ch + config_concat_ch[:-1]
+        self.stage_names = []
+        for i in range(4):  # num_stages
+            name = "stage%d" % (i + 2)
+            self.stage_names.append(name)
+            self.add_module(
+                name,
+                _OSA_stage(
+                    in_ch_list[i],
+                    config_stage_ch[i],
+                    config_concat_ch[i],
+                    block_per_stage[i],
+                    layer_per_block,
+                    i + 2,
+                ),
+            )
+
+        self.classifier = nn.Linear(config_concat_ch[-1], num_classes)
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight)
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.Linear):
+                nn.init.constant_(m.bias, 0)
+
+    def forward(self, x):
+        x = self.stem(x)
+        for name in self.stage_names:
+            x = getattr(self, name)(x)
+        x = F.adaptive_avg_pool2d(x, (1, 1)).view(x.size(0), -1)
+        x = self.classifier(x)
+        return x
+
+
+def _vovnet(
+    arch,
+    config_stage_ch,
+    config_concat_ch,
+    block_per_stage,
+    layer_per_block,
+    pretrained,
+    progress,
+    **kwargs,
+):
+    model = VoVNet(
+        config_stage_ch, config_concat_ch, block_per_stage, layer_per_block, **kwargs
+    )
+    if pretrained:
+        state_dict = load_state_dict_from_url(
+            model_urls[arch], map_location=torch.device("cpu"), progress=progress
+        )
+        # print(state_dict.keys())
+        new_state_dict = {}
+        for k, v in state_dict.items():
+            k = k[7:]
+            new_state_dict[k] = v
+        # print(new_state_dict.keys())
+        model.load_state_dict(new_state_dict)
+    return model
+
+
+def vovnet57(pretrained=False, progress=True, **kwargs):
+    r"""Constructs a VoVNet-57 model as described in
+    `"An Energy and GPU-Computation Efficient Backbone Networks"`
+    <https://arxiv.org/abs/1904.09730>`_.
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vovnet(
+        "vovnet57",
+        [128, 160, 192, 224],
+        [256, 512, 768, 1024],
+        [1, 1, 4, 3],
+        5,
+        pretrained,
+        progress,
+        **kwargs,
+    )
+
+
+def vovnet39(pretrained=False, progress=True, **kwargs):
+    r"""Constructs a VoVNet-39 model as described in
+    `"An Energy and GPU-Computation Efficient Backbone Networks"`
+    <https://arxiv.org/abs/1904.09730>`_.
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vovnet(
+        "vovnet39",
+        [128, 160, 192, 224],
+        [256, 512, 768, 1024],
+        [1, 1, 2, 2],
+        5,
+        pretrained,
+        progress,
+        **kwargs,
+    )
+
+
+def vovnet27_slim(pretrained=False, progress=True, **kwargs):
+    r"""Constructs a VoVNet-39 model as described in
+    `"An Energy and GPU-Computation Efficient Backbone Networks"`
+    <https://arxiv.org/abs/1904.09730>`_.
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    return _vovnet(
+        "vovnet27_slim",
+        [64, 80, 96, 112],
+        [128, 256, 384, 512],
+        [1, 1, 1, 1],
+        5,
+        pretrained,
+        progress,
+        **kwargs,
+    )

--- a/vovnet/pytorch/src/utils.py
+++ b/vovnet/pytorch/src/utils.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import hashlib
+import os
+import zipfile
+from six.moves import urllib
+import torch
+from loguru import logger
+from PIL import Image
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+import requests
+import shutil
+import time
+from ....tools.utils import get_file
+
+
+def preprocess_steps(model_type):
+    model = model_type(True, True).eval()
+    config = resolve_data_config({}, model=model)
+    transform = create_transform(**config)
+
+    try:
+        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
+        img = Image.open(file_path).convert("RGB")
+        img_tensor = transform(img).unsqueeze(0)  # transform and add batch dimension
+    except:
+        logger.warning(
+            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
+        )
+        img_tensor = torch.rand(1, 3, 224, 224)
+
+    return model, img_tensor
+
+
+def preprocess_timm_model(model_name):
+    use_pretrained_weights = True
+    if model_name == "ese_vovnet99b":
+        use_pretrained_weights = False
+    model = timm.create_model(model_name, pretrained=use_pretrained_weights)
+    model.eval()
+    config = resolve_data_config({}, model=model)
+    transform = create_transform(**config)
+
+    try:
+        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
+        img = Image.open(file_path).convert("RGB")
+        img_tensor = transform(img).unsqueeze(0)  # transform and add batch dimension
+    except:
+        logger.warning(
+            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
+        )
+        img_tensor = torch.rand(1, 3, 224, 224)
+
+    return model, img_tensor
+
+
+def download_model(download_func, *args, num_retries=3, timeout=180, **kwargs):
+    for _ in range(num_retries):
+        try:
+            return download_func(*args, **kwargs)
+        except (
+            requests.exceptions.HTTPError,
+            urllib.error.HTTPError,
+            requests.exceptions.ReadTimeout,
+            urllib.error.URLError,
+        ):
+            logger.trace("HTTP error occurred. Retrying...")
+            shutil.rmtree(os.path.expanduser("~") + "/.cache", ignore_errors=True)
+            shutil.rmtree(
+                os.path.expanduser("~") + "/.torch/models", ignore_errors=True
+            )
+            shutil.rmtree(
+                os.path.expanduser("~") + "/.torchxrayvision/models_data",
+                ignore_errors=True,
+            )
+            os.makedirs(os.path.expanduser("~") + "/.cache", exist_ok=True)
+        time.sleep(timeout)
+
+    logger.error("Failed to download the model after multiple retries.")
+    assert False, "Failed to download the model after multiple retries."

--- a/wide_resnet/pytorch/loader.py
+++ b/wide_resnet/pytorch/loader.py
@@ -21,13 +21,27 @@ from ...base import ForgeModel
 from ...tools.utils import get_file
 from ...tools.utils import print_compiled_model_results
 from typing import Optional
+from dataclasses import dataclass
+import timm
+from timm.data import resolve_data_config
+from timm.data.transforms_factory import create_transform
+
+
+@dataclass
+class WideResnetConfig(ModelConfig):
+    source: ModelSource
 
 
 class ModelVariant(StrEnum):
     """Available WideResnet model variants."""
 
+    # Torch Hub/Torchvision variants
     WIDE_RESNET50_2 = "wide_resnet50_2"
     WIDE_RESNET101_2 = "wide_resnet101_2"
+
+    # TIMM variants
+    TIMM_WIDE_RESNET50_2 = "wide_resnet50_2.timm"
+    TIMM_WIDE_RESNET101_2 = "wide_resnet101_2.timm"
 
 
 class ModelLoader(ForgeModel):
@@ -35,11 +49,23 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        ModelVariant.WIDE_RESNET50_2: ModelConfig(
+        # Torch Hub variants
+        ModelVariant.WIDE_RESNET50_2: WideResnetConfig(
             pretrained_model_name="wide_resnet50_2",
+            source=ModelSource.TORCH_HUB,
         ),
-        ModelVariant.WIDE_RESNET101_2: ModelConfig(
+        ModelVariant.WIDE_RESNET101_2: WideResnetConfig(
             pretrained_model_name="wide_resnet101_2",
+            source=ModelSource.TORCH_HUB,
+        ),
+        # TIMM variants
+        ModelVariant.TIMM_WIDE_RESNET50_2: WideResnetConfig(
+            pretrained_model_name="wide_resnet50_2",
+            source=ModelSource.TIMM,
+        ),
+        ModelVariant.TIMM_WIDE_RESNET101_2: WideResnetConfig(
+            pretrained_model_name="wide_resnet101_2",
+            source=ModelSource.TIMM,
         ),
     }
 
@@ -57,12 +83,15 @@ class ModelLoader(ForgeModel):
         Returns:
             ModelInfo: Information about the model and variant
         """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        source = cls._VARIANTS[variant].source
         return ModelInfo(
             model="wide_resnet",
             variant=variant,
             group=ModelGroup.GENERALITY,
             task=ModelTask.CV_IMAGE_CLS,
-            source=ModelSource.TORCH_HUB,
+            source=source,
             framework=Framework.TORCH,
         )
 
@@ -74,16 +103,25 @@ class ModelLoader(ForgeModel):
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
+        self._cached_model = None
 
     def load_model(self, dtype_override=None):
-        """Load a WideResnet model from Torch Hub."""
+        """Load a WideResnet model from Torch Hub or TIMM depending on variant source."""
 
-        # Get the pretrained model name from the instance's variant config
+        # Get the pretrained model name and source from the instance's variant config
         pretrained_model_name = self._variant_config.pretrained_model_name
-        model = torch.hub.load(
-            "pytorch/vision:v0.10.0", pretrained_model_name, pretrained=True
-        )
+        source = self._variant_config.source
+
+        if source == ModelSource.TIMM:
+            model = timm.create_model(pretrained_model_name, pretrained=True)
+        else:
+            model = torch.hub.load(
+                "pytorch/vision:v0.10.0", pretrained_model_name, pretrained=True
+            )
         model.eval()
+
+        # Cache for preprocessing config
+        self._cached_model = model
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
@@ -97,20 +135,31 @@ class ModelLoader(ForgeModel):
         image_file = get_file(
             "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
         )
-        input_image = Image.open(image_file)
+        input_image = Image.open(image_file).convert("RGB")
 
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        input_tensor = preprocess(input_image)
-        inputs = input_tensor.unsqueeze(0)
+        source = self._variant_config.source
+
+        if source == ModelSource.TIMM:
+            model_for_config = (
+                self._cached_model if self._cached_model is not None else None
+            )
+            if model_for_config is None:
+                model_for_config = self.load_model(dtype_override)
+            data_config = resolve_data_config({}, model=model_for_config)
+            transform = create_transform(**data_config)
+            inputs = transform(input_image).unsqueeze(0)
+        else:
+            preprocess = transforms.Compose(
+                [
+                    transforms.Resize(256),
+                    transforms.CenterCrop(224),
+                    transforms.ToTensor(),
+                    transforms.Normalize(
+                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                    ),
+                ]
+            )
+            inputs = preprocess(input_image).unsqueeze(0)
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-fe/issues/2822

### Problem description

- Add variant support for existing models and bring up tt-forge-fe models in tt-forge-models.

### What's changed

Added support for ModelVariant in the ModelLoader class for the following models:

-  Alexnet
-  DLA
-  Efficientnet
-  Hrnet
-  VGG
-  Vovnet
-  Wideresnet

### Logs
[alexnet_modified.log](https://github.com/user-attachments/files/21773550/alexnet_modified.log)
[dla_modified.log](https://github.com/user-attachments/files/21773552/dla_modified.log)
[vgg_modified.log](https://github.com/user-attachments/files/21773562/vgg_modified.log)
[vovnet_modified.log](https://github.com/user-attachments/files/21773558/vovnet_modified.log)
[wideresnet_modified.log](https://github.com/user-attachments/files/21773568/wideresnet_modified.log)
