### PR TITLE
replacing mistral model

### DIFF
--- a/mistral/causal_lm/jax/loader.py
+++ b/mistral/causal_lm/jax/loader.py
@@ -35,16 +35,16 @@ class ModelLoader(ForgeModel):
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
         ModelVariant.V0_1: LLMModelConfig(
-            pretrained_model_name="ksmcg/Mistral-7B-v0.1",
+            pretrained_model_name="mistralai/Mistral-7B-v0.1",
         ),
         ModelVariant.V0_1_TINY: LLMModelConfig(
             pretrained_model_name="ksmcg/Mistral-tiny",
         ),
         ModelVariant.V0_2_INSTRUCT: LLMModelConfig(
-            pretrained_model_name="unsloth/mistral-7b-instruct-v0.2",
+            pretrained_model_name="mistralai/Mistral-7B-Instruct-v0.2",
         ),
         ModelVariant.V0_3_INSTRUCT: LLMModelConfig(
-            pretrained_model_name="unsloth/mistral-7b-instruct-v0.3",
+            pretrained_model_name="mistralai/Mistral-7B-Instruct-v0.3",
         ),
     }
 


### PR DESCRIPTION
### Problem description
Since we now have an HF token in CI, we have replaced the original gated Mistral model with the third-party model

### What's changed
replaced with the model from mistral ai

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the GitHub action link where I tested to verify we have permission for this model:
https://github.com/tenstorrent/tt-xla/actions/runs/17758943066?pr=1397