### PR TITLE
Fix incorrect group for jax models

### DIFF
--- a/resnet/image_classification/jax/loader.py
+++ b/resnet/image_classification/jax/loader.py
@@ -83,10 +83,14 @@ class ModelLoader(ForgeModel):
         if variant is None:
             variant = cls.DEFAULT_VARIANT
 
+        group = ModelGroup.GENERALITY
+        if variant == ModelVariant.RESNET_50:
+            group = ModelGroup.RED
+
         return ModelInfo(
             model="resnet_v1.5",
             variant=variant,
-            group=ModelGroup.GENERALITY,
+            group=group,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.JAX,

--- a/vit/image_classification/jax/loader.py
+++ b/vit/image_classification/jax/loader.py
@@ -89,10 +89,14 @@ class ModelLoader(ForgeModel):
         if variant is None:
             variant = cls.DEFAULT_VARIANT
 
+        group = ModelGroup.GENERALITY
+        if variant == ModelVariant.BASE_PATCH16_224:
+            group = ModelGroup.RED
+
         return ModelInfo(
             model="vit",
             variant=variant,
-            group=ModelGroup.GENERALITY,
+            group=group,
             task=ModelTask.CV_IMAGE_CLS,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.JAX,


### PR DESCRIPTION
### Problem description
Fix incorrect group for jax models

### What's changed
update red models with correct group

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_resnet_50_after_changing_to_red.log](https://github.com/user-attachments/files/22337048/test_resnet_50_after_changing_to_red.log)
[test_vit_base.log](https://github.com/user-attachments/files/22337049/test_vit_base.log)
