### PR TITLE
Fix RuntimeError: Wrong input shape height=1213, width=1546. Expected…

### DIFF
--- a/unet/pytorch/loader.py
+++ b/unet/pytorch/loader.py
@@ -178,6 +178,23 @@ class ModelLoader(ForgeModel):
             mean = torch.tensor(params["mean"]).view(1, 3, 1, 1)
 
             img_tensor = transforms.ToTensor()(img).unsqueeze(0)
+
+            # Ensure dimensions are divisible by 32 (UNet output stride requirement)
+            # Pad the image to the next multiple of 32
+            _, _, h, w = img_tensor.shape
+            output_stride = 32
+            new_h = ((h - 1) // output_stride + 1) * output_stride
+            new_w = ((w - 1) // output_stride + 1) * output_stride
+
+            # Pad if needed
+            if h != new_h or w != new_w:
+                pad_h = new_h - h
+                pad_w = new_w - w
+                # Pad: (left, right, top, bottom)
+                img_tensor = torch.nn.functional.pad(
+                    img_tensor, (0, pad_w, 0, pad_h), mode="constant", value=0
+                )
+
             inputs = (img_tensor - mean) / std
 
         else:


### PR DESCRIPTION
… image height and width divisible by 32

### Ticket
 [Issue](https://github.com/tenstorrent/tt-forge-fe/issues/2920)

### Problem description
RuntimeError: Wrong input shape height=1213, width=1546. Expected image height and width divisible by 32. 

### What's changed
The loader.py of the unet script is changed where the load_input function is modified

### Checklist
- [ ] New/Existing tests provide coverage for changes
