### PR TITLE
Bringup MapTR Bevformer variants

### DIFF
--- a/bevformer/pytorch/loader.py
+++ b/bevformer/pytorch/loader.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-Detr3d model loader implementation
+BEVFormer model loader implementation
 """
 import torch
 import numpy as np

--- a/config.py
+++ b/config.py
@@ -56,6 +56,7 @@ class ModelTask(StrEnum):
     CV_KEYPOINT_DET = "cv_keypoint_det"
     CV_KNOW_DISTILL = "cv_know_distill"
     CV_PANOPTIC_SEG = "cv_panoptic_seg"
+    REALTIME_MAP_CONSTRUCTION = "realtime_map_construction"
     MM_IMAGE_CAPT = "mm_image_capt"
     MM_DOC_QA = "mm_doc_qa"
     MM_VISUAL_QA = "mm_visual_qa"

--- a/maptr/pytorch/__init__.py
+++ b/maptr/pytorch/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MapTR model implementation for Tenstorrent projects.
+"""
+
+from .loader import ModelLoader, ModelVariant

--- a/maptr/pytorch/loader.py
+++ b/maptr/pytorch/loader.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MAPTR model loader implementation
+"""
+import torch
+from typing import Optional
+from mmcv.runner import load_checkpoint
+
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ...base import ForgeModel
+from ...tools.utils import get_file
+from .src.maptr import build_model, bevformer_cfg
+from mmcv import ConfigDict
+import numpy as np
+
+
+class ModelVariant(StrEnum):
+    """Available MAPTR model variants."""
+
+    TINY_R50_24E_BEVFORMER = "tiny_r50_24e_bevformer"
+    TINY_R50_24E_BEVFORMER_T4 = "tiny_r50_24e_bevformer_t4"
+
+
+class ModelLoader(ForgeModel):
+    """MAPTR model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.TINY_R50_24E_BEVFORMER: ModelConfig(
+            pretrained_model_name="tiny_r50_24e_bevformer",
+        ),
+        ModelVariant.TINY_R50_24E_BEVFORMER_T4: ModelConfig(
+            pretrained_model_name="tiny_r50_24e_bevformer_t4",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.TINY_R50_24E_BEVFORMER
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant.
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="maptr",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.REALTIME_MAP_CONSTRUCTION,
+            source=ModelSource.GITHUB,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self):
+        """Load pretrained MAPTR model for this instance's variant.
+
+        Returns:
+            torch.nn.Module: The MAPTR model instance.
+        """
+        # Get the variant name from the instance's variant config
+        variant_name = self._variant_config.pretrained_model_name
+
+        # Get pretrained weights
+        model_path = str(get_file(f"test_files/pytorch/maptr/maptr_{variant_name}.pth"))
+
+        if variant_name == "tiny_r50_24e_bevformer_t4":
+            # Update model config
+            bevformer_cfg["pts_bbox_head"]["transformer"]["len_can_bus"] = 6
+
+        # wrap the model config
+        self.cfg = ConfigDict(bevformer_cfg)
+
+        # Build model
+        model = build_model(self.cfg)
+
+        # Load pretrained weights
+        load_checkpoint(model, model_path, map_location="cpu")
+        model.eval()
+
+        return model
+
+    def load_inputs(self):
+        """Prepare dummy sample inputs for the MAPTR model (NuScenes format).
+
+        This function creates synthetic test data mimicking the structure expected by
+        MAPTR when using the NuScenes dataset. It does not load real data, but instead
+        generates placeholder inputs for testing purposes:
+
+        - img_shape: List of image shapes, one per camera view.
+        - lidar2img: List of 4x4 projection matrices (identity matrices here as placeholders).
+        - can_bus: Vehicle state vector (zeros used as dummy values).
+        - img: Random image tensor simulating 6 camera views.
+
+        Returns:
+            dict: Dictionary containing:
+                - ``img_metas`` (list): Metadata with image shapes, projection matrices,
+                CAN bus vector, and a dummy scene token.
+                - ``img`` (list): Randomized image tensor of shape (1, 6, 3, 480, 800).
+        """
+
+        img_shape = [(480, 800, 3)] * 6
+        lidar2img = [np.eye(4) for _ in range(6)]
+        can_bus = np.zeros(18, dtype=np.float64)
+        img = torch.randn(1, 6, 3, 480, 800)
+
+        data = {
+            "img_metas": [
+                [
+                    {
+                        "img_shape": img_shape,
+                        "lidar2img": lidar2img,
+                        "can_bus": can_bus,
+                        "scene_token": "fcbccedd61424f1b85dcbf8f897f9754",
+                    }
+                ]
+            ],
+            "img": [img],
+        }
+
+        return data

--- a/maptr/pytorch/requirements.nodeps.txt
+++ b/maptr/pytorch/requirements.nodeps.txt
@@ -1,0 +1,3 @@
+mmcv-full==1.7.2
+mmdet==2.28.2
+yapf==0.43.0   # required for mmcv

--- a/maptr/pytorch/src/maptr.py
+++ b/maptr/pytorch/src/maptr.py
@@ -1,0 +1,2056 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MAPTR model implementation
+
+Apdapted from: https://github.com/hustvl/MapTR.git
+
+MIT License
+
+Copyright (c) 2022 Hust Vision Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+# ============================================================================
+# IMPORTS
+# ============================================================================
+
+import math
+import copy
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.nn.init import normal_
+
+from mmcv import ConfigDict
+from mmcv.cnn import (
+    Linear,
+    xavier_init,
+    constant_init,
+    build_norm_layer,
+)
+from mmcv.cnn.bricks.registry import (
+    ATTENTION,
+    TRANSFORMER_LAYER,
+    TRANSFORMER_LAYER_SEQUENCE,
+)
+from mmcv.cnn.bricks.transformer import (
+    build_transformer_layer_sequence,
+    build_attention,
+    build_feedforward_network,
+    TransformerLayerSequence,
+)
+from mmcv.ops.multi_scale_deform_attn import multi_scale_deformable_attn_pytorch
+from mmcv.runner.base_module import BaseModule, ModuleList
+
+from mmdet.core.bbox import BaseBBoxCoder, build_bbox_coder
+from mmdet.core.bbox.builder import BBOX_CODERS
+from mmdet.core.bbox.transforms import bbox_xyxy_to_cxcywh, bbox_cxcywh_to_xyxy
+from mmdet.models import DETECTORS, HEADS
+from mmdet.models.builder import BACKBONES, DETECTORS, HEADS, NECKS
+from mmdet.models.detectors import BaseDetector
+from mmdet.models.dense_heads import DETRHead
+from mmdet.models.utils.builder import TRANSFORMER
+from mmdet.models.utils.transformer import inverse_sigmoid
+
+# ============================================================================
+# UTILITY FUNCTIONS
+# ============================================================================
+
+
+def denormalize_2d_bbox(bboxes, pc_range):
+    bboxes = bbox_cxcywh_to_xyxy(bboxes)
+    bboxes[..., 0::2] = bboxes[..., 0::2] * (pc_range[3] - pc_range[0]) + pc_range[0]
+    bboxes[..., 1::2] = bboxes[..., 1::2] * (pc_range[4] - pc_range[1]) + pc_range[1]
+    return bboxes
+
+
+def denormalize_2d_pts(pts, pc_range):
+    new_pts = pts.clone()
+    new_pts[..., 0:1] = pts[..., 0:1] * (pc_range[3] - pc_range[0]) + pc_range[0]
+    new_pts[..., 1:2] = pts[..., 1:2] * (pc_range[4] - pc_range[1]) + pc_range[1]
+    return new_pts
+
+
+# ============================================================================
+# MODEL CONFIG
+# ============================================================================
+
+point_cloud_range = [-15.0, -30.0, -2.0, 15.0, 30.0, 2.0]
+voxel_size = [0.15, 0.15, 4]
+
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True
+)
+
+class_names = [
+    "car",
+    "truck",
+    "construction_vehicle",
+    "bus",
+    "trailer",
+    "barrier",
+    "motorcycle",
+    "bicycle",
+    "pedestrian",
+    "traffic_cone",
+]
+map_classes = ["divider", "ped_crossing", "boundary"]
+fixed_ptsnum_per_gt_line = 20
+fixed_ptsnum_per_pred_line = 20
+eval_use_same_gt_sample_num_flag = True
+num_map_classes = len(map_classes)
+input_modality = dict(
+    use_lidar=False, use_camera=True, use_radar=False, use_map=False, use_external=True
+)
+_dim_ = 256
+_pos_dim_ = _dim_ // 2
+_ffn_dim_ = _dim_ * 2
+_num_levels_ = 1
+bev_h_ = 200
+bev_w_ = 100
+queue_length = 1
+
+bevformer_cfg = dict(
+    type="MapTR",
+    use_grid_mask=True,
+    video_test_mode=False,
+    pretrained=dict(img=None),
+    img_backbone=dict(
+        type="ResNet",
+        depth=50,
+        num_stages=4,
+        out_indices=(3,),
+        frozen_stages=1,
+        norm_cfg=dict(type="BN", requires_grad=False),
+        norm_eval=True,
+        style="pytorch",
+    ),
+    img_neck=dict(
+        type="FPN",
+        in_channels=[2048],
+        out_channels=_dim_,
+        start_level=0,
+        add_extra_convs="on_output",
+        num_outs=_num_levels_,
+        relu_before_extra_convs=True,
+    ),
+    pts_bbox_head=dict(
+        type="MapTRHead",
+        bev_h=bev_h_,
+        bev_w=bev_w_,
+        num_query=900,
+        num_vec=50,
+        num_pts_per_vec=fixed_ptsnum_per_pred_line,
+        num_pts_per_gt_vec=fixed_ptsnum_per_gt_line,
+        dir_interval=1,
+        query_embed_type="instance_pts",
+        transform_method="minmax",
+        gt_shift_pts_pattern="v2",
+        num_classes=num_map_classes,
+        in_channels=_dim_,
+        sync_cls_avg_factor=True,
+        with_box_refine=True,
+        as_two_stage=False,
+        code_size=2,
+        code_weights=[1.0, 1.0, 1.0, 1.0],
+        transformer=dict(
+            type="MapTRPerceptionTransformer",
+            rotate_prev_bev=True,
+            use_shift=True,
+            use_can_bus=True,
+            embed_dims=_dim_,
+            encoder=dict(
+                type="BEVFormerEncoder",
+                num_layers=1,
+                pc_range=point_cloud_range,
+                num_points_in_pillar=4,
+                return_intermediate=False,
+                transformerlayers=dict(
+                    type="BEVFormerLayer",
+                    attn_cfgs=[
+                        dict(
+                            type="TemporalSelfAttention", embed_dims=_dim_, num_levels=1
+                        ),
+                        dict(
+                            type="SpatialCrossAttention",
+                            pc_range=point_cloud_range,
+                            deformable_attention=dict(
+                                type="MSDeformableAttention3D",
+                                embed_dims=_dim_,
+                                num_points=8,
+                                num_levels=_num_levels_,
+                            ),
+                            embed_dims=_dim_,
+                        ),
+                    ],
+                    feedforward_channels=_ffn_dim_,
+                    ffn_dropout=0.1,
+                    operation_order=(
+                        "self_attn",
+                        "norm",
+                        "cross_attn",
+                        "norm",
+                        "ffn",
+                        "norm",
+                    ),
+                ),
+            ),
+            decoder=dict(
+                type="MapTRDecoder",
+                num_layers=6,
+                return_intermediate=True,
+                transformerlayers=dict(
+                    type="DetrTransformerDecoderLayer",
+                    attn_cfgs=[
+                        dict(
+                            type="MultiheadAttention",
+                            embed_dims=_dim_,
+                            num_heads=8,
+                            dropout=0.1,
+                        ),
+                        dict(
+                            type="CustomMSDeformableAttention",
+                            embed_dims=_dim_,
+                            num_levels=1,
+                        ),
+                    ],
+                    feedforward_channels=_ffn_dim_,
+                    ffn_dropout=0.1,
+                    operation_order=(
+                        "self_attn",
+                        "norm",
+                        "cross_attn",
+                        "norm",
+                        "ffn",
+                        "norm",
+                    ),
+                ),
+            ),
+        ),
+        bbox_coder=dict(
+            type="MapTRNMSFreeCoder",
+            post_center_range=[-20, -35, -20, -35, 20, 35, 20, 35],
+            pc_range=point_cloud_range,
+            max_num=50,
+            voxel_size=voxel_size,
+            num_classes=num_map_classes,
+        ),
+        positional_encoding=dict(
+            type="LearnedPositionalEncoding",
+            num_feats=_pos_dim_,
+            row_num_embed=bev_h_,
+            col_num_embed=bev_w_,
+        ),
+        loss_cls=dict(
+            type="FocalLoss", use_sigmoid=True, gamma=2.0, alpha=0.25, loss_weight=2.0
+        ),
+    ),
+)
+
+# ============================================================================
+# BUILDERS
+# ============================================================================
+
+
+def build_backbone(cfg):
+    return BACKBONES.build(cfg)
+
+
+def build_neck(cfg):
+    return NECKS.build(cfg)
+
+
+def build_head(cfg):
+    return HEADS.build(cfg)
+
+
+def build_detector(cfg, train_cfg=None, test_cfg=None):
+    return DETECTORS.build(
+        cfg, default_args=dict(train_cfg=train_cfg, test_cfg=test_cfg)
+    )
+
+
+def build_model(cfg, train_cfg=None, test_cfg=None):
+    return build_detector(cfg, train_cfg=train_cfg, test_cfg=test_cfg)
+
+
+# ============================================================================
+# BBOX CODERS
+# ============================================================================
+
+
+@BBOX_CODERS.register_module()
+class MapTRNMSFreeCoder(BaseBBoxCoder):
+    def __init__(
+        self,
+        pc_range,
+        voxel_size=None,
+        post_center_range=None,
+        max_num=100,
+        score_threshold=None,
+        num_classes=10,
+    ):
+        self.pc_range = pc_range
+        self.voxel_size = voxel_size
+        self.post_center_range = post_center_range
+        self.max_num = max_num
+        self.score_threshold = score_threshold
+        self.num_classes = num_classes
+
+    def encode(self):
+        pass
+
+    def decode_single(self, cls_scores, bbox_preds, pts_preds):
+        max_num = self.max_num
+
+        cls_scores = cls_scores.sigmoid()
+        scores, indexs = cls_scores.view(-1).topk(max_num)
+        labels = indexs % self.num_classes
+        bbox_index = indexs // self.num_classes
+        bbox_preds = bbox_preds[bbox_index]
+        pts_preds = pts_preds[bbox_index]
+
+        final_box_preds = denormalize_2d_bbox(bbox_preds, self.pc_range)
+        final_pts_preds = denormalize_2d_pts(pts_preds, self.pc_range)
+        final_scores = scores
+        final_preds = labels
+
+        self.post_center_range = torch.tensor(
+            self.post_center_range, device=scores.device
+        )
+        mask = (final_box_preds[..., :4] >= self.post_center_range[:4]).all(1)
+        mask &= (final_box_preds[..., :4] <= self.post_center_range[4:]).all(1)
+
+        boxes3d = final_box_preds[mask]
+        scores = final_scores[mask]
+        pts = final_pts_preds[mask]
+        labels = final_preds[mask]
+        predictions_dict = {
+            "bboxes": boxes3d,
+            "scores": scores,
+            "labels": labels,
+            "pts": pts,
+        }
+        return predictions_dict
+
+    def decode(self, preds_dicts):
+
+        all_cls_scores = preds_dicts["all_cls_scores"][-1]
+        all_bbox_preds = preds_dicts["all_bbox_preds"][-1]
+        all_pts_preds = preds_dicts["all_pts_preds"][-1]
+        batch_size = all_cls_scores.size()[0]
+        predictions_list = []
+        for i in range(batch_size):
+            predictions_list.append(
+                self.decode_single(
+                    all_cls_scores[i], all_bbox_preds[i], all_pts_preds[i]
+                )
+            )
+        return predictions_list
+
+
+# ============================================================================
+# ATTENTION
+# ============================================================================
+
+
+@ATTENTION.register_module()
+class CustomMSDeformableAttention(BaseModule):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=4,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=False,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__(init_cfg)
+        self.norm_cfg = norm_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.sampling_offsets = nn.Linear(
+            embed_dims, num_heads * num_levels * num_points * 2
+        )
+        self.attention_weights = nn.Linear(
+            embed_dims, num_heads * num_levels * num_points
+        )
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+        self.init_weights()
+
+    def init_weights(self):
+        constant_init(self.sampling_offsets, 0.0)
+        thetas = torch.arange(self.num_heads, dtype=torch.float32) * (
+            2.0 * math.pi / self.num_heads
+        )
+        grid_init = torch.stack([thetas.cos(), thetas.sin()], -1)
+        grid_init = (
+            (grid_init / grid_init.abs().max(-1, keepdim=True)[0])
+            .view(self.num_heads, 1, 1, 2)
+            .repeat(1, self.num_levels, self.num_points, 1)
+        )
+        for i in range(self.num_points):
+            grid_init[:, :, i, :] *= i + 1
+
+        self.sampling_offsets.bias.data = grid_init.view(-1)
+        constant_init(self.attention_weights, val=0.0, bias=0.0)
+        xavier_init(self.value_proj, distribution="uniform", bias=0.0)
+        xavier_init(self.output_proj, distribution="uniform", bias=0.0)
+        self._is_init = True
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        flag="decoder",
+        **kwargs,
+    ):
+
+        if value is None:
+            value = query
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        if not self.batch_first:
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+
+        value = self.value_proj(value)
+        value = value.view(bs, num_value, self.num_heads, -1)
+
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_levels * self.num_points
+        )
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points
+        )
+
+        offset_normalizer = torch.stack(
+            [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1
+        )
+        sampling_locations = (
+            reference_points[:, :, None, :, None, :]
+            + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+        )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+
+        output = self.output_proj(output)
+
+        if not self.batch_first:
+            output = output.permute(1, 0, 2)
+
+        return self.dropout(output) + identity
+
+
+@ATTENTION.register_module()
+class SpatialCrossAttention(BaseModule):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_cams=6,
+        pc_range=None,
+        dropout=0.1,
+        init_cfg=None,
+        batch_first=False,
+        deformable_attention=dict(
+            type="MSDeformableAttention3D", embed_dims=256, num_levels=4
+        ),
+        **kwargs,
+    ):
+        super(SpatialCrossAttention, self).__init__(init_cfg)
+
+        self.init_cfg = init_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.pc_range = pc_range
+        self.fp16_enabled = False
+        self.deformable_attention = build_attention(deformable_attention)
+        self.embed_dims = embed_dims
+        self.num_cams = num_cams
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+        self.batch_first = batch_first
+        self.init_weight()
+
+    def init_weight(self):
+        xavier_init(self.output_proj, distribution="uniform", bias=0.0)
+
+    def forward(
+        self,
+        query,
+        key,
+        value,
+        residual=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        reference_points_cam=None,
+        bev_mask=None,
+        level_start_index=None,
+        flag="encoder",
+        **kwargs,
+    ):
+
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+        if residual is None:
+            inp_residual = query
+            slots = torch.zeros_like(query)
+        if query_pos is not None:
+            query = query + query_pos
+
+        bs, num_query, _ = query.size()
+
+        D = reference_points_cam.size(3)
+        indexes = []
+        for i, mask_per_img in enumerate(bev_mask):
+            index_query_per_img = mask_per_img[0].sum(-1).nonzero().squeeze(-1)
+            indexes.append(index_query_per_img)
+        max_len = max([len(each) for each in indexes])
+
+        queries_rebatch = query.new_zeros([bs, self.num_cams, max_len, self.embed_dims])
+        reference_points_rebatch = reference_points_cam.new_zeros(
+            [bs, self.num_cams, max_len, D, 2]
+        )
+
+        for j in range(bs):
+            for i, reference_points_per_img in enumerate(reference_points_cam):
+                index_query_per_img = indexes[i]
+                queries_rebatch[j, i, : len(index_query_per_img)] = query[
+                    j, index_query_per_img
+                ]
+                reference_points_rebatch[
+                    j, i, : len(index_query_per_img)
+                ] = reference_points_per_img[j, index_query_per_img]
+
+        num_cams, l, bs, embed_dims = key.shape
+
+        key = key.permute(2, 0, 1, 3).reshape(bs * self.num_cams, l, self.embed_dims)
+        value = value.permute(2, 0, 1, 3).reshape(
+            bs * self.num_cams, l, self.embed_dims
+        )
+
+        queries = self.deformable_attention(
+            query=queries_rebatch.view(bs * self.num_cams, max_len, self.embed_dims),
+            key=key,
+            value=value,
+            reference_points=reference_points_rebatch.view(
+                bs * self.num_cams, max_len, D, 2
+            ),
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+        ).view(bs, self.num_cams, max_len, self.embed_dims)
+        for j in range(bs):
+            for i, index_query_per_img in enumerate(indexes):
+                slots[j, index_query_per_img] += queries[
+                    j, i, : len(index_query_per_img)
+                ]
+
+        count = bev_mask.sum(-1) > 0
+        count = count.permute(1, 2, 0).sum(-1)
+        count = torch.clamp(count, min=1.0)
+        slots = slots / count[..., None]
+        slots = self.output_proj(slots)
+
+        return self.dropout(slots) + inp_residual
+
+
+@ATTENTION.register_module()
+class MSDeformableAttention3D(BaseModule):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=8,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+        super().__init__(init_cfg)
+        self.norm_cfg = norm_cfg
+        self.batch_first = batch_first
+        self.output_proj = None
+        self.fp16_enabled = False
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.sampling_offsets = nn.Linear(
+            embed_dims, num_heads * num_levels * num_points * 2
+        )
+        self.attention_weights = nn.Linear(
+            embed_dims, num_heads * num_levels * num_points
+        )
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+
+        self.init_weights()
+
+    def init_weights(self):
+        constant_init(self.sampling_offsets, 0.0)
+        thetas = torch.arange(self.num_heads, dtype=torch.float32) * (
+            2.0 * math.pi / self.num_heads
+        )
+        grid_init = torch.stack([thetas.cos(), thetas.sin()], -1)
+        grid_init = (
+            (grid_init / grid_init.abs().max(-1, keepdim=True)[0])
+            .view(self.num_heads, 1, 1, 2)
+            .repeat(1, self.num_levels, self.num_points, 1)
+        )
+        for i in range(self.num_points):
+            grid_init[:, :, i, :] *= i + 1
+
+        self.sampling_offsets.bias.data = grid_init.view(-1)
+        constant_init(self.attention_weights, val=0.0, bias=0.0)
+        xavier_init(self.value_proj, distribution="uniform", bias=0.0)
+        xavier_init(self.output_proj, distribution="uniform", bias=0.0)
+        self._is_init = True
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        **kwargs,
+    ):
+
+        if value is None:
+            value = query
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+
+        value = self.value_proj(value)
+        value = value.view(bs, num_value, self.num_heads, -1)
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_levels * self.num_points
+        )
+
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points
+        )
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.stack(
+                [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1
+            )
+
+            bs, num_query, num_Z_anchors, xy = reference_points.shape
+            reference_points = reference_points[:, :, None, None, None, :, :]
+            sampling_offsets = (
+                sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+            )
+            (
+                bs,
+                num_query,
+                num_heads,
+                num_levels,
+                num_all_points,
+                xy,
+            ) = sampling_offsets.shape
+            sampling_offsets = sampling_offsets.view(
+                bs,
+                num_query,
+                num_heads,
+                num_levels,
+                num_all_points // num_Z_anchors,
+                num_Z_anchors,
+                xy,
+            )
+            sampling_locations = reference_points + sampling_offsets
+            (
+                bs,
+                num_query,
+                num_heads,
+                num_levels,
+                num_points,
+                num_Z_anchors,
+                xy,
+            ) = sampling_locations.shape
+
+            sampling_locations = sampling_locations.view(
+                bs, num_query, num_heads, num_levels, num_all_points, xy
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+
+        return output
+
+
+@ATTENTION.register_module()
+class TemporalSelfAttention(BaseModule):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=4,
+        num_bev_queue=2,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+        init_cfg=None,
+    ):
+
+        super().__init__(init_cfg)
+        self.norm_cfg = norm_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.num_bev_queue = num_bev_queue
+        self.sampling_offsets = nn.Linear(
+            embed_dims * self.num_bev_queue,
+            num_bev_queue * num_heads * num_levels * num_points * 2,
+        )
+        self.attention_weights = nn.Linear(
+            embed_dims * self.num_bev_queue,
+            num_bev_queue * num_heads * num_levels * num_points,
+        )
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+        self.init_weights()
+
+    def init_weights(self):
+        constant_init(self.sampling_offsets, 0.0)
+        thetas = torch.arange(self.num_heads, dtype=torch.float32) * (
+            2.0 * math.pi / self.num_heads
+        )
+        grid_init = torch.stack([thetas.cos(), thetas.sin()], -1)
+        grid_init = (
+            (grid_init / grid_init.abs().max(-1, keepdim=True)[0])
+            .view(self.num_heads, 1, 1, 2)
+            .repeat(1, self.num_levels * self.num_bev_queue, self.num_points, 1)
+        )
+
+        for i in range(self.num_points):
+            grid_init[:, :, i, :] *= i + 1
+
+        self.sampling_offsets.bias.data = grid_init.view(-1)
+        constant_init(self.attention_weights, val=0.0, bias=0.0)
+        xavier_init(self.value_proj, distribution="uniform", bias=0.0)
+        xavier_init(self.output_proj, distribution="uniform", bias=0.0)
+        self._is_init = True
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        flag="decoder",
+        **kwargs,
+    ):
+
+        if value is None:
+            assert self.batch_first
+            bs, len_bev, c = query.shape
+            value = torch.stack([query, query], 1).reshape(bs * 2, len_bev, c)
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        bs, num_query, embed_dims = query.shape
+        _, num_value, _ = value.shape
+
+        query = torch.cat([value[:bs], query], -1)
+        value = self.value_proj(value)
+
+        value = value.reshape(bs * self.num_bev_queue, num_value, self.num_heads, -1)
+
+        sampling_offsets = self.sampling_offsets(query)
+        sampling_offsets = sampling_offsets.view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_bev_queue,
+            self.num_levels,
+            self.num_points,
+            2,
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_bev_queue,
+            self.num_levels * self.num_points,
+        )
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_bev_queue,
+            self.num_levels,
+            self.num_points,
+        )
+
+        attention_weights = (
+            attention_weights.permute(0, 3, 1, 2, 4, 5)
+            .reshape(
+                bs * self.num_bev_queue,
+                num_query,
+                self.num_heads,
+                self.num_levels,
+                self.num_points,
+            )
+            .contiguous()
+        )
+        sampling_offsets = sampling_offsets.permute(0, 3, 1, 2, 4, 5, 6).reshape(
+            bs * self.num_bev_queue,
+            num_query,
+            self.num_heads,
+            self.num_levels,
+            self.num_points,
+            2,
+        )
+
+        offset_normalizer = torch.stack(
+            [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1
+        )
+        sampling_locations = (
+            reference_points[:, :, None, :, None, :]
+            + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+        )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+
+        output = output.permute(1, 2, 0)
+
+        output = output.view(num_query, embed_dims, bs, self.num_bev_queue)
+        output = output.mean(-1)
+
+        output = output.permute(2, 0, 1)
+
+        output = self.output_proj(output)
+
+        return self.dropout(output) + identity
+
+
+# ============================================================================
+# TRANSFORMER LAYER
+# ============================================================================
+
+
+@TRANSFORMER_LAYER.register_module()
+class MyCustomBaseTransformerLayer(BaseModule):
+    def __init__(
+        self,
+        attn_cfgs=None,
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=1024,
+            num_fcs=2,
+            ffn_drop=0.0,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=None,
+        norm_cfg=dict(type="LN"),
+        init_cfg=None,
+        batch_first=True,
+        **kwargs,
+    ):
+
+        deprecated_args = dict(
+            feedforward_channels="feedforward_channels",
+            ffn_dropout="ffn_drop",
+            ffn_num_fcs="num_fcs",
+        )
+        for ori_name, new_name in deprecated_args.items():
+            if ori_name in kwargs:
+                ffn_cfgs[new_name] = kwargs[ori_name]
+
+        super(MyCustomBaseTransformerLayer, self).__init__(init_cfg)
+
+        self.batch_first = batch_first
+
+        num_attn = operation_order.count("self_attn") + operation_order.count(
+            "cross_attn"
+        )
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+
+        self.num_attn = num_attn
+        self.operation_order = operation_order
+        self.norm_cfg = norm_cfg
+        self.pre_norm = operation_order[0] == "norm"
+        self.attentions = ModuleList()
+
+        index = 0
+        for operation_name in operation_order:
+            if operation_name in ["self_attn", "cross_attn"]:
+                attn_cfgs[index]["batch_first"] = self.batch_first
+                attention = build_attention(attn_cfgs[index])
+                attention.operation_name = operation_name
+                self.attentions.append(attention)
+                index += 1
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        self.ffns = ModuleList()
+        num_ffns = operation_order.count("ffn")
+        if isinstance(ffn_cfgs, dict):
+            ffn_cfgs = ConfigDict(ffn_cfgs)
+        if isinstance(ffn_cfgs, dict):
+            ffn_cfgs = [copy.deepcopy(ffn_cfgs) for _ in range(num_ffns)]
+
+        for ffn_index in range(num_ffns):
+            assert ffn_cfgs[ffn_index]["embed_dims"] == self.embed_dims
+
+            self.ffns.append(build_feedforward_network(ffn_cfgs[ffn_index]))
+
+        self.norms = ModuleList()
+        num_norms = operation_order.count("norm")
+        for _ in range(num_norms):
+            self.norms.append(build_norm_layer(norm_cfg, self.embed_dims)[1])
+
+
+@TRANSFORMER_LAYER.register_module()
+class BEVFormerLayer(MyCustomBaseTransformerLayer):
+    def __init__(
+        self,
+        attn_cfgs,
+        feedforward_channels,
+        ffn_dropout=0.0,
+        operation_order=None,
+        act_cfg=dict(type="ReLU", inplace=True),
+        norm_cfg=dict(type="LN"),
+        ffn_num_fcs=2,
+        **kwargs,
+    ):
+        super(BEVFormerLayer, self).__init__(
+            attn_cfgs=attn_cfgs,
+            feedforward_channels=feedforward_channels,
+            ffn_dropout=ffn_dropout,
+            operation_order=operation_order,
+            act_cfg=act_cfg,
+            norm_cfg=norm_cfg,
+            ffn_num_fcs=ffn_num_fcs,
+            **kwargs,
+        )
+        self.fp16_enabled = False
+        assert len(operation_order) == 6
+        assert set(operation_order) == set(["self_attn", "norm", "cross_attn", "ffn"])
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        bev_pos=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        ref_2d=None,
+        ref_3d=None,
+        bev_h=None,
+        bev_w=None,
+        reference_points_cam=None,
+        mask=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        prev_bev=None,
+        **kwargs,
+    ):
+
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+
+        for layer in self.operation_order:
+
+            if layer == "self_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    prev_bev,
+                    prev_bev,
+                    identity if self.pre_norm else None,
+                    query_pos=bev_pos,
+                    key_pos=bev_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    reference_points=ref_2d,
+                    spatial_shapes=torch.tensor([[bev_h, bev_w]], device=query.device),
+                    level_start_index=torch.tensor([0], device=query.device),
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "norm":
+                query = self.norms[norm_index](query)
+                norm_index += 1
+
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    reference_points=ref_3d,
+                    reference_points_cam=reference_points_cam,
+                    mask=mask,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    spatial_shapes=spatial_shapes,
+                    level_start_index=level_start_index,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+                ffn_index += 1
+
+        return query
+
+
+# ============================================================================
+# TRANSFORMER LAYER SEQUENCES
+# ============================================================================
+
+
+@TRANSFORMER_LAYER_SEQUENCE.register_module()
+class MapTRDecoder(TransformerLayerSequence):
+    def __init__(self, *args, return_intermediate=False, **kwargs):
+        super(MapTRDecoder, self).__init__(*args, **kwargs)
+        self.return_intermediate = return_intermediate
+        self.fp16_enabled = False
+
+    def forward(
+        self,
+        query,
+        *args,
+        reference_points=None,
+        reg_branches=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        output = query
+        intermediate = []
+        intermediate_reference_points = []
+        for lid, layer in enumerate(self.layers):
+
+            reference_points_input = reference_points[..., :2].unsqueeze(2)
+            output = layer(
+                output,
+                *args,
+                reference_points=reference_points_input,
+                key_padding_mask=key_padding_mask,
+                **kwargs,
+            )
+            output = output.permute(1, 0, 2)
+
+            if reg_branches is not None:
+                tmp = reg_branches[lid](output)
+
+                assert reference_points.shape[-1] == 2
+
+                new_reference_points = torch.zeros_like(reference_points)
+                new_reference_points[..., :2] = tmp[..., :2] + inverse_sigmoid(
+                    reference_points[..., :2]
+                )
+
+                new_reference_points = new_reference_points.sigmoid()
+
+                reference_points = new_reference_points.detach()
+
+            output = output.permute(1, 0, 2)
+            if self.return_intermediate:
+                intermediate.append(output)
+                intermediate_reference_points.append(reference_points)
+
+        if self.return_intermediate:
+            return torch.stack(intermediate), torch.stack(intermediate_reference_points)
+
+        return output, reference_points
+
+
+@TRANSFORMER_LAYER_SEQUENCE.register_module()
+class BEVFormerEncoder(TransformerLayerSequence):
+    def __init__(
+        self,
+        *args,
+        pc_range=None,
+        num_points_in_pillar=4,
+        return_intermediate=False,
+        dataset_type="nuscenes",
+        **kwargs,
+    ):
+
+        super(BEVFormerEncoder, self).__init__(*args, **kwargs)
+        self.return_intermediate = return_intermediate
+
+        self.num_points_in_pillar = num_points_in_pillar
+        self.pc_range = pc_range
+        self.fp16_enabled = False
+
+    @staticmethod
+    def get_reference_points(
+        H,
+        W,
+        Z=8,
+        num_points_in_pillar=4,
+        dim="3d",
+        bs=1,
+        device="cpu",
+        dtype=torch.float,
+    ):
+        if dim == "3d":
+            zs = (
+                torch.linspace(
+                    0.5, Z - 0.5, num_points_in_pillar, dtype=dtype, device=device
+                )
+                .view(-1, 1, 1)
+                .expand(num_points_in_pillar, H, W)
+                / Z
+            )
+            xs = (
+                torch.linspace(0.5, W - 0.5, W, dtype=dtype, device=device)
+                .view(1, 1, W)
+                .expand(num_points_in_pillar, H, W)
+                / W
+            )
+            ys = (
+                torch.linspace(0.5, H - 0.5, H, dtype=dtype, device=device)
+                .view(1, H, 1)
+                .expand(num_points_in_pillar, H, W)
+                / H
+            )
+            ref_3d = torch.stack((xs, ys, zs), -1)
+            ref_3d = ref_3d.permute(0, 3, 1, 2).flatten(2).permute(0, 2, 1)
+            ref_3d = ref_3d[None].repeat(bs, 1, 1, 1)
+            return ref_3d
+
+        elif dim == "2d":
+            ref_y, ref_x = torch.meshgrid(
+                torch.linspace(0.5, H - 0.5, H, dtype=dtype, device=device),
+                torch.linspace(0.5, W - 0.5, W, dtype=dtype, device=device),
+            )
+            ref_y = ref_y.reshape(-1)[None] / H
+            ref_x = ref_x.reshape(-1)[None] / W
+            ref_2d = torch.stack((ref_x, ref_y), -1)
+            ref_2d = ref_2d.repeat(bs, 1, 1).unsqueeze(2)
+            return ref_2d
+
+    def point_sampling(self, reference_points, pc_range, img_metas):
+
+        lidar2img = []
+        for img_meta in img_metas:
+            lidar2img.append(img_meta["lidar2img"])
+        lidar2img = np.asarray(lidar2img)
+        lidar2img = reference_points.new_tensor(lidar2img)
+        reference_points = reference_points.clone()
+
+        reference_points[..., 0:1] = (
+            reference_points[..., 0:1] * (pc_range[3] - pc_range[0]) + pc_range[0]
+        )
+        reference_points[..., 1:2] = (
+            reference_points[..., 1:2] * (pc_range[4] - pc_range[1]) + pc_range[1]
+        )
+        reference_points[..., 2:3] = (
+            reference_points[..., 2:3] * (pc_range[5] - pc_range[2]) + pc_range[2]
+        )
+
+        reference_points = torch.cat(
+            (reference_points, torch.ones_like(reference_points[..., :1])), -1
+        )
+
+        reference_points = reference_points.permute(1, 0, 2, 3)
+        D, B, num_query = reference_points.size()[:3]
+        num_cam = lidar2img.size(1)
+
+        reference_points = (
+            reference_points.view(D, B, 1, num_query, 4)
+            .repeat(1, 1, num_cam, 1, 1)
+            .unsqueeze(-1)
+        )
+
+        lidar2img = lidar2img.view(1, B, num_cam, 1, 4, 4).repeat(
+            D, 1, 1, num_query, 1, 1
+        )
+
+        reference_points_cam = torch.matmul(
+            lidar2img.to(torch.float32), reference_points.to(torch.float32)
+        ).squeeze(-1)
+        eps = 1e-5
+
+        bev_mask = reference_points_cam[..., 2:3] > eps
+        reference_points_cam = reference_points_cam[..., 0:2] / torch.maximum(
+            reference_points_cam[..., 2:3],
+            torch.ones_like(reference_points_cam[..., 2:3]) * eps,
+        )
+
+        reference_points_cam[..., 0] /= img_metas[0]["img_shape"][0][1]
+        reference_points_cam[..., 1] /= img_metas[0]["img_shape"][0][0]
+
+        bev_mask = (
+            bev_mask
+            & (reference_points_cam[..., 1:2] > 0.0)
+            & (reference_points_cam[..., 1:2] < 1.0)
+            & (reference_points_cam[..., 0:1] < 1.0)
+            & (reference_points_cam[..., 0:1] > 0.0)
+        )
+
+        bev_mask = torch.nan_to_num(bev_mask)
+
+        reference_points_cam = reference_points_cam.permute(2, 1, 3, 0, 4)
+        bev_mask = bev_mask.permute(2, 1, 3, 0, 4).squeeze(-1)
+
+        return reference_points_cam, bev_mask
+
+    def forward(
+        self,
+        bev_query,
+        key,
+        value,
+        *args,
+        bev_h=None,
+        bev_w=None,
+        bev_pos=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        valid_ratios=None,
+        prev_bev=None,
+        shift=0.0,
+        **kwargs,
+    ):
+
+        output = bev_query
+        intermediate = []
+
+        ref_3d = self.get_reference_points(
+            bev_h,
+            bev_w,
+            self.pc_range[5] - self.pc_range[2],
+            self.num_points_in_pillar,
+            dim="3d",
+            bs=bev_query.size(1),
+            device=bev_query.device,
+            dtype=bev_query.dtype,
+        )
+        ref_2d = self.get_reference_points(
+            bev_h,
+            bev_w,
+            dim="2d",
+            bs=bev_query.size(1),
+            device=bev_query.device,
+            dtype=bev_query.dtype,
+        )
+
+        reference_points_cam, bev_mask = self.point_sampling(
+            ref_3d, self.pc_range, kwargs["img_metas"]
+        )
+
+        shift_ref_2d = ref_2d.clone()
+        shift_ref_2d += shift[:, None, None, :]
+
+        bev_query = bev_query.permute(1, 0, 2)
+        bev_pos = bev_pos.permute(1, 0, 2)
+        bs, len_bev, num_bev_level, _ = ref_2d.shape
+
+        hybird_ref_2d = torch.stack([ref_2d, ref_2d], 1).reshape(
+            bs * 2, len_bev, num_bev_level, 2
+        )
+
+        for lid, layer in enumerate(self.layers):
+            output = layer(
+                bev_query,
+                key,
+                value,
+                *args,
+                bev_pos=bev_pos,
+                ref_2d=hybird_ref_2d,
+                ref_3d=ref_3d,
+                bev_h=bev_h,
+                bev_w=bev_w,
+                spatial_shapes=spatial_shapes,
+                level_start_index=level_start_index,
+                reference_points_cam=reference_points_cam,
+                bev_mask=bev_mask,
+                prev_bev=prev_bev,
+                **kwargs,
+            )
+
+            bev_query = output
+            if self.return_intermediate:
+                intermediate.append(output)
+
+        return output
+
+
+# ============================================================================
+# TRANSFORMER
+# ============================================================================
+
+
+@TRANSFORMER.register_module()
+class MapTRPerceptionTransformer(BaseModule):
+    def __init__(
+        self,
+        num_feature_levels=4,
+        num_cams=6,
+        two_stage_num_proposals=300,
+        fuser=None,
+        encoder=None,
+        decoder=None,
+        embed_dims=256,
+        rotate_prev_bev=True,
+        use_shift=True,
+        use_can_bus=True,
+        len_can_bus=18,
+        can_bus_norm=True,
+        use_cams_embeds=True,
+        rotate_center=[100, 100],
+        modality="vision",
+        **kwargs,
+    ):
+        super(MapTRPerceptionTransformer, self).__init__(**kwargs)
+        self.use_attn_bev = encoder["type"] == "BEVFormerEncoder"
+        self.encoder = build_transformer_layer_sequence(encoder)
+        self.decoder = build_transformer_layer_sequence(decoder)
+        self.embed_dims = embed_dims
+        self.num_feature_levels = num_feature_levels
+        self.num_cams = num_cams
+        self.fp16_enabled = False
+
+        self.rotate_prev_bev = rotate_prev_bev
+        self.use_shift = use_shift
+        self.use_can_bus = use_can_bus
+        self.len_can_bus = len_can_bus
+        self.can_bus_norm = can_bus_norm
+        self.use_cams_embeds = use_cams_embeds
+
+        self.two_stage_num_proposals = two_stage_num_proposals
+        self.init_layers()
+        self.rotate_center = rotate_center
+
+    def init_layers(self):
+        self.level_embeds = nn.Parameter(
+            torch.Tensor(self.num_feature_levels, self.embed_dims)
+        )
+        self.cams_embeds = nn.Parameter(torch.Tensor(self.num_cams, self.embed_dims))
+        self.reference_points = nn.Linear(self.embed_dims, 2)
+        self.can_bus_mlp = nn.Sequential(
+            nn.Linear(self.len_can_bus, self.embed_dims // 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(self.embed_dims // 2, self.embed_dims),
+            nn.ReLU(inplace=True),
+        )
+        if self.can_bus_norm:
+            self.can_bus_mlp.add_module("norm", nn.LayerNorm(self.embed_dims))
+
+    def init_weights(self):
+
+        for m in self.modules():
+            if (
+                isinstance(m, MSDeformableAttention3D)
+                or isinstance(m, TemporalSelfAttention)
+                or isinstance(m, CustomMSDeformableAttention)
+            ):
+                try:
+                    m.init_weight()
+                except AttributeError:
+                    m.init_weights()
+        normal_(self.level_embeds)
+        normal_(self.cams_embeds)
+        xavier_init(self.reference_points, distribution="uniform", bias=0.0)
+        xavier_init(self.can_bus_mlp, distribution="uniform", bias=0.0)
+
+    def attn_bev_encode(
+        self,
+        mlvl_feats,
+        bev_queries,
+        bev_h,
+        bev_w,
+        grid_length=[0.512, 0.512],
+        bev_pos=None,
+        prev_bev=None,
+        **kwargs,
+    ):
+        bs = mlvl_feats[0].size(0)
+        bev_queries = bev_queries.unsqueeze(1).repeat(1, bs, 1)
+        bev_pos = bev_pos.flatten(2).permute(2, 0, 1)
+
+        delta_x = np.array([each["can_bus"][0] for each in kwargs["img_metas"]])
+        delta_y = np.array([each["can_bus"][1] for each in kwargs["img_metas"]])
+        ego_angle = np.array(
+            [each["can_bus"][-2] / np.pi * 180 for each in kwargs["img_metas"]]
+        )
+        grid_length_y = grid_length[0]
+        grid_length_x = grid_length[1]
+        translation_length = np.sqrt(delta_x**2 + delta_y**2)
+        translation_angle = np.arctan2(delta_y, delta_x) / np.pi * 180
+        bev_angle = ego_angle - translation_angle
+        shift_y = (
+            translation_length * np.cos(bev_angle / 180 * np.pi) / grid_length_y / bev_h
+        )
+        shift_x = (
+            translation_length * np.sin(bev_angle / 180 * np.pi) / grid_length_x / bev_w
+        )
+        shift_y = shift_y * self.use_shift
+        shift_x = shift_x * self.use_shift
+        shift = bev_queries.new_tensor([shift_x, shift_y]).permute(1, 0)
+
+        can_bus = bev_queries.new_tensor(
+            [each["can_bus"] for each in kwargs["img_metas"]]
+        )
+        can_bus = self.can_bus_mlp(can_bus[:, : self.len_can_bus])[None, :, :]
+        bev_queries = bev_queries + can_bus * self.use_can_bus
+
+        feat_flatten = []
+        spatial_shapes = []
+        for lvl, feat in enumerate(mlvl_feats):
+            bs, num_cam, c, h, w = feat.shape
+            spatial_shape = (h, w)
+            feat = feat.flatten(3).permute(1, 0, 3, 2)
+            if self.use_cams_embeds:
+                feat = feat + self.cams_embeds[:, None, None, :].to(feat.dtype)
+            feat = feat + self.level_embeds[None, None, lvl : lvl + 1, :].to(feat.dtype)
+            spatial_shapes.append(spatial_shape)
+            feat_flatten.append(feat)
+
+        feat_flatten = torch.cat(feat_flatten, 2)
+        spatial_shapes = torch.as_tensor(
+            spatial_shapes, dtype=torch.long, device=bev_pos.device
+        )
+        level_start_index = torch.cat(
+            (spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1])
+        )
+
+        feat_flatten = feat_flatten.permute(0, 2, 1, 3)
+
+        bev_embed = self.encoder(
+            bev_queries,
+            feat_flatten,
+            feat_flatten,
+            bev_h=bev_h,
+            bev_w=bev_w,
+            bev_pos=bev_pos,
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+            prev_bev=prev_bev,
+            shift=shift,
+            **kwargs,
+        )
+        return bev_embed
+
+    def get_bev_features(
+        self,
+        mlvl_feats,
+        lidar_feat,
+        bev_queries,
+        bev_h,
+        bev_w,
+        grid_length=[0.512, 0.512],
+        bev_pos=None,
+        prev_bev=None,
+        **kwargs,
+    ):
+        if self.use_attn_bev:
+            bev_embed = self.attn_bev_encode(
+                mlvl_feats,
+                bev_queries,
+                bev_h,
+                bev_w,
+                grid_length=grid_length,
+                bev_pos=bev_pos,
+                prev_bev=prev_bev,
+                **kwargs,
+            )
+
+        return bev_embed
+
+    def forward(
+        self,
+        mlvl_feats,
+        lidar_feat,
+        bev_queries,
+        object_query_embed,
+        bev_h,
+        bev_w,
+        grid_length=[0.512, 0.512],
+        bev_pos=None,
+        reg_branches=None,
+        cls_branches=None,
+        prev_bev=None,
+        **kwargs,
+    ):
+        bev_embed = self.get_bev_features(
+            mlvl_feats,
+            lidar_feat,
+            bev_queries,
+            bev_h,
+            bev_w,
+            grid_length=grid_length,
+            bev_pos=bev_pos,
+            prev_bev=prev_bev,
+            **kwargs,
+        )
+
+        bs = mlvl_feats[0].size(0)
+        query_pos, query = torch.split(object_query_embed, self.embed_dims, dim=1)
+        query_pos = query_pos.unsqueeze(0).expand(bs, -1, -1)
+        query = query.unsqueeze(0).expand(bs, -1, -1)
+        reference_points = self.reference_points(query_pos)
+        reference_points = reference_points.sigmoid()
+        init_reference_out = reference_points
+
+        query = query.permute(1, 0, 2)
+        query_pos = query_pos.permute(1, 0, 2)
+        bev_embed = bev_embed.permute(1, 0, 2)
+
+        inter_states, inter_references = self.decoder(
+            query=query,
+            key=None,
+            value=bev_embed,
+            query_pos=query_pos,
+            reference_points=reference_points,
+            reg_branches=reg_branches,
+            cls_branches=cls_branches,
+            spatial_shapes=torch.tensor([[bev_h, bev_w]], device=query.device),
+            level_start_index=torch.tensor([0], device=query.device),
+            **kwargs,
+        )
+
+        inter_references_out = inter_references
+
+        return bev_embed, inter_states, init_reference_out, inter_references_out
+
+
+# ============================================================================
+# HEADS
+# ============================================================================
+@HEADS.register_module()
+class MapTRHead(DETRHead):
+    def __init__(
+        self,
+        *args,
+        with_box_refine=False,
+        as_two_stage=False,
+        transformer=None,
+        bbox_coder=None,
+        num_cls_fcs=2,
+        code_weights=None,
+        bev_h=30,
+        bev_w=30,
+        num_vec=20,
+        num_pts_per_vec=2,
+        num_pts_per_gt_vec=2,
+        query_embed_type="all_pts",
+        transform_method="minmax",
+        gt_shift_pts_pattern="v0",
+        dir_interval=1,
+        **kwargs,
+    ):
+
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.fp16_enabled = False
+
+        self.with_box_refine = with_box_refine
+        self.as_two_stage = as_two_stage
+        self.bev_encoder_type = transformer.encoder.type
+        if self.as_two_stage:
+            transformer["as_two_stage"] = self.as_two_stage
+        if "code_size" in kwargs:
+            self.code_size = kwargs["code_size"]
+
+        if code_weights is not None:
+            self.code_weights = code_weights
+
+        self.bbox_coder = build_bbox_coder(bbox_coder)
+        self.pc_range = self.bbox_coder.pc_range
+        self.real_w = self.pc_range[3] - self.pc_range[0]
+        self.real_h = self.pc_range[4] - self.pc_range[1]
+        self.num_cls_fcs = num_cls_fcs - 1
+
+        self.query_embed_type = query_embed_type
+        self.transform_method = transform_method
+        self.gt_shift_pts_pattern = gt_shift_pts_pattern
+        num_query = num_vec * num_pts_per_vec
+        self.num_query = num_query
+        self.num_vec = num_vec
+        self.num_pts_per_vec = num_pts_per_vec
+        self.num_pts_per_gt_vec = num_pts_per_gt_vec
+        self.dir_interval = dir_interval
+
+        super(MapTRHead, self).__init__(*args, transformer=transformer, **kwargs)
+        self.code_weights = nn.Parameter(
+            torch.tensor(self.code_weights, requires_grad=False), requires_grad=False
+        )
+        self._init_layers()
+
+    def _init_layers(self):
+        cls_branch = []
+        for _ in range(self.num_reg_fcs):
+            cls_branch.append(Linear(self.embed_dims, self.embed_dims))
+            cls_branch.append(nn.LayerNorm(self.embed_dims))
+            cls_branch.append(nn.ReLU(inplace=True))
+        cls_branch.append(Linear(self.embed_dims, self.cls_out_channels))
+        fc_cls = nn.Sequential(*cls_branch)
+
+        reg_branch = []
+        for _ in range(self.num_reg_fcs):
+            reg_branch.append(Linear(self.embed_dims, self.embed_dims))
+            reg_branch.append(nn.ReLU())
+        reg_branch.append(Linear(self.embed_dims, self.code_size))
+        reg_branch = nn.Sequential(*reg_branch)
+
+        def _get_clones(module, N):
+            return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+        num_pred = (
+            (self.transformer.decoder.num_layers + 1)
+            if self.as_two_stage
+            else self.transformer.decoder.num_layers
+        )
+
+        if self.with_box_refine:
+            self.cls_branches = _get_clones(fc_cls, num_pred)
+            self.reg_branches = _get_clones(reg_branch, num_pred)
+
+        if not self.as_two_stage:
+            if self.bev_encoder_type == "BEVFormerEncoder":
+                self.bev_embedding = nn.Embedding(
+                    self.bev_h * self.bev_w, self.embed_dims
+                )
+            if self.query_embed_type == "instance_pts":
+                self.query_embedding = None
+                self.instance_embedding = nn.Embedding(
+                    self.num_vec, self.embed_dims * 2
+                )
+                self.pts_embedding = nn.Embedding(
+                    self.num_pts_per_vec, self.embed_dims * 2
+                )
+
+    def init_weights(self):
+        self.transformer.init_weights()
+        if self.loss_cls.use_sigmoid:
+            bias_init = bias_init_with_prob(0.01)
+            for m in self.cls_branches:
+                nn.init.constant_(m[-1].bias, bias_init)
+
+    def forward(self, mlvl_feats, lidar_feat, img_metas, prev_bev=None, only_bev=False):
+        bs, num_cam, _, _, _ = mlvl_feats[0].shape
+        dtype = mlvl_feats[0].dtype
+
+        if self.query_embed_type == "instance_pts":
+            pts_embeds = self.pts_embedding.weight.unsqueeze(0)
+            instance_embeds = self.instance_embedding.weight.unsqueeze(1)
+            object_query_embeds = (pts_embeds + instance_embeds).flatten(0, 1).to(dtype)
+
+        if self.bev_embedding is not None:
+            bev_queries = self.bev_embedding.weight.to(dtype)
+
+            bev_mask = torch.zeros(
+                (bs, self.bev_h, self.bev_w), device=bev_queries.device
+            ).to(dtype)
+            bev_pos = self.positional_encoding(bev_mask).to(dtype)
+
+        outputs = self.transformer(
+            mlvl_feats,
+            lidar_feat,
+            bev_queries,
+            object_query_embeds,
+            self.bev_h,
+            self.bev_w,
+            grid_length=(self.real_h / self.bev_h, self.real_w / self.bev_w),
+            bev_pos=bev_pos,
+            reg_branches=self.reg_branches if self.with_box_refine else None,
+            cls_branches=self.cls_branches if self.as_two_stage else None,
+            img_metas=img_metas,
+            prev_bev=prev_bev,
+        )
+
+        bev_embed, hs, init_reference, inter_references = outputs
+        hs = hs.permute(0, 2, 1, 3)
+        outputs_classes = []
+        outputs_coords = []
+        outputs_pts_coords = []
+        for lvl in range(hs.shape[0]):
+            if lvl == 0:
+                reference = init_reference
+            else:
+                reference = inter_references[lvl - 1]
+            reference = inverse_sigmoid(reference)
+            outputs_class = self.cls_branches[lvl](
+                hs[lvl].view(bs, self.num_vec, self.num_pts_per_vec, -1).mean(2)
+            )
+            tmp = self.reg_branches[lvl](hs[lvl])
+
+            tmp[..., 0:2] += reference[..., 0:2]
+            tmp = tmp.sigmoid()
+            outputs_coord, outputs_pts_coord = self.transform_box(tmp)
+            outputs_classes.append(outputs_class)
+            outputs_coords.append(outputs_coord)
+            outputs_pts_coords.append(outputs_pts_coord)
+
+        outputs_classes = torch.stack(outputs_classes)
+        outputs_coords = torch.stack(outputs_coords)
+        outputs_pts_coords = torch.stack(outputs_pts_coords)
+        outs = {
+            "bev_embed": bev_embed,
+            "all_cls_scores": outputs_classes,
+            "all_bbox_preds": outputs_coords,
+            "all_pts_preds": outputs_pts_coords,
+            "enc_cls_scores": None,
+            "enc_bbox_preds": None,
+            "enc_pts_preds": None,
+        }
+
+        return outs
+
+    def transform_box(self, pts, y_first=False):
+
+        pts_reshape = pts.view(pts.shape[0], self.num_vec, self.num_pts_per_vec, 2)
+        pts_y = pts_reshape[:, :, :, 0] if y_first else pts_reshape[:, :, :, 1]
+        pts_x = pts_reshape[:, :, :, 1] if y_first else pts_reshape[:, :, :, 0]
+        if self.transform_method == "minmax":
+            xmin = pts_x.min(dim=2, keepdim=True)[0]
+            xmax = pts_x.max(dim=2, keepdim=True)[0]
+            ymin = pts_y.min(dim=2, keepdim=True)[0]
+            ymax = pts_y.max(dim=2, keepdim=True)[0]
+            bbox = torch.cat([xmin, ymin, xmax, ymax], dim=2)
+            bbox = bbox_xyxy_to_cxcywh(bbox)
+
+        return bbox, pts_reshape
+
+    def get_bboxes(self, preds_dicts, img_metas, rescale=False):
+        preds_dicts = self.bbox_coder.decode(preds_dicts)
+
+        num_samples = len(preds_dicts)
+        ret_list = []
+        for i in range(num_samples):
+            preds = preds_dicts[i]
+            bboxes = preds["bboxes"]
+            scores = preds["scores"]
+            labels = preds["labels"]
+            pts = preds["pts"]
+
+            ret_list.append([bboxes, scores, labels, pts])
+
+        return ret_list
+
+
+# ============================================================================
+# DETECTORS
+# ============================================================================
+
+
+@DETECTORS.register_module()
+class MVXTwoStageDetector(BaseDetector):
+    def __init__(
+        self,
+        pts_voxel_layer=None,
+        pts_voxel_encoder=None,
+        pts_middle_encoder=None,
+        pts_fusion_layer=None,
+        img_backbone=None,
+        pts_backbone=None,
+        img_neck=None,
+        pts_neck=None,
+        pts_bbox_head=None,
+        img_roi_head=None,
+        img_rpn_head=None,
+        train_cfg=None,
+        test_cfg=None,
+        pretrained=None,
+        init_cfg=None,
+    ):
+        super(MVXTwoStageDetector, self).__init__(init_cfg=init_cfg)
+
+        if pts_bbox_head:
+            pts_train_cfg = train_cfg.pts if train_cfg else None
+            pts_bbox_head.update(train_cfg=pts_train_cfg)
+            pts_test_cfg = test_cfg.pts if test_cfg else None
+            pts_bbox_head.update(test_cfg=pts_test_cfg)
+            self.pts_bbox_head = build_head(pts_bbox_head)
+
+        if img_backbone:
+            self.img_backbone = build_backbone(img_backbone)
+        if img_neck is not None:
+            self.img_neck = build_neck(img_neck)
+
+        self.test_cfg = test_cfg
+
+        img_pretrained = pretrained.get("img", None)
+        pts_pretrained = pretrained.get("pts", None)
+
+        if self.with_img_backbone:
+            if img_pretrained is not None:
+
+                self.img_backbone.init_cfg = dict(
+                    type="Pretrained", checkpoint=img_pretrained
+                )
+        if self.with_img_roi_head:
+            if img_pretrained is not None:
+
+                self.img_roi_head.init_cfg = dict(
+                    type="Pretrained", checkpoint=img_pretrained
+                )
+
+        if self.with_pts_backbone:
+            if pts_pretrained is not None:
+
+                self.pts_backbone.init_cfg = dict(
+                    type="Pretrained", checkpoint=pts_pretrained
+                )
+
+    @property
+    def with_img_backbone(self):
+        return hasattr(self, "img_backbone") and self.img_backbone is not None
+
+    @property
+    def with_pts_backbone(self):
+        return hasattr(self, "pts_backbone") and self.pts_backbone is not None
+
+    @property
+    def with_img_neck(self):
+        return hasattr(self, "img_neck") and self.img_neck is not None
+
+    @property
+    def with_img_roi_head(self):
+        return hasattr(self, "img_roi_head") and self.img_roi_head is not None
+
+    def aug_test(self, points, img_metas, imgs=None, rescale=False):
+        pass
+
+
+@DETECTORS.register_module()
+class MapTR(MVXTwoStageDetector):
+    def __init__(
+        self,
+        use_grid_mask=False,
+        pts_voxel_layer=None,
+        pts_voxel_encoder=None,
+        pts_middle_encoder=None,
+        pts_fusion_layer=None,
+        img_backbone=None,
+        pts_backbone=None,
+        img_neck=None,
+        pts_neck=None,
+        pts_bbox_head=None,
+        img_roi_head=None,
+        img_rpn_head=None,
+        train_cfg=None,
+        test_cfg=None,
+        pretrained=None,
+        video_test_mode=False,
+        modality="vision",
+        lidar_encoder=None,
+    ):
+
+        super(MapTR, self).__init__(
+            pts_voxel_layer,
+            pts_voxel_encoder,
+            pts_middle_encoder,
+            pts_fusion_layer,
+            img_backbone,
+            pts_backbone,
+            img_neck,
+            pts_neck,
+            pts_bbox_head,
+            img_roi_head,
+            img_rpn_head,
+            train_cfg,
+            test_cfg,
+            pretrained,
+        )
+        self.use_grid_mask = use_grid_mask
+        self.fp16_enabled = False
+        self.video_test_mode = video_test_mode
+        self.prev_frame_info = {
+            "prev_bev": None,
+            "scene_token": None,
+            "prev_pos": 0,
+            "prev_angle": 0,
+        }
+
+    def extract_img_feat(self, img, img_metas, len_queue=None):
+        B = img.size(0)
+        if img is not None:
+            if img.dim() == 5 and img.size(0) == 1:
+                img.squeeze_()
+            img_feats = self.img_backbone(img)
+
+        if self.with_img_neck:
+            img_feats = self.img_neck(img_feats)
+
+        img_feats_reshaped = []
+        for img_feat in img_feats:
+            BN, C, H, W = img_feat.size()
+            img_feats_reshaped.append(img_feat.view(B, int(BN / B), C, H, W))
+        return img_feats_reshaped
+
+    def extract_feat(self, img, img_metas=None, len_queue=None):
+        img_feats = self.extract_img_feat(img, img_metas, len_queue=len_queue)
+        return img_feats
+
+    def forward(self, **kwargs):
+        return self.forward_test(**kwargs)
+
+    def forward_test(self, img_metas, img=None, points=None, **kwargs):
+        img = [img] if img is None else img
+        points = [points] if points is None else points
+
+        if img_metas[0][0]["scene_token"] != self.prev_frame_info["scene_token"]:
+            self.prev_frame_info["prev_bev"] = None
+
+        self.prev_frame_info["scene_token"] = img_metas[0][0]["scene_token"]
+
+        if not self.video_test_mode:
+            self.prev_frame_info["prev_bev"] = None
+
+        tmp_pos = copy.deepcopy(img_metas[0][0]["can_bus"][:3])
+        tmp_angle = copy.deepcopy(img_metas[0][0]["can_bus"][-1])
+
+        img_metas[0][0]["can_bus"][-1] = 0
+        img_metas[0][0]["can_bus"][:3] = 0
+
+        new_prev_bev, bbox_results = self.simple_test(
+            img_metas[0],
+            img[0],
+            points[0],
+            prev_bev=self.prev_frame_info["prev_bev"],
+            **kwargs,
+        )
+        self.prev_frame_info["prev_pos"] = tmp_pos
+        self.prev_frame_info["prev_angle"] = tmp_angle
+        self.prev_frame_info["prev_bev"] = new_prev_bev
+        return bbox_results
+
+    def pred2result(self, bboxes, scores, labels, pts, attrs=None):
+
+        result_dict = dict(
+            boxes_3d=bboxes,
+            scores_3d=scores,
+            labels_3d=labels,
+            pts_3d=pts,
+        )
+
+        return result_dict
+
+    def simple_test_pts(self, x, lidar_feat, img_metas, prev_bev=None, rescale=False):
+        outs = self.pts_bbox_head(x, lidar_feat, img_metas, prev_bev=prev_bev)
+
+        bbox_list = self.pts_bbox_head.get_bboxes(outs, img_metas, rescale=rescale)
+
+        bbox_results = [
+            self.pred2result(bboxes, scores, labels, pts)
+            for bboxes, scores, labels, pts in bbox_list
+        ]
+        return outs["bev_embed"], bbox_results
+
+    def simple_test(
+        self, img_metas, img=None, points=None, prev_bev=None, rescale=False, **kwargs
+    ):
+        lidar_feat = None
+        img_feats = self.extract_feat(img=img, img_metas=img_metas)
+
+        bbox_list = [dict() for i in range(len(img_metas))]
+        new_prev_bev, bbox_pts = self.simple_test_pts(
+            img_feats, lidar_feat, img_metas, prev_bev, rescale=rescale
+        )
+        for result_dict, pts_bbox in zip(bbox_list, bbox_pts):
+            result_dict["pts_bbox"] = pts_bbox
+        return new_prev_bev, bbox_list


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1144

### Problem description

- Bringup MapTR's Bevformer variants

### What's changed

- This PR adds model support for MapTR's Bevformer variants([tiny_r50_24e_bevformer](https://github.com/hustvl/MapTR/blob/a6872d8d9670bde17b4b01560f1221f88b443d55/projects/configs/maptr/maptr_tiny_r50_24e_bevformer.py), [tiny_r50_24e_bevformer_t4](https://github.com/hustvl/MapTR/blob/a6872d8d9670bde17b4b01560f1221f88b443d55/projects/configs/maptr/maptr_tiny_r50_24e_bevformer_t4.py))

**Note :**

- The model requires the following packages (installed using --no-deps to avoid sub-dependency conflicts):
```
mmcv-full==1.7.2  
mmdet==2.28.2  
yapf==0.43.0   # required for mmcv
```
- Currently, we are passing random inputs due to [#146](https://github.com/tenstorrent/tt-forge-models/issues/146) , and the above set of packages is sufficient in that case.

- If in the future we move to passing actual inputs, the following additional packages will also be required for data preprocessing (these too can be installed with --no-deps):

```
nuscenes-devkit==1.2.0  
pyquaternion==0.9.9  
cachetools==6.2.0   # required for nuscenes-devkit
```

- Results were verified by passing actual inputs on GPU vs our current environment, and they match with PCC = 1. [sep17_maptr_bev_pcc_comp.log](https://github.com/user-attachments/files/22413351/sep17_maptr_bev_pcc_comp.log)

- Visual comparisons:
  - [bevformer results comp(org GPU vs our cpu impl)](https://www.diffchecker.com/jOZV721C/)
  - [bevformer t4 results comp(org GPU vs our cpu impl)](https://www.diffchecker.com/E1bkqAES/)

### Checklist
- [x] verified the changes on local testing 

### Logs

- [sep18_maptr_results_for_rand_inputs.log](https://github.com/user-attachments/files/22413361/sep18_maptr_filter_12.log)

