### PR TITLE
Add JAX models for Electra and distilbert

### DIFF
--- a/bigbird/question_answering/jax/loader.py
+++ b/bigbird/question_answering/jax/loader.py
@@ -126,8 +126,10 @@ class ModelLoader(ForgeModel):
 
         from transformers import FlaxBigBirdForQuestionAnswering
 
+        # For input_sequence_length < 1024, original_full attention type is used.
+        # Ref : https://huggingface.co/docs/transformers/en/model_doc/big_bird#notes
         model = FlaxBigBirdForQuestionAnswering.from_pretrained(
-            self._model_name, **model_kwargs
+            self._model_name, attention_type="original_full", **model_kwargs
         )
 
         return model

--- a/distilbert/masked_lm/jax/__init__.py
+++ b/distilbert/masked_lm/jax/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/distilbert/masked_lm/jax/loader.py
+++ b/distilbert/masked_lm/jax/loader.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DistilBERT model loader implementation for masked language modeling.
+"""
+
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available DistilBERT model variants."""
+
+    BASE_UNCASED = "base-uncased"
+
+
+class ModelLoader(ForgeModel):
+    """DistilBERT model loader implementation for masked language modeling."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.BASE_UNCASED: LLMModelConfig(
+            pretrained_model_name="distilbert/distilbert-base-uncased",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.BASE_UNCASED
+
+    # Shared configuration parameters
+    sample_text = "The capital of France is [MASK]."
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self._tokenizer = None
+        self._model_name = self._variant_config.pretrained_model_name
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+
+        return ModelInfo(
+            model="distilbert",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_MASKED_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.JAX,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+
+        Args:
+            dtype_override: Optional dtype to override the tokenizer's default dtype.
+
+        Returns:
+            tokenizer: The loaded tokenizer instance
+        """
+
+        from transformers import AutoTokenizer
+
+        # Initialize tokenizer with dtype_override if provided
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["dtype"] = dtype_override
+
+        # Load the tokenizer
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            self._model_name, **tokenizer_kwargs
+        )
+
+        return self._tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the DistilBERT model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            model: The loaded model instance
+        """
+        from transformers import FlaxDistilBertForMaskedLM
+
+        # Ensure tokenizer is loaded
+        if self._tokenizer is None:
+            self._load_tokenizer(dtype_override)
+
+        # Initialize model kwargs
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["dtype"] = dtype_override
+
+        # Load the model
+        model = FlaxDistilBertForMaskedLM.from_pretrained(
+            self._model_name, **model_kwargs
+        )
+
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Load and return sample inputs for the DistilBERT model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional dtype to override the model's default dtype.
+
+        Returns:
+            inputs: Input tensors that can be fed to the model.
+        """
+
+        # Ensure tokenizer is initialized
+        if self._tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        inputs = self._tokenizer(
+            self.sample_text,
+            return_tensors="jax",
+        )
+
+        return inputs

--- a/electra/causal_lm/jax/__init__.py
+++ b/electra/causal_lm/jax/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/electra/causal_lm/jax/loader.py
+++ b/electra/causal_lm/jax/loader.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Electra model loader implementation for causal language modeling.
+"""
+
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available ELECTRA model variants."""
+
+    BASE_DISCRIMINATOR = "base-discriminator"
+    BASE_GENERATOR = "base-generator"
+    LARGE_DISCRIMINATOR = "large-discriminator"
+    SMALL_DISCRIMINATOR = "small-discriminator"
+
+
+class ModelLoader(ForgeModel):
+    """ELECTRA model loader implementation for causal language modeling."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.BASE_DISCRIMINATOR: LLMModelConfig(
+            pretrained_model_name="google/electra-base-discriminator",
+        ),
+        ModelVariant.BASE_GENERATOR: LLMModelConfig(
+            pretrained_model_name="google/electra-base-generator",
+        ),
+        ModelVariant.LARGE_DISCRIMINATOR: LLMModelConfig(
+            pretrained_model_name="google/electra-large-discriminator",
+        ),
+        ModelVariant.SMALL_DISCRIMINATOR: LLMModelConfig(
+            pretrained_model_name="google/electra-small-discriminator",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.BASE_DISCRIMINATOR
+
+    # Shared configuration parameters
+    sample_text = "Hello, my dog is cute"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self._tokenizer = None
+        self._model_name = self._variant_config.pretrained_model_name
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+
+        return ModelInfo(
+            model="electra",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.JAX,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+
+        Args:
+            dtype_override: Optional dtype to override the tokenizer's default dtype.
+
+        Returns:
+            tokenizer: The loaded tokenizer instance
+        """
+
+        from transformers import AutoTokenizer
+
+        # Initialize tokenizer with dtype_override if provided
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["dtype"] = dtype_override
+
+        # Load the tokenizer
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            self._model_name, **tokenizer_kwargs
+        )
+
+        return self._tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the ELECTRA model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            model: The loaded model instance
+        """
+
+        from transformers import FlaxElectraForCausalLM
+
+        # Ensure tokenizer is loaded
+        if self._tokenizer is None:
+            self._load_tokenizer(dtype_override)
+
+        # Initialize model kwargs
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["dtype"] = dtype_override
+
+        # Load the model
+        model = FlaxElectraForCausalLM.from_pretrained(self._model_name, **model_kwargs)
+
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Load and return sample inputs for the ELECTRA model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional dtype to override the model's default dtype.
+
+        Returns:
+            inputs: Input tensors that can be fed to the model.
+        """
+
+        # Ensure tokenizer is initialized
+        if self._tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        inputs = self._tokenizer(
+            self.sample_text,
+            return_tensors="jax",
+        )
+
+        return inputs


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-xla/issues/1045

* Add JAX models for Electra and Distilbert 
* added attention_type to bigbird model 

### Checklist
- [x] New/Existing tests provide coverage for changes

PFA logs for reference: 
[distilbert.log](https://github.com/user-attachments/files/21854539/distilbert.log)

[elec_base_discrim.log](https://github.com/user-attachments/files/21854541/elec_base_discrim.log)
[elec_base_generator.log](https://github.com/user-attachments/files/21854542/elec_base_generator.log)
[elec_large_discrim.log](https://github.com/user-attachments/files/21854543/elec_large_discrim.log)
[elec_small_discrim.log](https://github.com/user-attachments/files/21854544/elec_small_discrim.log)

[bbird_base_attn.log](https://github.com/user-attachments/files/21885508/bbird_base_attn.log)
[bbird_large_attn.log](https://github.com/user-attachments/files/21885510/bbird_large_attn.log)

