### PR TITLE
Deduplicate ModelVariant enums, add 2 missing model variants (unet, resnext) used by tt-torch

### DIFF
--- a/hrnet/pytorch/loader.py
+++ b/hrnet/pytorch/loader.py
@@ -50,15 +50,15 @@ class ModelVariant(StrEnum):
     HRNET_W18_MS_AUG_IN1K = "hrnet_w18.ms_aug_in1k"
 
     # OSMR (pytorchcv) variants
-    HRNET_W18_SMALL_V1_OSMR = "hrnet_w18_small_v1"
-    HRNET_W18_SMALL_V2_OSMR = "hrnet_w18_small_v2"
-    HRNETV2_W18_OSMR = "hrnetv2_w18"
-    HRNETV2_W30_OSMR = "hrnetv2_w30"
-    HRNETV2_W32_OSMR = "hrnetv2_w32"
-    HRNETV2_W40_OSMR = "hrnetv2_w40"
-    HRNETV2_W44_OSMR = "hrnetv2_w44"
-    HRNETV2_W48_OSMR = "hrnetv2_w48"
-    HRNETV2_W64_OSMR = "hrnetv2_w64"
+    HRNET_W18_SMALL_V1_OSMR = "hrnet_w18_small_v1_osmr"
+    HRNET_W18_SMALL_V2_OSMR = "hrnet_w18_small_v2_osmr"
+    HRNETV2_W18_OSMR = "hrnetv2_w18_osmr"
+    HRNETV2_W30_OSMR = "hrnetv2_w30_osmr"
+    HRNETV2_W32_OSMR = "hrnetv2_w32_osmr"
+    HRNETV2_W40_OSMR = "hrnetv2_w40_osmr"
+    HRNETV2_W44_OSMR = "hrnetv2_w44_osmr"
+    HRNETV2_W48_OSMR = "hrnetv2_w48_osmr"
+    HRNETV2_W64_OSMR = "hrnetv2_w64_osmr"
 
 
 class ModelLoader(ForgeModel):

--- a/resnet/pytorch/loader.py
+++ b/resnet/pytorch/loader.py
@@ -45,7 +45,7 @@ class ModelVariant(StrEnum):
     RESNET_50_HF = "resnet_50_hf"
 
     # TIMM variants
-    RESNET_50_TIMM = "resnet50"
+    RESNET_50_TIMM = "resnet50_timm"
 
     # Torchvision variants
     RESNET_18 = "resnet18"

--- a/resnext/pytorch/loader.py
+++ b/resnext/pytorch/loader.py
@@ -43,10 +43,10 @@ class ModelVariant(StrEnum):
     RESNEXT101_32X8D_WSL = "resnext101_32x8d_wsl"
 
     # OSMR variants
-    RESNEXT14_32X4D_OSMR = "resnext14_32x4d"
-    RESNEXT26_32X4D_OSMR = "resnext26_32x4d"
-    RESNEXT50_32X4D_OSMR = "resnext50_32x4d"
-    RESNEXT101_64X4D_OSMR = "resnext101_64x4d"
+    RESNEXT14_32X4D_OSMR = "resnext14_32x4d_osmr"
+    RESNEXT26_32X4D_OSMR = "resnext26_32x4d_osmr"
+    RESNEXT50_32X4D_OSMR = "resnext50_32x4d_osmr"
+    RESNEXT101_64X4D_OSMR = "resnext101_64x4d_osmr"
 
 
 class ModelLoader(ForgeModel):

--- a/resnext/pytorch/loader.py
+++ b/resnext/pytorch/loader.py
@@ -39,6 +39,7 @@ class ModelVariant(StrEnum):
     # Torch Hub variants
     RESNEXT50_32X4D = "resnext50_32x4d"
     RESNEXT101_32X8D = "resnext101_32x8d"
+    RESNEXT101_64X4D = "resnext101_64x4d"
     RESNEXT101_32X8D_WSL = "resnext101_32x8d_wsl"
 
     # OSMR variants
@@ -61,6 +62,11 @@ class ModelLoader(ForgeModel):
         ),
         ModelVariant.RESNEXT101_32X8D: ResNeXtConfig(
             pretrained_model_name="resnext101_32x8d",
+            source=ModelSource.TORCH_HUB,
+            hub_source="pytorch/vision:v0.10.0",
+        ),
+        ModelVariant.RESNEXT101_64X4D: ResNeXtConfig(
+            pretrained_model_name="resnext101_64x4d",
             source=ModelSource.TORCH_HUB,
             hub_source="pytorch/vision:v0.10.0",
         ),

--- a/unet/pytorch/loader.py
+++ b/unet/pytorch/loader.py
@@ -46,6 +46,9 @@ class ModelVariant(StrEnum):
     # TorchHub brain segmentation UNet
     TORCHHUB_BRAIN_UNET = "torchhub_brain_unet"
 
+    # Carvana UNet (in-repo fallback)
+    CARVANA_UNET = "carvana_unet"
+
 
 class ModelLoader(ForgeModel):
     """UNet model loader implementation supporting multiple sources."""
@@ -65,6 +68,10 @@ class ModelLoader(ForgeModel):
             source=ModelSource.TORCH_HUB,
             hub_repo="mateuszbuda/brain-segmentation-pytorch",
             hub_model="unet",
+        ),
+        ModelVariant.CARVANA_UNET: UnetConfig(
+            pretrained_model_name="carvana_unet",
+            source=ModelSource.CUSTOM,
         ),
     }
 

--- a/vovnet/pytorch/loader.py
+++ b/vovnet/pytorch/loader.py
@@ -48,8 +48,8 @@ class ModelVariant(StrEnum):
     VOVNET57 = "vovnet57"
 
     # TorchHub variant
-    VOVNET39_TORCHHUB = "vovnet39"
-    VOVNET57_TORCHHUB = "vovnet57"
+    VOVNET39_TORCHHUB = "vovnet39_th"
+    VOVNET57_TORCHHUB = "vovnet57_th"
 
     # TIMM image classification variants (subset)
     TIMM_VOVNET19B_DW = "ese_vovnet19b_dw"


### PR DESCRIPTION
### Ticket
#112

### Problem description
- A couple missing model variants (unet_carvana custom source, resnext101_64x4d torchvision source)
- A few models (hrnet, resnet, vovnet, resnext) have duplicate ModelVariant enum values causing earlier versions to be dropped in _VARIANTS dict

### What's changed

- Expose CARVANA_UNET as unet variant since we run it in tt-torch
- Add RESNEXT101_64X4D torchvision source to resnext loader
-  Deduplicate some ModelVariant enums (hrnet, resnet, vovnet, resnext)
     - hrnet:   hrnet_w18_small_v2 is now hrnet_w18_small_v2_osmr
     - resnext: resnext50_32x4d is now resnext50_32x4d_osmr
     - resnext: resnext101_64x4d is now resnext101_64x4d_osmr
     - vovnet: vovnet39 is now vovnet39_th
     - vovnet: vovnet57 is now vovnet57_th
     - resnet: resnet50_timm newly exposed (was hidden)

### Checklist
- [x] Tested locally in tt-torch, new variants passing, warnings about duplicate enum values gone
