### PR TITLE
Update LLMConfig to mark max_len as Optional with JAX models

### DIFF
--- a/albert/masked_lm/jax/loader.py
+++ b/albert/masked_lm/jax/loader.py
@@ -37,19 +37,15 @@ class ModelLoader(ForgeModel):
     _VARIANTS = {
         ModelVariant.BASE_V2: LLMModelConfig(
             pretrained_model_name="albert/albert-base-v2",
-            max_length=128,
         ),
         ModelVariant.LARGE_V2: LLMModelConfig(
             pretrained_model_name="albert/albert-large-v2",
-            max_length=128,
         ),
         ModelVariant.XLARGE_V2: LLMModelConfig(
             pretrained_model_name="albert/albert-xlarge-v2",
-            max_length=128,
         ),
         ModelVariant.XXLARGE_V2: LLMModelConfig(
             pretrained_model_name="albert/albert-xxlarge-v2",
-            max_length=128,
         ),
     }
 
@@ -155,15 +151,9 @@ class ModelLoader(ForgeModel):
         if self.tokenizer is None:
             self._load_tokenizer(dtype_override=dtype_override)
 
-        # Get max_length from the variant config
-        max_length = self._variant_config.max_length
-
         # Create tokenized inputs for the masked language modeling task
         inputs = self.tokenizer(
             self.sample_text,
-            max_length=max_length,
-            padding="max_length",
-            truncation=True,
             return_tensors="jax",
         )
 

--- a/bart/causal_lm/jax/loader.py
+++ b/bart/causal_lm/jax/loader.py
@@ -35,11 +35,9 @@ class ModelLoader(ForgeModel):
     _VARIANTS = {
         ModelVariant.BASE: LLMModelConfig(
             pretrained_model_name="facebook/bart-base",
-            max_length=128,
         ),
         ModelVariant.LARGE: LLMModelConfig(
             pretrained_model_name="facebook/bart-large",
-            max_length=128,
         ),
     }
 
@@ -144,15 +142,9 @@ class ModelLoader(ForgeModel):
         if self._tokenizer is None:
             self._load_tokenizer(dtype_override=dtype_override)
 
-        # Get max_length from the variant config
-        max_length = self._variant_config.max_length
-
         # Create tokenized inputs for the causal language modeling task
         inputs = self._tokenizer(
             self.sample_text,
-            max_length=max_length,
-            padding="max_length",
-            truncation=True,
             return_tensors="jax",
         )
 

--- a/bert/masked_lm/jax/loader.py
+++ b/bert/masked_lm/jax/loader.py
@@ -35,11 +35,9 @@ class ModelLoader(ForgeModel):
     _VARIANTS = {
         ModelVariant.BASE: LLMModelConfig(
             pretrained_model_name="google-bert/bert-base-uncased",
-            max_length=128,
         ),
         ModelVariant.LARGE: LLMModelConfig(
             pretrained_model_name="google-bert/bert-large-uncased",
-            max_length=128,
         ),
     }
 
@@ -142,15 +140,9 @@ class ModelLoader(ForgeModel):
         if self._tokenizer is None:
             self._load_tokenizer(dtype_override=dtype_override)
 
-        # Get max_length from the variant config
-        max_length = self._variant_config.max_length
-
         # Create tokenized inputs for the masked language modeling task
         inputs = self._tokenizer(
             self.sample_text,
-            max_length=max_length,
-            padding="max_length",
-            truncation=True,
             return_tensors="jax",
         )
 

--- a/bigbird/question_answering/jax/loader.py
+++ b/bigbird/question_answering/jax/loader.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from ....base import ForgeModel
 from ....config import (
-    ModelConfig,
+    LLMModelConfig,
     ModelInfo,
     ModelGroup,
     ModelTask,
@@ -30,10 +30,10 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        ModelVariant.BASE: ModelConfig(
+        ModelVariant.BASE: LLMModelConfig(
             pretrained_model_name="google/bigbird-base-trivia-itc",
         ),
-        ModelVariant.LARGE: ModelConfig(
+        ModelVariant.LARGE: LLMModelConfig(
             pretrained_model_name="google/bigbird-roberta-large",
         ),
     }
@@ -59,7 +59,6 @@ class ModelLoader(ForgeModel):
         super().__init__(variant)
         self._tokenizer = None
         self._model_name = self._variant_config.pretrained_model_name
-        self._max_length = 384
 
     @classmethod
     def _get_model_info(cls, variant_name: str = None):
@@ -150,9 +149,6 @@ class ModelLoader(ForgeModel):
         inputs = self._tokenizer(
             self.question,
             self.context,
-            max_length=self._max_length,
-            padding="max_length",
-            truncation=True,
             return_tensors="jax",
         )
 

--- a/blenderbot/summarization/jax/loader.py
+++ b/blenderbot/summarization/jax/loader.py
@@ -34,19 +34,15 @@ class ModelLoader(ForgeModel):
     _VARIANTS = {
         ModelVariant.BLENDERBOT_3B: LLMModelConfig(
             pretrained_model_name="facebook/blenderbot-3B",
-            max_length=128,
         ),
         ModelVariant.BLENDERBOT_SMALL_90M: LLMModelConfig(
             pretrained_model_name="facebook/blenderbot_small-90M",
-            max_length=128,
         ),
         ModelVariant.BLENDERBOT_1B_DISTILL: LLMModelConfig(
             pretrained_model_name="facebook/blenderbot-1B-distill",
-            max_length=128,
         ),
         ModelVariant.BLENDERBOT_400M_DISTILL: LLMModelConfig(
             pretrained_model_name="facebook/blenderbot-400M-distill",
-            max_length=128,
         ),
     }
 

--- a/config.py
+++ b/config.py
@@ -152,7 +152,7 @@ class ModelConfig:
 class LLMModelConfig(ModelConfig):
     """Configuration specific to language models"""
 
-    max_length: int
+    max_length: Optional[int] = None
     attention_mechanism: Optional[str] = None
     sliding_window: Optional[int] = None
 


### PR DESCRIPTION
### Problem description
`max_len` is set as mandatory parameter in LLMConfig. It can be marked as Optional 

### What's changed
* updated `config.py` to mark  max_len as Optional
* update JAX models such as albert_v2, bart, bert, bigbird, blenderbot to remove max_len

### Checklist
- [x] New/Existing tests provide coverage for changes

Some Logs for reference

[alb_base_None.log](https://github.com/user-attachments/files/21854256/alb_base_None.log)
[alb_large.log](https://github.com/user-attachments/files/21854257/alb_large.log)
[bart_large.log](https://github.com/user-attachments/files/21854258/bart_large.log)
