### PR TITLE
Added use_cache = false for qwen3 loader to fix PCC issue in tt-torch

### DIFF
--- a/qwen_3/embedding/pytorch/loader.py
+++ b/qwen_3/embedding/pytorch/loader.py
@@ -135,6 +135,7 @@ class ModelLoader(ForgeModel):
         model_kwargs = {}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs["use_cache"] = False
 
         model = AutoModel.from_pretrained(pretrained_model_name, **model_kwargs)
         model.eval()


### PR DESCRIPTION
### Ticket
[TT-Torch Issue #985](https://github.com/tenstorrent/tt-torch/issues/985)

### Problem description
Qwen3 was having a low PCC its (0.74).

### What's changed
The low PCC (0.74) seemed to be just for one of the intermediate outputs and not for the model overall. All the other intermediates had PCC ~0.98.
The intermediate PCCs are evaluated because use_cache wasn't set to false for the model when loading. Added use_cache = false as a model_kwargs to qwen3 pytorch loader for the correction. New output PCC is 0.984.

