### PR TITLE
Fix _get_model_info missing classmethod attribute in nanogpt

### DIFF
--- a/nanogpt/pytorch/loader.py
+++ b/nanogpt/pytorch/loader.py
@@ -37,6 +37,7 @@ class ModelLoader(ForgeModel):
     # Default variant to use
     DEFAULT_VARIANT = ModelVariant.FINANCIAL_SUPPORT_NANOGPT
 
+    @classmethod
     def _get_model_info(cls, variant_name: str = None):
         """Get model information for dashboard and metrics reporting.
 


### PR DESCRIPTION
### Ticket
Closes #109 

### Problem description
- Similar bug noticed and fixed in falcon recently via #98 , with missing classmethod attribute for _get_model_info() 
- This causes variant to be reported as None and model_name incorrect

### What's changed
- Add missing attribute to affected model nanogpt

### Checklist
- [x] Test out locally
