### PR TITLE
Add post processing steps for yolov5,v8,v9,v10 and fix minor bugs

### DIFF
--- a/config.py
+++ b/config.py
@@ -64,6 +64,7 @@ class ModelTask(StrEnum):
     MM_VIDEO_TTT = "mm_video_ttt"
     MM_MASKED_LM = "mm_masked_lm"
     CONDITIONAL_GENERATION = "conditional_generation"
+    ATOMIC_ML = "atomic_ml"
 
 
 class ModelSource(StrEnum):

--- a/deepseek/deepseek_coder/pytorch/loader.py
+++ b/deepseek/deepseek_coder/pytorch/loader.py
@@ -72,7 +72,7 @@ class ModelLoader(ForgeModel):
             model="deepseek_coder",
             variant=variant,
             group=ModelGroup.GENERALITY,
-            task=ModelTask.QA,
+            task=ModelTask.NLP_QA,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )

--- a/deepseek/deepseek_math/pytorch/loader.py
+++ b/deepseek/deepseek_math/pytorch/loader.py
@@ -57,7 +57,7 @@ class ModelLoader(ForgeModel):
             model="deepseek_math",
             variant=variant,
             group=ModelGroup.GENERALITY,
-            task=ModelTask.QA,
+            task=ModelTask.NLP_QA,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )

--- a/gpt2/pytorch/loader.py
+++ b/gpt2/pytorch/loader.py
@@ -60,9 +60,9 @@ class ModelLoader(ForgeModel):
             variant = cls.DEFAULT_VARIANT
 
         task = (
-            ModelTask.TEXT_GENERATION
+            ModelTask.NLP_CAUSAL_LM
             if variant == ModelVariant.GPT2_BASE
-            else ModelTask.SEQUENCE_CLASSIFICATION
+            else ModelTask.NLP_TEXT_CLS
         )
 
         return ModelInfo(

--- a/gpt_neo/causal_lm/pytorch/__init__.py
+++ b/gpt_neo/causal_lm/pytorch/__init__.py
@@ -4,4 +4,4 @@
 """
 GPT-Neo PyTorch model implementation for Tenstorrent projects.
 """
-from .loader import ModelLoader
+from .loader import ModelLoader, ModelVariant

--- a/llava/pytorch/loader.py
+++ b/llava/pytorch/loader.py
@@ -59,7 +59,7 @@ class ModelLoader(ForgeModel):
             model="llava",
             variant=variant,
             group=ModelGroup.RED,
-            task=ModelTask.MULTIMODAL_CONDITIONAL_GENERATION,
+            task=ModelTask.CONDITIONAL_GENERATION,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
         )

--- a/resnet/pytorch/src/utils.py
+++ b/resnet/pytorch/src/utils.py
@@ -21,10 +21,7 @@ def run_and_print_results(framework_model, compiled_model, inputs):
 
     results = []
     for i, image in enumerate(inputs):
-        processed_inputs = processor(image, return_tensors="pt")["pixel_values"].to(
-            torch.bfloat16
-        )
-
+        processed_inputs = processor(image, return_tensors="pt")["pixel_values"]
         cpu_logits = framework_model(processed_inputs)[0]
         cpu_conf, cpu_idx = cpu_logits.softmax(-1).max(-1)
         cpu_pred = label_dict.get(cpu_idx.item(), "Unknown")

--- a/yolov10/pytorch/loader.py
+++ b/yolov10/pytorch/loader.py
@@ -21,6 +21,7 @@ from ...config import (
 from ...base import ForgeModel
 from torch.hub import load_state_dict_from_url
 from ultralytics.nn.tasks import DetectionModel
+from ...tools.utils import yolo_postprocess
 
 
 class ModelVariant(StrEnum):
@@ -133,3 +134,14 @@ class ModelLoader(ForgeModel):
             batch_tensor = batch_tensor.to(dtype_override)
 
         return batch_tensor
+
+    def post_process(self, co_out):
+        """Post-process YOLOv10 model outputs to extract detection results.
+
+        Args:
+            co_out: Raw model output tensor from YOLOv10 forward pass.
+
+        Returns:
+            Post-processed detection results.
+        """
+        return yolo_postprocess(co_out)

--- a/yolov5/pytorch/src/utils.py
+++ b/yolov5/pytorch/src/utils.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+from pathlib import Path
+import yolov5
+import cv2
+import numpy as np
+from PIL import Image
+from yolov5.models.common import Detections
+from yolov5.utils.dataloaders import exif_transpose, letterbox
+from yolov5.utils.general import Profile, non_max_suppression, scale_boxes
+
+
+def data_preprocessing(ims: Image.Image, size: tuple) -> tuple:
+    """Data preprocessing function for YOLOv5 object detection.
+
+    Parameters
+    ----------
+    ims : Image.Image
+        Input image
+    size : tuple
+        Desired image size
+
+    Returns
+    -------
+    tuple
+        List of images, number of samples, filenames, image size, inference size, preprocessed images
+    """
+
+    if not isinstance(ims, (list, tuple)):
+        ims = [ims]
+    num_images = len(ims)
+    shape_orig, shape_infer, filenames = [], [], []
+
+    for idx, img in enumerate(ims):
+        filename = getattr(img, "filename", f"image{idx}")
+        img = np.asarray(exif_transpose(img))
+        filename = Path(filename).with_suffix(".jpg").name
+        filenames.append(filename)
+
+        if img.shape[0] < 5:
+            img = img.transpose((1, 2, 0))
+
+        if img.ndim == 3:
+            img = img[..., :3]
+        else:
+            img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+
+        shape_orig.append(img.shape[:2])
+        scale = max(size) / max(img.shape[:2])
+        shape_infer.append([int(dim * scale) for dim in img.shape[:2]])
+        ims[idx] = img if img.flags["C_CONTIGUOUS"] else np.ascontiguousarray(img)
+
+    shape_infer = [size[0] for _ in np.array(shape_infer).max(0)]
+    imgs_padded = [letterbox(img, shape_infer, auto=False)[0] for img in ims]
+    imgs_padded = np.ascontiguousarray(np.array(imgs_padded).transpose((0, 3, 1, 2)))
+    tensor_imgs = torch.from_numpy(imgs_padded) / 255
+
+    return ims, num_images, filenames, shape_orig, shape_infer, tensor_imgs
+
+
+def data_postprocessing(
+    ims: list,
+    x_shape: torch.Size,
+    pred: list,
+    model: yolov5.models.common.AutoShape,
+    n: int,
+    shape0: list,
+    shape1: list,
+    files: list,
+) -> Detections:
+    """Data postprocessing function for YOLOv5 object detection.
+
+    Parameters
+    ----------
+    ims : list
+        List of input images
+    x_shape : torch.Size
+        Shape of each image
+    pred : list
+        List of model predictions
+    model : yolov5.models.common.AutoShape
+        Model
+    n : int
+        Number of input samples
+    shape0 : list
+        Image shape
+    shape1 : list
+        Inference shape
+    files : list
+        Filenames
+
+    Returns
+    -------
+    Detections
+        Detection object
+    """
+
+    # Create dummy dt tuple (not used but required for Detections)
+    dt = (Profile(), Profile(), Profile())
+
+    # Perform NMS
+    y = non_max_suppression(
+        prediction=pred,
+        conf_thres=model.conf,
+        iou_thres=model.iou,
+        classes=None,
+        agnostic=model.agnostic,
+        multi_label=model.multi_label,
+        labels=(),
+        max_det=model.max_det,
+    )
+
+    # Scale bounding boxes
+    for i in range(n):
+        scale_boxes(shape1, y[i][:, :4], shape0[i])
+
+    # Return Detections object
+    return Detections(ims, y, files, times=dt, names=model.names, shape=x_shape)

--- a/yolov8/pytorch/loader.py
+++ b/yolov8/pytorch/loader.py
@@ -23,6 +23,7 @@ from torch.hub import load_state_dict_from_url
 from ultralytics.nn.tasks import DetectionModel
 from torchvision import transforms
 from datasets import load_dataset
+from ...tools.utils import yolo_postprocess
 
 
 class ModelVariant(StrEnum):
@@ -135,3 +136,14 @@ class ModelLoader(ForgeModel):
             batch_tensor = batch_tensor.to(dtype_override)
 
         return batch_tensor
+
+    def post_process(self, co_out):
+        """Post-process YOLOv8 model outputs to extract detection results.
+
+        Args:
+            co_out: Raw model output tensor from YOLOv8 forward pass.
+
+        Returns:
+            Post-processed detection results.
+        """
+        return yolo_postprocess(co_out)

--- a/yolov9/pytorch/loader.py
+++ b/yolov9/pytorch/loader.py
@@ -16,6 +16,7 @@ from torch.hub import load_state_dict_from_url
 from ultralytics.nn.tasks import DetectionModel
 from torchvision import transforms
 from datasets import load_dataset
+from ...tools.utils import yolo_postprocess
 
 
 class ModelLoader(ForgeModel):
@@ -111,3 +112,14 @@ class ModelLoader(ForgeModel):
             batch_tensor = batch_tensor.to(dtype_override)
 
         return batch_tensor
+
+    def post_process(self, co_out):
+        """Post-process YOLOv9 model outputs to extract detection results.
+
+        Args:
+            co_out: Raw model output tensor from YOLOv9 forward pass.
+
+        Returns:
+            Post-processed detection results.
+        """
+        return yolo_postprocess(co_out)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge/issues/374
- Fixes https://github.com/tenstorrent/tt-forge-models/issues/94

### Problem description

- YOLOv5, YOLOv8, YOLOv9, and YOLOv10 are missing post-processing steps.
- YOLOv5 also has incorrect preprocessing steps.
- ResNet post-processing includes an unnecessary BFP16 conversion of inputs.

### What's changed

- Added the required post-processing steps for YOLOv5, YOLOv8, YOLOv9, and YOLOv10.
- Fixed YOLOv5 preprocessing.
- Removed the unnecessary BFP16 input conversion in ResNet post-processing.

### Checklist
- [x] verified the changes with local testing

### Logs

- [set2_check.zip](https://github.com/user-attachments/files/21896993/set2_check.zip)

