### PR TITLE
Fix dtype mismatch between model and input in ResNet HF post-processing

### DIFF
--- a/resnet/pytorch/loader.py
+++ b/resnet/pytorch/loader.py
@@ -239,7 +239,12 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def post_process(
-        self, co_out=None, framework_model=None, compiled_model=None, inputs=None
+        self,
+        co_out=None,
+        framework_model=None,
+        compiled_model=None,
+        inputs=None,
+        dtype_override=None,
     ):
 
         """
@@ -250,6 +255,7 @@ class ModelLoader(ForgeModel):
             framework_model: The original framework-based model.
             compiled_model: The compiled version of the model.
             inputs: A list of images to process and classify.
+            dtype_override: Optional torch.dtype to override the input's dtype.
 
         Returns:
             None: Prints predicted results.
@@ -258,6 +264,8 @@ class ModelLoader(ForgeModel):
         source = self._variant_config.source
 
         if source == ModelSource.HUGGING_FACE:
-            run_and_print_results(framework_model, compiled_model, inputs)
+            run_and_print_results(
+                framework_model, compiled_model, inputs, dtype_override
+            )
         else:
             print_compiled_model_results(co_out)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-fe/issues/2880

### Problem description

- A dtype mismatch occurs between the model and input in ResNet HF post-processing, resulting in the following error:

```
RuntimeError: Input type (torch.FloatTensor) and weight type (CPUBFloat16Type) should be the same or input should be a MKLDNN tensor and weight is a dense tensor
```

### Root Cause 

- The ResNet HF test (`forge/test/models/pytorch/vision/resnet/test_resnet.py::test_resnet_hf`) uses a [new image](https://github.com/tenstorrent/tt-forge-fe/blob/82d8e73e0a431bf7149370e7a7ff218ac79216fb/forge/test/models/pytorch/vision/resnet/test_resnet.py#L45C5-L46C58) in post-processing. These images were not converted to the expected dtype inside run_and_print_results fucntion leading to a mismatch between the model and input when running tests in bfp16.

### What's changed

- Propagated dtype override information to the relevant post-processing functions.
- Ensured that inputs are converted to the required dtype within the function.


### Checklist
- [x] verified the changes with local testing

### Logs

- [aug25_resnet_after_fix.log](https://github.com/user-attachments/files/21961938/aug25_resnet_af.log)

