### PR TITLE
UNIAD Pytorch Model Bringup

### DIFF
--- a/uniad/pytorch/__init__.py
+++ b/uniad/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+UNIAD PYTORCH model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/uniad/pytorch/loader.py
+++ b/uniad/pytorch/loader.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+UniAD model loader implementation
+"""
+import torch
+from typing import Optional
+from ...base import ForgeModel
+from ...config import ModelGroup, ModelTask, ModelSource, Framework, StrEnum, ModelInfo
+from ...tools.utils import get_file
+from third_party.tt_forge_models.uniad.pytorch.src.uniad_e2e import UniAD
+from third_party.tt_forge_models.uniad.pytorch.src.track_utils import (
+    LiDARInstance3DBoxes,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available UniAD model variants for autonomous driving."""
+
+    UNIAD_E2E = "uniad_e2e"
+
+
+class ModelLoader(ForgeModel):
+    """UniAD model loader implementation for autonomous driving tasks."""
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.UNIAD_E2E
+
+    def __init__(self, variant=None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        # Configuration parameters
+        self.processor = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+
+        return ModelInfo(
+            model="uniad",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.CV_OBJECT_DET,
+            source=ModelSource.CUSTOM,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, **kwargs):
+        """Load and return the UniAD model instance with default settings.
+
+        Returns:
+            Torch model: The UniAD model instance.
+        """
+        # Load model with defaults
+        model = UniAD()
+        checkpoint_path = get_file("test_files/pytorch/uniad/uniad_e2e.pth")
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+        model.load_state_dict(
+            checkpoint["state_dict"] if "state_dict" in checkpoint else checkpoint,
+            strict=False,
+        )
+        return model
+
+    def load_inputs(self, **kwargs):
+        """Return sample inputs for the UniAD model with default settings.
+
+        Returns:
+            dict: A dictionary of input tensors and metadata suitable for the model.
+        """
+        img_tensor = img_tensor = [
+            torch.randn(1, 6, 3, 928, 1600, dtype=torch.float) * 50
+        ]
+        img_metas = [
+            [
+                {
+                    "ori_shape": [(900, 1600, 3)] * 6,
+                    "img_shape": [(928, 1600, 3)] * 6,
+                    "lidar2img": [
+                        torch.randn(4, 4, dtype=torch.float32) * 500 for _ in range(6)
+                    ],
+                    "box_type_3d": LiDARInstance3DBoxes,
+                    "sample_idx": "3e8750f331d7499e9b5123e9eb70f2e2",
+                    "scene_token": "fcbccedd61424f1b85dcbf8f897f9754",
+                    "can_bus": torch.randn(18, dtype=torch.float64) * 300,
+                }
+            ]
+        ]
+
+        timestamp = [torch.tensor([1533151603.5476])]
+        l2g_r_mat = torch.randn(1, 3, 3)
+        l2g_t = torch.randn(1, 3) * 800
+
+        gt_lane_labels = [torch.randint(0, 4, (1, 12))]
+        gt_lane_bboxes = [torch.randint(0, 200, (1, 12, 4))]
+        gt_segmentation = [torch.randint(0, 256, (1, 7, 200, 200))]
+        gt_lane_masks = [torch.zeros((1, 12, 200, 200), dtype=torch.uint8)]
+
+        gt_instance = [torch.randint(0, 318, (1, 7, 200, 200))]
+        gt_centerness = [torch.randint(0, 256, (1, 7, 1, 200, 200))]
+        gt_offset = [torch.randint(-5, 256, (1, 7, 2, 200, 200))]
+        gt_flow = [torch.full((1, 7, 2, 200, 200), 255)]
+        gt_backward_flow = [torch.full((1, 7, 2, 200, 200), 255)]
+        gt_occ_has_invalid_frame = [torch.ones((1,), dtype=torch.long)]
+        gt_occ_img_is_valid = [torch.randint(0, 2, (1, 9))]
+
+        sdc_planning = [torch.rand(1, 1, 6, 3) * 25]
+        sdc_planning_mask = [torch.ones(1, 1, 6, 2)]
+        command = [torch.tensor([0])]
+
+        kwargs = {
+            "command": command,
+            "gt_backward_flow": gt_backward_flow,
+            "gt_centerness": gt_centerness,
+            "gt_flow": gt_flow,
+            "gt_instance": gt_instance,
+            "gt_lane_bboxes": gt_lane_bboxes,
+            "gt_lane_labels": gt_lane_labels,
+            "gt_lane_masks": gt_lane_masks,
+            "gt_occ_has_invalid_frame": gt_occ_has_invalid_frame,
+            "gt_occ_img_is_valid": gt_occ_img_is_valid,
+            "gt_offset": gt_offset,
+            "gt_segmentation": gt_segmentation,
+            "img": [img_tensor],
+            "img_metas": img_metas,
+            "l2g_r_mat": l2g_r_mat,
+            "l2g_t": l2g_t,
+            "rescale": True,
+            "sdc_planning": sdc_planning,
+            "sdc_planning_mask": sdc_planning_mask,
+            "timestamp": timestamp,
+        }
+
+        return kwargs

--- a/uniad/pytorch/src/motion_head.py
+++ b/uniad/pytorch/src/motion_head.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from third_party.tt_forge_models.uniad.pytorch.src.motion_utils import *
+from ....tools.utils import get_file
+
+
+class MotionHead(BaseMotionHead):
+    """
+    MotionHead module for a neural network, which predicts motion trajectories and is used in an autonomous driving task.
+
+    Args:
+        *args: Variable length argument list.
+        predict_steps (int): The number of steps to predict motion trajectories.
+        transformerlayers (dict): A dictionary defining the configuration of transformer layers.
+        bbox_coder: An instance of a bbox coder to be used for encoding/decoding boxes.
+        num_cls_fcs (int): The number of fully-connected layers in the classification branch.
+        bev_h (int): The height of the bird's-eye-view map.
+        bev_w (int): The width of the bird's-eye-view map.
+        embed_dims (int): The number of dimensions to use for the query and key vectors in transformer layers.
+        num_anchor (int): The number of anchor points.
+        det_layer_num (int): The number of layers in the transformer model.
+        group_id_list (list): A list of group IDs to use for grouping the classes.
+        pc_range: The range of the point cloud.
+        use_nonlinear_optimizer (bool): A boolean indicating whether to use a non-linear optimizer for training.
+        anchor_info_path (str): The path to the file containing the anchor information.
+        vehicle_id_list(list[int]): class id of vehicle class, used for filtering out non-vehicle objects
+    """
+
+    def __init__(
+        self,
+        *args,
+        predict_steps=12,
+        transformerlayers=MotionTransformerDecoder(),
+        bev_h=200,
+        bev_w=200,
+        num_query=300,
+        num_classes=10,
+        predict_modes=6,
+        embed_dims=256,
+        num_cls_fcs=3,
+        pc_range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+        group_id_list=[[0, 1, 2, 3, 4], [6, 7], [8], [5, 9]],
+        num_anchor=6,
+        use_nonlinear_optimizer=True,
+        vehicle_id_list=[0, 1, 2, 3, 4, 6, 7],
+        det_layer_num=6,
+        anchor_info_path=get_file(
+            "test_files/pytorch/uniad/motion_anchor_infos_mode6.pkl"
+        )
+    ):
+        super(MotionHead, self).__init__()
+
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.num_cls_fcs = num_cls_fcs - 1
+        self.num_reg_fcs = num_cls_fcs - 1
+        self.embed_dims = embed_dims
+        self.num_anchor = num_anchor
+        self.num_anchor_group = len(group_id_list)
+
+        self.cls2group = [0 for i in range(num_classes)]
+        for i, grouped_ids in enumerate(group_id_list):
+            for gid in grouped_ids:
+                self.cls2group[gid] = i
+        self.cls2group = torch.tensor(self.cls2group)
+        self.pc_range = [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0]
+        self.predict_steps = predict_steps
+        self.vehicle_id_list = vehicle_id_list
+
+        self.use_nonlinear_optimizer = use_nonlinear_optimizer
+        self._load_anchors(anchor_info_path)
+        self._build_layers(transformerlayers, det_layer_num)
+        self._init_layers()
+
+    def forward_test(self, bev_embed, outs_track={}, outs_seg={}):
+        """Test function"""
+        track_query = outs_track["track_query_embeddings"][None, None, ...]
+        track_boxes = outs_track["track_bbox_results"]
+
+        track_query = torch.cat(
+            [track_query, outs_track["sdc_embedding"][None, None, None, :]], dim=2
+        )
+        sdc_track_boxes = outs_track["sdc_track_bbox_results"]
+
+        track_boxes[0][0].tensor = torch.cat(
+            [track_boxes[0][0].tensor, sdc_track_boxes[0][0].tensor], dim=0
+        )
+        track_boxes[0][1] = torch.cat([track_boxes[0][1], sdc_track_boxes[0][1]], dim=0)
+        track_boxes[0][2] = torch.cat([track_boxes[0][2], sdc_track_boxes[0][2]], dim=0)
+        track_boxes[0][3] = torch.cat([track_boxes[0][3], sdc_track_boxes[0][3]], dim=0)
+        (
+            memory,
+            memory_mask,
+            memory_pos,
+            lane_query,
+            _,
+            lane_query_pos,
+            hw_lvl,
+        ) = outs_seg["args_tuple"]
+        outs_motion = self(
+            bev_embed, track_query, lane_query, lane_query_pos, track_boxes
+        )
+        traj_results = self.get_trajs(outs_motion, track_boxes)
+        bboxes, scores, labels, bbox_index, mask = track_boxes[0]
+        outs_motion["track_scores"] = scores[None, :]
+        labels[-1] = 0
+
+        def filter_vehicle_query(outs_motion, labels, vehicle_id_list):
+            if len(labels) < 1:
+                return None
+
+            vehicle_mask = torch.zeros_like(labels)
+            for veh_id in vehicle_id_list:
+                vehicle_mask |= labels == veh_id
+            outs_motion["traj_query"] = outs_motion["traj_query"][
+                :, :, vehicle_mask > 0
+            ]
+            outs_motion["track_query"] = outs_motion["track_query"][:, vehicle_mask > 0]
+            outs_motion["track_query_pos"] = outs_motion["track_query_pos"][
+                :, vehicle_mask > 0
+            ]
+            outs_motion["track_scores"] = outs_motion["track_scores"][
+                :, vehicle_mask > 0
+            ]
+            return outs_motion
+
+        outs_motion = filter_vehicle_query(outs_motion, labels, self.vehicle_id_list)
+
+        outs_motion["sdc_traj_query"] = outs_motion["traj_query"][:, :, -1]
+        outs_motion["sdc_track_query"] = outs_motion["track_query"][:, -1]
+        outs_motion["sdc_track_query_pos"] = outs_motion["track_query_pos"][:, -1]
+        outs_motion["traj_query"] = outs_motion["traj_query"][:, :, :-1]
+        outs_motion["track_query"] = outs_motion["track_query"][:, :-1]
+        outs_motion["track_query_pos"] = outs_motion["track_query_pos"][:, :-1]
+        outs_motion["track_scores"] = outs_motion["track_scores"][:, :-1]
+
+        return traj_results, outs_motion
+
+    def forward(
+        self, bev_embed, track_query, lane_query, lane_query_pos, track_bbox_results
+    ):
+        """
+        Applies forward pass on the model for motion prediction using bird's eye view (BEV) embedding, track query, lane query, and track bounding box results.
+
+        Args:
+        bev_embed (torch.Tensor): A tensor of shape (h*w, B, D) representing the bird's eye view embedding.
+        track_query (torch.Tensor): A tensor of shape (B, num_dec, A_track, D) representing the track query.
+        lane_query (torch.Tensor): A tensor of shape (N, M_thing, D) representing the lane query.
+        lane_query_pos (torch.Tensor): A tensor of shape (N, M_thing, D) representing the position of the lane query.
+        track_bbox_results (List[torch.Tensor]): A list of tensors containing the tracking bounding box results for each image in the batch.
+
+        Returns:
+        dict: A dictionary containing the following keys and values:
+        - 'all_traj_scores': A tensor of shape (num_levels, B, A_track, num_points) with trajectory scores for each level.
+        - 'all_traj_preds': A tensor of shape (num_levels, B, A_track, num_points, num_future_steps, 2) with predicted trajectories for each level.
+        - 'valid_traj_masks': A tensor of shape (B, A_track) indicating the validity of trajectory masks.
+        - 'traj_query': A tensor containing intermediate states of the trajectory queries.
+        - 'track_query': A tensor containing the input track queries.
+        - 'track_query_pos': A tensor containing the positional embeddings of the track queries.
+        """
+
+        dtype = track_query.dtype
+        num_groups = self.kmeans_anchors.shape[0]
+
+        track_query = track_query[:, -1]
+        reference_points_track = self._extract_tracking_centers(
+            track_bbox_results, self.pc_range
+        )
+        track_query_pos = self.boxes_query_embedding_layer(
+            pos2posemb2d(reference_points_track)
+        )
+
+        learnable_query_pos = self.learnable_motion_query_embedding.weight.to(dtype)
+        learnable_query_pos = torch.stack(
+            torch.split(learnable_query_pos, self.num_anchor, dim=0)
+        )
+
+        agent_level_anchors = (
+            self.kmeans_anchors.to(dtype)
+            .view(num_groups, self.num_anchor, self.predict_steps, 2)
+            .detach()
+        )
+        scene_level_ego_anchors = anchor_coordinate_transform(
+            agent_level_anchors, track_bbox_results, with_translation_transform=True
+        )
+        scene_level_offset_anchors = anchor_coordinate_transform(
+            agent_level_anchors, track_bbox_results, with_translation_transform=False
+        )
+
+        agent_level_norm = norm_points(agent_level_anchors, self.pc_range)
+        scene_level_ego_norm = norm_points(scene_level_ego_anchors, self.pc_range)
+        scene_level_offset_norm = norm_points(scene_level_offset_anchors, self.pc_range)
+
+        agent_level_embedding = self.agent_level_embedding_layer(
+            pos2posemb2d(agent_level_norm[..., -1, :])
+        )
+        scene_level_ego_embedding = self.scene_level_ego_embedding_layer(
+            pos2posemb2d(scene_level_ego_norm[..., -1, :])
+        )
+        scene_level_offset_embedding = self.scene_level_offset_embedding_layer(
+            pos2posemb2d(scene_level_offset_norm[..., -1, :])
+        )
+
+        batch_size, num_agents = scene_level_ego_embedding.shape[:2]
+        agent_level_embedding = agent_level_embedding[None, None, ...].expand(
+            batch_size, num_agents, -1, -1, -1
+        )
+        learnable_embed = learnable_query_pos[None, None, ...].expand(
+            batch_size, num_agents, -1, -1, -1
+        )
+
+        scene_level_offset_anchors = self.group_mode_query_pos(
+            track_bbox_results, scene_level_offset_anchors
+        )
+
+        agent_level_embedding = self.group_mode_query_pos(
+            track_bbox_results, agent_level_embedding
+        )
+        scene_level_ego_embedding = self.group_mode_query_pos(
+            track_bbox_results, scene_level_ego_embedding
+        )
+
+        scene_level_offset_embedding = self.group_mode_query_pos(
+            track_bbox_results, scene_level_offset_embedding
+        )
+        learnable_embed = self.group_mode_query_pos(track_bbox_results, learnable_embed)
+
+        init_reference = scene_level_offset_anchors.detach()
+
+        outputs_traj_scores = []
+        outputs_trajs = []
+
+        inter_states, inter_references = self.motionformer(
+            track_query,
+            lane_query,
+            track_query_pos=track_query_pos,
+            lane_query_pos=lane_query_pos,
+            track_bbox_results=track_bbox_results,
+            bev_embed=bev_embed,
+            reference_trajs=init_reference,
+            traj_reg_branches=self.traj_reg_branches,
+            traj_cls_branches=self.traj_cls_branches,
+            agent_level_embedding=agent_level_embedding,
+            scene_level_ego_embedding=scene_level_ego_embedding,
+            scene_level_offset_embedding=scene_level_offset_embedding,
+            learnable_embed=learnable_embed,
+            agent_level_embedding_layer=self.agent_level_embedding_layer,
+            scene_level_ego_embedding_layer=self.scene_level_ego_embedding_layer,
+            scene_level_offset_embedding_layer=self.scene_level_offset_embedding_layer,
+            spatial_shapes=torch.tensor([[self.bev_h, self.bev_w]]),
+            level_start_index=torch.tensor([0]),
+        )
+
+        for lvl in range(inter_states.shape[0]):
+            outputs_class = self.traj_cls_branches[lvl](inter_states[lvl])
+            tmp = self.traj_reg_branches[lvl](inter_states[lvl])
+            self.unflatten_traj = nn.Unflatten(3, (self.predict_steps, 5))
+            self.log_softmax = nn.LogSoftmax(dim=2)
+            tmp = self.unflatten_traj(tmp)
+
+            tmp[..., :2] = torch.cumsum(tmp[..., :2], dim=3)
+
+            outputs_class = self.log_softmax(outputs_class.squeeze(3))
+            outputs_traj_scores.append(outputs_class)
+
+            for bs in range(tmp.shape[0]):
+                tmp[bs] = bivariate_gaussian_activation(tmp[bs])
+            outputs_trajs.append(tmp)
+        outputs_traj_scores = torch.stack(outputs_traj_scores)
+        outputs_trajs = torch.stack(outputs_trajs)
+
+        B, A_track, D = track_query.shape
+        valid_traj_masks = track_query.new_ones((B, A_track)) > 0
+        outs = {
+            "all_traj_scores": outputs_traj_scores,
+            "all_traj_preds": outputs_trajs,
+            "valid_traj_masks": valid_traj_masks,
+            "traj_query": inter_states,
+            "track_query": track_query,
+            "track_query_pos": track_query_pos,
+        }
+
+        return outs
+
+    def group_mode_query_pos(self, bbox_results, mode_query_pos):
+        """
+        Group mode query positions based on the input bounding box results.
+
+        Args:
+            bbox_results (List[Tuple[torch.Tensor]]): A list of tuples containing the bounding box results for each image in the batch.
+            mode_query_pos (torch.Tensor): A tensor of shape (B, A, G, P, D) representing the mode query positions.
+
+        Returns:
+            torch.Tensor: A tensor of shape (B, A, P, D) representing the classified mode query positions.
+        """
+        batch_size = len(bbox_results)
+        agent_num = mode_query_pos.shape[1]
+        batched_mode_query_pos = []
+        self.cls2group = self.cls2group
+
+        for i in range(batch_size):
+            bboxes, scores, labels, bbox_index, mask = bbox_results[i]
+            label = labels
+            grouped_label = self.cls2group[label]
+            grouped_mode_query_pos = []
+            for j in range(agent_num):
+                grouped_mode_query_pos.append(mode_query_pos[i, j, grouped_label[j]])
+            batched_mode_query_pos.append(torch.stack(grouped_mode_query_pos))
+        return torch.stack(batched_mode_query_pos)
+
+    def compute_matched_gt_traj(
+        self,
+        gt_fut_traj,
+        gt_fut_traj_mask,
+        all_matched_idxes,
+        track_bbox_results,
+        gt_bboxes_3d,
+    ):
+        """
+        Computes the matched ground truth trajectories for a batch of images based on matched indexes.
+
+        Args:
+        gt_fut_traj (torch.Tensor): Ground truth future trajectories of shape (num_imgs, num_objects, num_future_steps, 2).
+        gt_fut_traj_mask (torch.Tensor): Ground truth future trajectory masks of shape (num_imgs, num_objects, num_future_steps, 2).
+        all_matched_idxes (List[torch.Tensor]): A list of tensors containing the matched indexes for each image in the batch.
+        track_bbox_results (List[torch.Tensor]): A list of tensors containing the tracking bounding box results for each image in the batch.
+        gt_bboxes_3d (List[torch.Tensor]): A list of tensors containing the ground truth 3D bounding boxes for each image in the batch.
+
+        Returns:
+        torch.Tensor: A concatenated tensor of the matched ground truth future trajectories.
+        torch.Tensor: A concatenated tensor of the matched ground truth future trajectory masks.
+        """
+        num_imgs = len(all_matched_idxes)
+        gt_fut_traj_all = []
+        gt_fut_traj_mask_all = []
+        for i in range(num_imgs):
+            matched_gt_idx = all_matched_idxes[i]
+            valid_traj_masks = matched_gt_idx >= 0
+            matched_gt_fut_traj = gt_fut_traj[i][matched_gt_idx][valid_traj_masks]
+            matched_gt_fut_traj_mask = gt_fut_traj_mask[i][matched_gt_idx][
+                valid_traj_masks
+            ]
+        gt_fut_traj_all = torch.cat(gt_fut_traj_all, dim=0)
+        gt_fut_traj_mask_all = torch.cat(gt_fut_traj_mask_all, dim=0)
+        return gt_fut_traj_all, gt_fut_traj_mask_all
+
+    def get_trajs(self, preds_dicts, bbox_results):
+        """
+        Generates trajectories from the prediction results, bounding box results.
+
+        Args:
+            preds_dicts (tuple[list[dict]]): A tuple containing lists of dictionaries with prediction results.
+            bbox_results (List[Tuple[torch.Tensor]]): A list of tuples containing the bounding box results for each image in the batch.
+
+        Returns:
+            List[dict]: A list of dictionaries containing decoded bounding boxes, scores, and labels after non-maximum suppression.
+        """
+        num_samples = len(bbox_results)
+        num_layers = preds_dicts["all_traj_preds"].shape[0]
+        ret_list = []
+        for i in range(num_samples):
+            preds = dict()
+            for j in range(num_layers):
+                subfix = "_" + str(j) if j < (num_layers - 1) else ""
+                traj = preds_dicts["all_traj_preds"][j, i]
+                traj_scores = preds_dicts["all_traj_scores"][j, i]
+
+                traj_scores, traj = traj_scores, traj
+                preds["traj" + subfix] = traj
+                preds["traj_scores" + subfix] = traj_scores
+            ret_list.append(preds)
+        return ret_list

--- a/uniad/pytorch/src/motion_utils.py
+++ b/uniad/pytorch/src/motion_utils.py
@@ -1,0 +1,1192 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch.nn as nn
+import torch
+import copy
+import pickle
+import math
+from einops import rearrange
+import warnings
+import torch.nn.functional as F
+from third_party.tt_forge_models.uniad.pytorch.src.transformer import (
+    FFN,
+    multi_scale_deformable_attn_pytorch,
+)
+
+
+def bivariate_gaussian_activation(ip):
+    """
+    Activation function to output parameters of bivariate Gaussian distribution.
+
+    Args:
+        ip (torch.Tensor): Input tensor.
+
+    Returns:
+        torch.Tensor: Output tensor containing the parameters of the bivariate Gaussian distribution.
+    """
+    mu_x = ip[..., 0:1]
+    mu_y = ip[..., 1:2]
+    sig_x = ip[..., 2:3]
+    sig_y = ip[..., 3:4]
+    rho = ip[..., 4:5]
+    sig_x = torch.exp(sig_x)
+    sig_y = torch.exp(sig_y)
+    rho = torch.tanh(rho)
+    out = torch.cat([mu_x, mu_y, sig_x, sig_y, rho], dim=-1)
+    return out
+
+
+def norm_points(pos, pc_range):
+    """
+    Normalize the end points of a given position tensor.
+
+    Args:
+        pos (torch.Tensor): Input position tensor.
+        pc_range (List[float]): Point cloud range.
+
+    Returns:
+        torch.Tensor: Normalized end points tensor.
+    """
+    x_norm = (pos[..., 0] - pc_range[0]) / (pc_range[3] - pc_range[0])
+    y_norm = (pos[..., 1] - pc_range[1]) / (pc_range[4] - pc_range[1])
+    return torch.stack([x_norm, y_norm], dim=-1)
+
+
+def pos2posemb2d(pos, num_pos_feats=128, temperature=10000):
+    """
+    Convert 2D position into positional embeddings.
+
+    Args:
+        pos (torch.Tensor): Input 2D position tensor.
+        num_pos_feats (int, optional): Number of positional features. Default is 128.
+        temperature (int, optional): Temperature factor for positional embeddings. Default is 10000.
+
+    Returns:
+        torch.Tensor: Positional embeddings tensor.
+    """
+    scale = 2 * math.pi
+    pos = pos * scale
+    dim_t = torch.arange(num_pos_feats, dtype=torch.float32)
+    dim_t = temperature ** (2 * (dim_t // 2) / num_pos_feats)
+    pos_x = pos[..., 0, None] / dim_t
+    pos_y = pos[..., 1, None] / dim_t
+    pos_x = torch.stack(
+        (pos_x[..., 0::2].sin(), pos_x[..., 1::2].cos()), dim=-1
+    ).flatten(-2)
+    pos_y = torch.stack(
+        (pos_y[..., 0::2].sin(), pos_y[..., 1::2].cos()), dim=-1
+    ).flatten(-2)
+    posemb = torch.cat((pos_y, pos_x), dim=-1)
+    return posemb
+
+
+def rot_2d(yaw):
+    """
+    Compute 2D rotation matrix for a given yaw angle tensor.
+
+    Args:
+        yaw (torch.Tensor): Input yaw angle tensor.
+
+    Returns:
+        torch.Tensor: 2D rotation matrix tensor.
+    """
+    sy, cy = torch.sin(yaw), torch.cos(yaw)
+    out = torch.stack([torch.stack([cy, -sy]), torch.stack([sy, cy])]).permute(
+        [2, 0, 1]
+    )
+    return out
+
+
+def anchor_coordinate_transform(
+    anchors, bbox_results, with_translation_transform=True, with_rotation_transform=True
+):
+    """
+    Transform anchor coordinates with respect to detected bounding boxes in the batch.
+
+    Args:
+        anchors (torch.Tensor): A tensor containing the k-means anchor values.
+        bbox_results (List[Tuple[torch.Tensor]]): A list of tuples containing the bounding box results for each image in the batch.
+        with_translate (bool, optional): Whether to perform translation transformation. Defaults to True.
+        with_rot (bool, optional): Whether to perform rotation transformation. Defaults to True.
+
+    Returns:
+        torch.Tensor: A tensor containing the transformed anchor coordinates.
+    """
+    batch_size = len(bbox_results)
+    batched_anchors = []
+    transformed_anchors = anchors[None, ...]
+    for i in range(batch_size):
+        bboxes, scores, labels, bbox_index, mask = bbox_results[i]
+        yaw = bboxes.yaw.to(transformed_anchors)
+        bbox_centers = bboxes.gravity_center.to(transformed_anchors)
+        if with_rotation_transform:
+            angle = yaw - 3.1415953
+            rot_yaw = rot_2d(angle)
+            rot_yaw = rot_yaw[:, None, None, :, :]
+            transformed_anchors = rearrange(
+                transformed_anchors, "b g m t c -> b g m c t"
+            )
+            transformed_anchors = torch.matmul(rot_yaw, transformed_anchors)
+            transformed_anchors = rearrange(
+                transformed_anchors, "b g m c t -> b g m t c"
+            )
+        if with_translation_transform:
+            transformed_anchors = (
+                bbox_centers[:, None, None, None, :2] + transformed_anchors
+            )
+        batched_anchors.append(transformed_anchors)
+    return torch.stack(batched_anchors)
+
+
+def trajectory_coordinate_transform(
+    trajectory,
+    bbox_results,
+    with_translation_transform=True,
+    with_rotation_transform=True,
+):
+    """
+    Transform trajectory coordinates with respect to detected bounding boxes in the batch.
+    Args:
+        trajectory (torch.Tensor): predicted trajectory.
+        bbox_results (List[Tuple[torch.Tensor]]): A list of tuples containing the bounding box results for each image in the batch.
+        with_translate (bool, optional): Whether to perform translation transformation. Defaults to True.
+        with_rot (bool, optional): Whether to perform rotation transformation. Defaults to True.
+
+    Returns:
+        torch.Tensor: A tensor containing the transformed trajectory coordinates.
+    """
+    batch_size = len(bbox_results)
+    batched_trajectories = []
+    for i in range(batch_size):
+        bboxes, scores, labels, bbox_index, mask = bbox_results[i]
+        yaw = bboxes.yaw.to(trajectory)
+        bbox_centers = bboxes.gravity_center.to(trajectory)
+        transformed_trajectory = trajectory[i, ...]
+        if with_rotation_transform:
+
+            angle = -(yaw - 3.1415953)
+            rot_yaw = rot_2d(angle)
+            rot_yaw = rot_yaw[:, None, None, :, :]
+            transformed_trajectory = rearrange(
+                transformed_trajectory, "a g p t c -> a g p c t"
+            )
+            transformed_trajectory = torch.matmul(rot_yaw, transformed_trajectory)
+            transformed_trajectory = rearrange(
+                transformed_trajectory, "a g p c t -> a g p t c"
+            )
+        if with_translation_transform:
+            transformed_trajectory = (
+                bbox_centers[:, None, None, None, :2] + transformed_trajectory
+            )
+        batched_trajectories.append(transformed_trajectory)
+    return torch.stack(batched_trajectories)
+
+
+class BaseMotionHead(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super(BaseMotionHead, self).__init__()
+        pass
+
+    def _load_anchors(self, anchor_info_path):
+        """
+        Load the anchor information from a file.
+
+        Args:
+            anchor_info_path (str): The path to the file containing the anchor information.
+
+        Returns:
+            None
+        """
+        anchor_infos = pickle.load(open(anchor_info_path, "rb"))
+        self.kmeans_anchors = torch.stack(
+            [torch.from_numpy(a) for a in anchor_infos["anchors_all"]]
+        )
+
+    def _build_layers(self, transformerlayers, det_layer_num):
+        """
+        Build the layers of the motion prediction module.
+
+        Args:
+            transformerlayers (dict): A dictionary containing the parameters for the transformer layers.
+            det_layer_num (int): The number of detection layers.
+
+        Returns:
+            None
+        """
+        self.learnable_motion_query_embedding = nn.Embedding(
+            self.num_anchor * self.num_anchor_group, self.embed_dims
+        )
+        self.motionformer = MotionTransformerDecoder()
+
+        self.layer_track_query_fuser = nn.Sequential(
+            nn.Linear(self.embed_dims * det_layer_num, self.embed_dims),
+            nn.LayerNorm(self.embed_dims),
+            nn.ReLU(inplace=True),
+        )
+
+        self.agent_level_embedding_layer = nn.Sequential(
+            nn.Linear(self.embed_dims, self.embed_dims * 2),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims * 2, self.embed_dims),
+        )
+        self.scene_level_ego_embedding_layer = nn.Sequential(
+            nn.Linear(self.embed_dims, self.embed_dims * 2),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims * 2, self.embed_dims),
+        )
+        self.scene_level_offset_embedding_layer = nn.Sequential(
+            nn.Linear(self.embed_dims, self.embed_dims * 2),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims * 2, self.embed_dims),
+        )
+        self.boxes_query_embedding_layer = nn.Sequential(
+            nn.Linear(self.embed_dims, self.embed_dims * 2),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims * 2, self.embed_dims),
+        )
+
+    def _init_layers(self):
+        """Initialize classification branch and regression branch of head."""
+        traj_cls_branch = []
+        traj_cls_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+        traj_cls_branch.append(nn.LayerNorm(self.embed_dims))
+        traj_cls_branch.append(nn.ReLU(inplace=True))
+        for _ in range(self.num_reg_fcs - 1):
+            traj_cls_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+            traj_cls_branch.append(nn.LayerNorm(self.embed_dims))
+            traj_cls_branch.append(nn.ReLU(inplace=True))
+        traj_cls_branch.append(nn.Linear(self.embed_dims, 1))
+        traj_cls_branch = nn.Sequential(*traj_cls_branch)
+
+        traj_reg_branch = []
+        traj_reg_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+        traj_reg_branch.append(nn.ReLU())
+        for _ in range(self.num_reg_fcs - 1):
+            traj_reg_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+            traj_reg_branch.append(nn.ReLU())
+        traj_reg_branch.append(nn.Linear(self.embed_dims, self.predict_steps * 5))
+        traj_reg_branch = nn.Sequential(*traj_reg_branch)
+
+        def _get_clones(module, N):
+            return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+        num_pred = self.motionformer.num_layers
+        self.traj_cls_branches = _get_clones(traj_cls_branch, num_pred)
+        self.traj_reg_branches = _get_clones(traj_reg_branch, num_pred)
+
+    def _extract_tracking_centers(self, bbox_results, bev_range):
+        """
+        extract the bboxes centers and normized according to the bev range
+
+        Args:
+            bbox_results (List[Tuple[torch.Tensor]]): A list of tuples containing the bounding box results for each image in the batch.
+            bev_range (List[float]): A list of float values representing the bird's eye view range.
+
+        Returns:
+            torch.Tensor: A tensor representing normized centers of the detection bounding boxes.
+        """
+        boxes, scores, labels, bbox_index, mask = bbox_results[0]
+        batch_size = len(bbox_results)
+        det_bbox_posembed = []
+        for i in range(batch_size):
+            bboxes, scores, labels, bbox_index, mask = bbox_results[i]
+            if bboxes is None:
+                return torch.empty(0, 2), torch.empty(0, dtype=torch.bool)
+            xy = bboxes.gravity_center[:, :2]
+            x_norm = (xy[:, 0] - bev_range[0]) / (bev_range[3] - bev_range[0])
+            y_norm = (xy[:, 1] - bev_range[1]) / (bev_range[4] - bev_range[1])
+            det_bbox_posembed.append(
+                torch.cat([x_norm[:, None], y_norm[:, None]], dim=-1)
+            )
+        return torch.stack(det_bbox_posembed)
+
+
+class MotionTransformerDecoder(nn.Module):
+    """Implements the decoder in DETR3D transformer.
+    Args:
+        return_intermediate (bool): Whether to return intermediate outputs.
+        coder_norm_cfg (dict): Config of last normalization layer. Default：
+            `LN`.
+    """
+
+    def __init__(
+        self,
+        pc_range=None,
+        embed_dims=256,
+        transformerlayers=None,
+        num_layers=3,
+        **kwargs,
+    ):
+        super(MotionTransformerDecoder, self).__init__()
+        self.pc_range = [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0]
+        self.embed_dims = 256
+        self.num_layers = 3
+        self.intention_interaction_layers = IntentionInteraction()
+        self.track_agent_interaction_layers = nn.ModuleList(
+            [TrackAgentInteraction() for i in range(self.num_layers)]
+        )
+        self.map_interaction_layers = nn.ModuleList(
+            [MapInteraction() for i in range(self.num_layers)]
+        )
+        self.bev_interaction_layers = nn.ModuleList(
+            [
+                MotionTransformerAttentionLayer(
+                    attn_cfgs=[MotionDeformableAttention()],
+                )
+                for _ in range(self.num_layers)
+            ]
+        )
+
+        self.static_dynamic_fuser = nn.Sequential(
+            nn.Linear(self.embed_dims * 2, self.embed_dims * 2),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims * 2, self.embed_dims),
+        )
+        self.dynamic_embed_fuser = nn.Sequential(
+            nn.Linear(self.embed_dims * 3, self.embed_dims * 2),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims * 2, self.embed_dims),
+        )
+        self.in_query_fuser = nn.Sequential(
+            nn.Linear(self.embed_dims * 2, self.embed_dims * 2),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims * 2, self.embed_dims),
+        )
+        self.out_query_fuser = nn.Sequential(
+            nn.Linear(self.embed_dims * 4, self.embed_dims * 2),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims * 2, self.embed_dims),
+        )
+
+    def forward(
+        self,
+        track_query,
+        lane_query,
+        track_query_pos=None,
+        lane_query_pos=None,
+        track_bbox_results=None,
+        bev_embed=None,
+        reference_trajs=None,
+        traj_reg_branches=None,
+        agent_level_embedding=None,
+        scene_level_ego_embedding=None,
+        scene_level_offset_embedding=None,
+        learnable_embed=None,
+        agent_level_embedding_layer=None,
+        scene_level_ego_embedding_layer=None,
+        scene_level_offset_embedding_layer=None,
+        **kwargs,
+    ):
+        """Forward function for `MotionTransformerDecoder`.
+        Args:
+            agent_query (B, A, D)
+            map_query (B, M, D)
+            map_query_pos (B, G, D)
+            static_intention_embed (B, A, P, D)
+            offset_query_embed (B, A, P, D)
+            global_intention_embed (B, A, P, D)
+            learnable_intention_embed (B, A, P, D)
+            det_query_pos (B, A, D)
+        Returns:
+            None
+        """
+        intermediate = []
+        intermediate_reference_trajs = []
+
+        B, _, P, D = agent_level_embedding.shape
+        track_query_bc = track_query.unsqueeze(2).expand(-1, -1, P, -1)
+        track_query_pos_bc = track_query_pos.unsqueeze(2).expand(-1, -1, P, -1)
+
+        agent_level_embedding = self.intention_interaction_layers(agent_level_embedding)
+        static_intention_embed = (
+            agent_level_embedding + scene_level_offset_embedding + learnable_embed
+        )
+        reference_trajs_input = reference_trajs.unsqueeze(4).detach()
+
+        query_embed = torch.zeros_like(static_intention_embed)
+        for lid in range(self.num_layers):
+            dynamic_query_embed = self.dynamic_embed_fuser(
+                torch.cat(
+                    [
+                        agent_level_embedding,
+                        scene_level_offset_embedding,
+                        scene_level_ego_embedding,
+                    ],
+                    dim=-1,
+                )
+            )
+
+            query_embed_intention = self.static_dynamic_fuser(
+                torch.cat([static_intention_embed, dynamic_query_embed], dim=-1)
+            )
+
+            query_embed = self.in_query_fuser(
+                torch.cat([query_embed, query_embed_intention], dim=-1)
+            )
+
+            track_query_embed = self.track_agent_interaction_layers[lid](
+                query_embed,
+                track_query,
+                query_pos=track_query_pos_bc,
+                key_pos=track_query_pos,
+            )
+
+            map_query_embed = self.map_interaction_layers[lid](
+                query_embed,
+                lane_query,
+                query_pos=track_query_pos_bc,
+                key_pos=lane_query_pos,
+            )
+
+            bev_query_embed = self.bev_interaction_layers[lid](
+                query_embed,
+                value=bev_embed,
+                query_pos=track_query_pos_bc,
+                bbox_results=track_bbox_results,
+                reference_trajs=reference_trajs_input,
+                **kwargs,
+            )
+
+            query_embed = [
+                track_query_embed,
+                map_query_embed,
+                bev_query_embed,
+                track_query_bc + track_query_pos_bc,
+            ]
+            query_embed = torch.cat(query_embed, dim=-1)
+            query_embed = self.out_query_fuser(query_embed)
+
+            if traj_reg_branches is not None:
+                tmp = traj_reg_branches[lid](query_embed)
+                bs, n_agent, n_modes, n_steps, _ = reference_trajs.shape
+                tmp = tmp.view(bs, n_agent, n_modes, n_steps, -1)
+
+                tmp[..., :2] = torch.cumsum(tmp[..., :2], dim=3)
+                new_reference_trajs = torch.zeros_like(reference_trajs)
+                new_reference_trajs = tmp[..., :2]
+                reference_trajs = new_reference_trajs.detach()
+                reference_trajs_input = reference_trajs.unsqueeze(4)
+
+                ep_offset_embed = reference_trajs.detach()
+                ep_ego_embed = (
+                    trajectory_coordinate_transform(
+                        reference_trajs.unsqueeze(2),
+                        track_bbox_results,
+                        with_translation_transform=True,
+                        with_rotation_transform=False,
+                    )
+                    .squeeze(2)
+                    .detach()
+                )
+                ep_agent_embed = (
+                    trajectory_coordinate_transform(
+                        reference_trajs.unsqueeze(2),
+                        track_bbox_results,
+                        with_translation_transform=False,
+                        with_rotation_transform=True,
+                    )
+                    .squeeze(2)
+                    .detach()
+                )
+
+                agent_level_embedding = agent_level_embedding_layer(
+                    pos2posemb2d(norm_points(ep_agent_embed[..., -1, :], self.pc_range))
+                )
+                scene_level_ego_embedding = scene_level_ego_embedding_layer(
+                    pos2posemb2d(norm_points(ep_ego_embed[..., -1, :], self.pc_range))
+                )
+                scene_level_offset_embedding = scene_level_offset_embedding_layer(
+                    pos2posemb2d(
+                        norm_points(ep_offset_embed[..., -1, :], self.pc_range)
+                    )
+                )
+
+                intermediate.append(query_embed)
+                intermediate_reference_trajs.append(reference_trajs)
+
+        return torch.stack(intermediate), torch.stack(intermediate_reference_trajs)
+
+
+class TrackAgentInteraction(nn.Module):
+    """
+    Modeling the interaction between the agents
+    """
+
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+    ):
+        super().__init__()
+        self.batch_first = batch_first
+        self.interaction_transformer = nn.TransformerDecoderLayer(
+            d_model=embed_dims,
+            nhead=num_heads,
+            dropout=dropout,
+            dim_feedforward=embed_dims * 2,
+            batch_first=batch_first,
+        )
+
+    def forward(self, query, key, query_pos=None, key_pos=None):
+        """
+        query: context query (B, A, P, D)
+        query_pos: mode pos embedding (B, A, P, D)
+        key: (B, A, D)
+        key_pos: (B, A, D)
+        """
+        B, A, P, D = query.shape
+        if query_pos is not None:
+            query = query + query_pos
+        if key_pos is not None:
+            key = key + key_pos
+        mem = key.expand(B * A, -1, -1)
+        query = torch.flatten(query, start_dim=0, end_dim=1)
+        query = self.interaction_transformer(query, mem)
+        query = query.view(B, A, P, D)
+        return query
+
+
+class MapInteraction(nn.Module):
+    """
+    Modeling the interaction between the agent and the map
+    """
+
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+    ):
+        super().__init__()
+
+        self.batch_first = batch_first
+        self.interaction_transformer = nn.TransformerDecoderLayer(
+            d_model=embed_dims,
+            nhead=num_heads,
+            dropout=dropout,
+            dim_feedforward=embed_dims * 2,
+            batch_first=batch_first,
+        )
+
+    def forward(self, query, key, query_pos=None, key_pos=None):
+        """
+        x: context query (B, A, P, D)
+        query_pos: mode pos embedding (B, A, P, D)
+        """
+        B, A, P, D = query.shape
+        if query_pos is not None:
+            query = query + query_pos
+        if key_pos is not None:
+            key = key + key_pos
+
+        query = torch.flatten(query, start_dim=0, end_dim=1)
+        mem = key.expand(B * A, -1, -1)
+        query = self.interaction_transformer(query, mem)
+        query = query.view(B, A, P, D)
+        return query
+
+
+class IntentionInteraction(nn.Module):
+    """
+    Modeling the interaction between anchors
+    """
+
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+    ):
+        super().__init__()
+        self.batch_first = batch_first
+        self.interaction_transformer = nn.TransformerEncoderLayer(
+            d_model=embed_dims,
+            nhead=num_heads,
+            dropout=dropout,
+            dim_feedforward=embed_dims * 2,
+            batch_first=batch_first,
+        )
+
+    def forward(self, query):
+        B, A, P, D = query.shape
+        rebatch_x = torch.flatten(query, start_dim=0, end_dim=1)
+        rebatch_x = self.interaction_transformer(rebatch_x)
+        out = rebatch_x.view(B, A, P, D)
+        return out
+
+
+class MotionTransformerAttentionLayer(nn.Module):
+    """Base `TransformerLayer` for vision transformer.
+    It can be built from `mmcv.ConfigDict` and support more flexible
+    customization, for example, using any number of `FFN or LN ` and
+    use different kinds of `attention` by specifying a list of `ConfigDict`
+    named `attn_cfgs`. It is worth mentioning that it supports `prenorm`
+    when you specifying `norm` as the first element of `operation_order`.
+    More details about the `prenorm`: `On Layer Normalization in the
+    Transformer Architecture <https://arxiv.org/abs/2002.04745>`_ .
+    Args:
+        attn_cfgs (list[`mmcv.ConfigDict`] | obj:`mmcv.ConfigDict` | None )):
+            Configs for `self_attention` or `cross_attention` modules,
+            The order of the configs in the list should be consistent with
+            corresponding attentions in operation_order.
+            If it is a dict, all of the attention modules in operation_order
+            will be built with this config. Default: None.
+        ffn_cfgs (list[`mmcv.ConfigDict`] | obj:`mmcv.ConfigDict` | None )):
+            Configs for FFN, The order of the configs in the list should be
+            consistent with corresponding ffn in operation_order.
+            If it is a dict, all of the attention modules in operation_order
+            will be built with this config.
+        operation_order (tuple[str]): The execution order of operation
+            in transformer. Such as ('self_attn', 'norm', 'ffn', 'norm').
+            Support `prenorm` when you specifying first element as `norm`.
+            Default：None.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: dict(type='LN').
+        batch_first (bool): Key, Query and Value are shape
+            of (batch, n, embed_dim)
+            or (n, batch, embed_dim). Default to False.
+    """
+
+    def __init__(
+        self,
+        attn_cfgs=None,
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=512,
+            num_fcs=2,
+            ffn_drop=0.1,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=("cross_attn", "norm", "ffn", "norm"),
+        norm_cfg=dict(type="LN"),
+        batch_first=True,
+        **kwargs,
+    ):
+        deprecated_args = dict(
+            feedforward_channels="feedforward_channels",
+            ffn_dropout="ffn_drop",
+            ffn_num_fcs="num_fcs",
+        )
+        for ori_name, new_name in deprecated_args.items():
+            if ori_name in kwargs:
+                warnings.warn(
+                    f"The arguments `{ori_name}` in BaseTransformerLayer "
+                    f"has been deprecated, now you should set `{new_name}` "
+                    f"and other FFN related arguments "
+                    f"to a dict named `ffn_cfgs`. ",
+                    DeprecationWarning,
+                )
+                ffn_cfgs[new_name] = kwargs[ori_name]
+
+        super().__init__()
+
+        self.batch_first = batch_first
+
+        num_attn = operation_order.count("self_attn") + operation_order.count(
+            "cross_attn"
+        )
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+        else:
+            assert num_attn == len(attn_cfgs), (
+                f"The length "
+                f"of attn_cfg {num_attn} is "
+                f"not consistent with the number of attention"
+                f"in operation_order {operation_order}."
+            )
+
+        self.num_attn = num_attn
+        self.operation_order = operation_order
+        self.norm_cfg = norm_cfg
+        self.pre_norm = operation_order[0] == "norm"
+        self.attentions = nn.ModuleList()
+
+        index = 0
+        for operation_name in operation_order:
+            if operation_name in ["self_attn", "cross_attn"]:
+                attention = MotionDeformableAttention()
+                attention.operation_name = operation_name
+                self.attentions.append(attention)
+                index += 1
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        self.ffns = nn.ModuleList()
+        self.ffns.append(
+            FFN(
+                embed_dims=256,
+                feedforward_channels=512,
+                num_fcs=2,
+                ffn_drop=0.1,
+                act_cfg=dict(type="ReLU", inplace=True),
+            )
+        )
+        self.norms = nn.ModuleList()
+        num_norms = operation_order.count("norm")
+        for _ in range(num_norms):
+            self.norms.append(nn.LayerNorm(self.embed_dims))
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        """Forward function for `TransformerDecoderLayer`.
+        **kwargs contains some specific arguments of attentions.
+        Args:
+            query (Tensor): The input query with shape
+                [num_queries, bs, embed_dims] if
+                self.batch_first is False, else
+                [bs, num_queries embed_dims].
+            key (Tensor): The key tensor with shape [num_keys, bs,
+                embed_dims] if self.batch_first is False, else
+                [bs, num_keys, embed_dims] .
+            value (Tensor): The value tensor with same shape as `key`.
+            query_pos (Tensor): The positional encoding for `query`.
+                Default: None.
+            key_pos (Tensor): The positional encoding for `key`.
+                Default: None.
+            attn_masks (List[Tensor] | None): 2D Tensor used in
+                calculation of corresponding attention. The length of
+                it should equal to the number of `attention` in
+                `operation_order`. Default: None.
+            query_key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_queries]. Only used in `self_attn` layer.
+                Defaults to None.
+            key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_keys]. Default: None.
+        Returns:
+            Tensor: forwarded results with shape [num_queries, bs, embed_dims].
+        """
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        attn_masks = [None for _ in range(self.num_attn)]
+
+        for layer in self.operation_order:
+            if layer == "self_attn":
+                temp_key = temp_value = query
+                query = self.attentions[attn_index](
+                    query,
+                    temp_key,
+                    temp_value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=query_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "norm":
+                query = self.norms[norm_index](query)
+                norm_index += 1
+
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+                ffn_index += 1
+
+        return query
+
+
+class MotionDeformableAttention(nn.Module):
+    """An attention module used in Deformable-Detr.
+
+    `Deformable DETR: Deformable Transformers for End-to-End Object Detection.
+    <https://arxiv.org/pdf/2010.04159.pdf>`_.
+
+    Args:
+        embed_dims (int): The embedding dimension of Attention.
+            Default: 256.
+        num_heads (int): Parallel attention heads. Default: 64.
+        num_levels (int): The number of feature map used in
+            Attention. Default: 4.
+        num_points (int): The number of sampling points for
+            each query in each head. Default: 4.
+        im2col_step (int): The step used in image_to_column.
+            Default: 64.
+        dropout (float): A Dropout layer on `inp_identity`.
+            Default: 0.1.
+        batch_first (bool): Key, Query and Value are shape of
+            (batch, n, embed_dim)
+            or (n, batch, embed_dim). Default to False.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: None.
+    """
+
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=1,
+        num_points=4,
+        num_steps=12,
+        sample_index=-1,
+        im2col_step=64,
+        dropout=0.1,
+        bev_range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+        voxel_size=[0.2, 0.2, 8],
+        batch_first=True,
+        norm_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(
+                f"embed_dims must be divisible by num_heads, "
+                f"but got {embed_dims} and {num_heads}"
+            )
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+        self.bev_range = bev_range
+
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError(
+                    "invalid input for _is_power_of_2: {} (type: {})".format(n, type(n))
+                )
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.num_steps = num_steps
+        self.sample_index = sample_index
+        self.sampling_offsets = nn.Linear(
+            embed_dims, num_heads * num_steps * num_levels * num_points * 2
+        )
+        self.attention_weights = nn.Linear(
+            embed_dims, num_heads * num_steps * num_levels * num_points
+        )
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+        self.output_proj = nn.Sequential(
+            nn.Linear(num_steps * embed_dims, embed_dims),
+            nn.LayerNorm(embed_dims),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        bbox_results=None,
+        reference_trajs=None,
+        flag="decoder",
+        **kwargs,
+    ):
+        """Forward Function of MultiScaleDeformAttention.
+
+        Args:
+            query (Tensor): Query of Transformer with shape
+                (num_query, bs, embed_dims).
+            key (Tensor): The key tensor with shape
+                `(num_key, bs, embed_dims)`.
+            value (Tensor): The value tensor with shape
+                `(num_key, bs, embed_dims)`.
+            identity (Tensor): The tensor used for addition, with the
+                same shape as `query`. Default None. If None,
+                `query` will be used.
+            query_pos (Tensor): The positional encoding for `query`.
+                Default: None.
+            key_pos (Tensor): The positional encoding for `key`. Default
+                None.
+            reference_points (Tensor):  The normalized reference
+                points with shape (bs, num_query, num_levels, 2),
+                all elements is range in [0, 1], top-left (0,0),
+                bottom-right (1, 1), including padding area.
+                or (N, Length_{query}, num_levels, 4), add
+                additional two dimensions is (w, h) to
+                form reference boxes.
+            key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_key].
+            spatial_shapes (Tensor): Spatial shape of features in
+                different levels. With shape (num_levels, 2),
+                last dimension represents (h, w).
+            level_start_index (Tensor): The start index of each level.
+                A tensor has shape ``(num_levels, )`` and can be represented
+                as [0, h_0*w_0, h_0*w_0+h_1*w_1, ...].
+
+        Returns:
+             Tensor: forwarded results with shape [num_query, bs, embed_dims].
+        """
+        bs, num_agent, num_mode, _ = query.shape
+        num_query = num_agent * num_mode
+        if value is None:
+            value = query
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        query = torch.flatten(query, start_dim=1, end_dim=2)
+
+        value = value.permute(1, 0, 2)
+        bs, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+
+        value = self.value_proj(value)
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+        value = value.view(bs, num_value, self.num_heads, -1)
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_steps,
+            self.num_levels,
+            self.num_points,
+            2,
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_steps,
+            self.num_levels * self.num_points,
+        )
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_steps,
+            self.num_levels,
+            self.num_points,
+        )
+
+        reference_trajs = reference_trajs[:, :, :, [self.sample_index], :, :]
+        reference_trajs_ego = self.agent_coords_to_ego_coords(
+            copy.deepcopy(reference_trajs), bbox_results
+        ).detach()
+        reference_trajs_ego = torch.flatten(reference_trajs_ego, start_dim=1, end_dim=2)
+        reference_trajs_ego = reference_trajs_ego[:, :, None, :, :, None, :]
+        reference_trajs_ego[..., 0] -= self.bev_range[0]
+        reference_trajs_ego[..., 1] -= self.bev_range[1]
+        reference_trajs_ego[..., 0] /= self.bev_range[3] - self.bev_range[0]
+        reference_trajs_ego[..., 1] /= self.bev_range[4] - self.bev_range[1]
+        offset_normalizer = torch.stack(
+            [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1
+        )
+        sampling_locations = (
+            reference_trajs_ego
+            + sampling_offsets / offset_normalizer[None, None, None, None, :, None, :]
+        )
+
+        sampling_locations = rearrange(
+            sampling_locations, "bs nq nh ns nl np c -> bs nq ns nh nl np c"
+        )
+        attention_weights = rearrange(
+            attention_weights, "bs nq nh ns nl np -> bs nq ns nh nl np"
+        )
+        sampling_locations = sampling_locations.reshape(
+            bs,
+            num_query * self.num_steps,
+            self.num_heads,
+            self.num_levels,
+            self.num_points,
+            2,
+        )
+        attention_weights = attention_weights.reshape(
+            bs,
+            num_query * self.num_steps,
+            self.num_heads,
+            self.num_levels,
+            self.num_points,
+        )
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+        output = output.view(bs, num_query, self.num_steps, -1)
+        output = torch.flatten(output, start_dim=2, end_dim=3)
+        output = self.output_proj(output)
+        output = output.view(bs, num_agent, num_mode, -1)
+        return self.dropout(output) + identity
+
+    def agent_coords_to_ego_coords(self, reference_trajs, bbox_results):
+        batch_size = len(bbox_results)
+        reference_trajs_ego = []
+        for i in range(batch_size):
+            boxes_3d, scores, labels, bbox_index, mask = bbox_results[i]
+            det_centers = boxes_3d.gravity_center.to(reference_trajs)
+            batch_reference_trajs = reference_trajs[i]
+            batch_reference_trajs += det_centers[:, None, None, None, :2]
+            reference_trajs_ego.append(batch_reference_trajs)
+        return torch.stack(reference_trajs_ego)
+
+
+class CustomModeMultiheadAttention(nn.Module):
+    """A wrapper for ``torch.nn.MultiheadAttention``.
+    This module implements MultiheadAttention with identity connection,
+    and positional encoding  is also passed as input.
+    Args:
+        embed_dims (int): The embedding dimension.
+        num_heads (int): Parallel attention heads.
+        attn_drop (float): A Dropout layer on attn_output_weights.
+            Default: 0.0.
+        proj_drop (float): A Dropout layer after `nn.MultiheadAttention`.
+            Default: 0.0.
+        dropout_layer (obj:`ConfigDict`): The dropout_layer used
+            when adding the shortcut.
+        batch_first (bool): When it is True,  Key, Query and Value are shape of
+            (batch, n, embed_dim), otherwise (n, batch, embed_dim).
+             Default to False.
+    """
+
+    def __init__(
+        self,
+        embed_dims,
+        num_heads,
+        attn_drop=0.0,
+        proj_drop=0.0,
+        dropout_layer=dict(type="Dropout", drop_prob=0.0),
+        **kwargs,
+    ):
+        super().__init__()
+        if "dropout" in kwargs:
+            warnings.warn(
+                "The arguments `dropout` in MultiheadAttention "
+                "has been deprecated, now you can separately "
+                "set `attn_drop`(float), proj_drop(float), "
+                "and `dropout_layer`(dict) ",
+                DeprecationWarning,
+            )
+            attn_drop = kwargs["dropout"]
+            dropout_layer["drop_prob"] = kwargs.pop("dropout")
+
+        self.embed_dims = embed_dims
+        self.num_heads = num_heads
+
+        self.attn = nn.MultiheadAttention(embed_dims, num_heads, attn_drop, **kwargs)
+
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.dropout_layer = (
+            nn.Dropout(p=dropout_layer.get("drop_prob", 0.1))
+            if dropout_layer
+            else nn.Identity()
+        )
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_pos=None,
+        attn_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        """Forward function for `MultiheadAttention`.
+        **kwargs allow passing a more general data flow when combining
+        with other operations in `transformerlayer`.
+        Args:
+            query (Tensor): The input query with shape [num_queries, bs,
+                embed_dims] if self.batch_first is False, else
+                [bs, num_queries embed_dims].
+            key (Tensor): The key tensor with shape [num_keys, bs,
+                embed_dims] if self.batch_first is False, else
+                [bs, num_keys, embed_dims] .
+                If None, the ``query`` will be used. Defaults to None.
+            value (Tensor): The value tensor with same shape as `key`.
+                Same in `nn.MultiheadAttention.forward`. Defaults to None.
+                If None, the `key` will be used.
+            identity (Tensor): This tensor, with the same shape as x,
+                will be used for the identity link.
+                If None, `x` will be used. Defaults to None.
+            query_pos (Tensor): The positional encoding for query, with
+                the same shape as `x`. If not None, it will
+                be added to `x` before forward function. Defaults to None.
+            key_pos (Tensor): The positional encoding for `key`, with the
+                same shape as `key`. Defaults to None. If not None, it will
+                be added to `key` before forward function. If None, and
+                `query_pos` has the same shape as `key`, then `query_pos`
+                will be used for `key_pos`. Defaults to None.
+            attn_mask (Tensor): ByteTensor mask with shape [num_queries,
+                num_keys]. Same in `nn.MultiheadAttention.forward`.
+                Defaults to None.
+            key_padding_mask (Tensor): ByteTensor with shape [bs, num_keys].
+                Defaults to None.
+        Returns:
+            Tensor: forwarded results with shape
+            [num_queries, bs, embed_dims]
+            if self.batch_first is False, else
+            [bs, num_queries embed_dims].
+        """
+        query_pos = query_pos.unsqueeze(1)
+        key_pos = key_pos.unsqueeze(1)
+        bs, n_agent, n_query, D = query.shape
+
+        query = torch.flatten(query, start_dim=0, end_dim=1)
+        key = torch.flatten(key, start_dim=0, end_dim=1)
+        value = torch.flatten(value, start_dim=0, end_dim=1)
+        identity = torch.flatten(identity, start_dim=0, end_dim=1)
+
+        query = query.transpose(0, 1)
+        key = key.transpose(0, 1)
+        value = value.transpose(0, 1)
+
+        out = self.attn(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+            key_padding_mask=key_padding_mask,
+        )[0]
+
+        out = out.transpose(0, 1)
+        out = identity + self.dropout_layer(self.proj_drop(out))
+
+        return out.view(bs, n_agent, n_query, D)

--- a/uniad/pytorch/src/occ_head.py
+++ b/uniad/pytorch/src/occ_head.py
@@ -1,0 +1,303 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+import copy
+from third_party.tt_forge_models.uniad.pytorch.src.occ_utils import *
+
+
+def _get_clones(module, N):
+    return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+
+class OccHead(nn.Module):
+    def __init__(
+        self,
+        receptive_field=3,
+        n_future=4,
+        spatial_extent=(50, 50),
+        ignore_index=255,
+        grid_conf={
+            "xbound": [-50.0, 50.0, 0.5],
+            "ybound": [-50.0, 50.0, 0.5],
+            "zbound": [-10.0, 10.0, 20.0],
+        },
+        bev_size=(200, 200),
+        bev_emb_dim=256,
+        bev_proj_dim=256,
+        bev_proj_nlayers=4,
+        query_dim=256,
+        query_mlp_layers=3,
+        detach_query_pos=True,
+        temporal_mlp_layer=2,
+        transformer_decoder=DetrTransformerDecoder(),
+        attn_mask_thresh=0.3,
+        sample_ignore_mode="all_valid",
+        pan_eval=True,
+        test_seg_thresh: float = 0.1,
+        test_with_track_score=True,
+    ):
+        super().__init__()
+        self.receptive_field = receptive_field
+        self.n_future = n_future
+        self.spatial_extent = spatial_extent
+        self.ignore_index = ignore_index
+
+        bevformer_bev_conf = {
+            "xbound": [-51.2, 51.2, 0.512],
+            "ybound": [-51.2, 51.2, 0.512],
+            "zbound": [-10.0, 10.0, 20.0],
+        }
+        self.bev_sampler = BevFeatureSlicer(bevformer_bev_conf, grid_conf)
+
+        self.bev_size = bev_size
+        self.bev_proj_dim = bev_proj_dim
+
+        self.bev_light_proj = SimpleConv2d(
+            in_channels=bev_emb_dim,
+            conv_channels=bev_emb_dim,
+            out_channels=bev_proj_dim,
+            num_conv=bev_proj_nlayers,
+        )
+
+        self.base_downscale = nn.Sequential(
+            Bottleneck(in_channels=bev_proj_dim, downsample=True),
+            Bottleneck(in_channels=bev_proj_dim, downsample=True),
+        )
+
+        self.n_future_blocks = self.n_future + 1
+
+        self.attn_mask_thresh = attn_mask_thresh
+
+        self.num_trans_layers = 5
+        assert self.num_trans_layers % self.n_future_blocks == 0
+
+        self.num_heads = 8
+        self.transformer_decoder = DetrTransformerDecoder()
+
+        temporal_mlp = MLP(
+            query_dim, query_dim, bev_proj_dim, num_layers=temporal_mlp_layer
+        )
+        self.temporal_mlps = _get_clones(temporal_mlp, self.n_future_blocks)
+
+        downscale_conv = Bottleneck(in_channels=bev_proj_dim, downsample=True)
+        self.downscale_convs = _get_clones(downscale_conv, self.n_future_blocks)
+
+        upsample_add = UpsamplingAdd(
+            in_channels=bev_proj_dim, out_channels=bev_proj_dim
+        )
+        self.upsample_adds = _get_clones(upsample_add, self.n_future_blocks)
+
+        self.dense_decoder = CVT_Decoder(
+            dim=bev_proj_dim,
+            blocks=[bev_proj_dim, bev_proj_dim],
+        )
+
+        self.mode_fuser = nn.Sequential(
+            nn.Linear(query_dim, bev_proj_dim),
+            nn.LayerNorm(bev_proj_dim),
+            nn.ReLU(inplace=True),
+        )
+        self.multi_query_fuser = nn.Sequential(
+            nn.Linear(query_dim * 3, query_dim * 2),
+            nn.LayerNorm(query_dim * 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(query_dim * 2, bev_proj_dim),
+        )
+
+        self.detach_query_pos = detach_query_pos
+
+        self.query_to_occ_feat = MLP(
+            query_dim, query_dim, bev_proj_dim, num_layers=query_mlp_layers
+        )
+        self.temporal_mlp_for_mask = copy.deepcopy(self.query_to_occ_feat)
+
+        self.sample_ignore_mode = sample_ignore_mode
+        assert self.sample_ignore_mode in ["all_valid", "past_valid", "none"]
+
+        self.pan_eval = pan_eval
+        self.test_seg_thresh = test_seg_thresh
+
+        self.test_with_track_score = test_with_track_score
+
+    def get_attn_mask(self, state, ins_query):
+        ins_embed = self.temporal_mlp_for_mask(ins_query)
+        mask_pred = torch.einsum("bqc,bchw->bqhw", ins_embed, state)
+        attn_mask = mask_pred.sigmoid() < self.attn_mask_thresh
+        attn_mask = (
+            rearrange(attn_mask, "b q h w -> b (h w) q")
+            .unsqueeze(1)
+            .repeat(1, self.num_heads, 1, 1)
+            .flatten(0, 1)
+        )
+        attn_mask = attn_mask.detach()
+
+        attn_mask[torch.where(attn_mask.sum(-1) == attn_mask.shape[-1])] = False
+
+        upsampled_mask_pred = F.interpolate(
+            mask_pred, self.bev_size, mode="bilinear", align_corners=False
+        )
+
+        return attn_mask, upsampled_mask_pred, ins_embed
+
+    def forward(self, x, ins_query):
+        base_state = rearrange(x, "(h w) b d -> b d h w", h=self.bev_size[0])
+
+        base_state = self.bev_sampler(base_state)
+        base_state = self.bev_light_proj(base_state)
+        base_state = self.base_downscale(base_state)
+        base_ins_query = ins_query
+
+        last_state = base_state
+        last_ins_query = base_ins_query
+        future_states = []
+        mask_preds = []
+        temporal_query = []
+        temporal_embed_for_mask_attn = []
+        n_trans_layer_each_block = self.num_trans_layers // self.n_future_blocks
+        assert n_trans_layer_each_block >= 1
+
+        for i in range(self.n_future_blocks):
+            cur_state = self.downscale_convs[i](last_state)
+
+            cur_ins_query = self.temporal_mlps[i](last_ins_query)
+            temporal_query.append(cur_ins_query)
+
+            attn_mask, mask_pred, cur_ins_emb_for_mask_attn = self.get_attn_mask(
+                cur_state, cur_ins_query
+            )
+            attn_masks = [None, attn_mask]
+
+            mask_preds.append(mask_pred)
+            temporal_embed_for_mask_attn.append(cur_ins_emb_for_mask_attn)
+
+            cur_state = rearrange(cur_state, "b c h w -> (h w) b c")
+            cur_ins_query = rearrange(cur_ins_query, "b q c -> q b c")
+
+            for j in range(n_trans_layer_each_block):
+                trans_layer_ind = i * n_trans_layer_each_block + j
+                trans_layer = self.transformer_decoder.layers[trans_layer_ind]
+                cur_state = trans_layer(
+                    query=cur_state,
+                    key=cur_ins_query,
+                    value=cur_ins_query,
+                    query_pos=None,
+                    key_pos=None,
+                    attn_masks=attn_masks,
+                    query_key_padding_mask=None,
+                    key_padding_mask=None,
+                )
+
+            cur_state = rearrange(
+                cur_state, "(h w) b c -> b c h w", h=self.bev_size[0] // 8
+            )
+
+            cur_state = self.upsample_adds[i](cur_state, last_state)
+
+            future_states.append(cur_state)
+            last_state = cur_state
+
+        future_states = torch.stack(future_states, dim=1)
+        temporal_query = torch.stack(temporal_query, dim=1)
+        mask_preds = torch.stack(mask_preds, dim=2)
+        ins_query = torch.stack(temporal_embed_for_mask_attn, dim=1)
+
+        future_states = self.dense_decoder(future_states)
+        ins_occ_query = self.query_to_occ_feat(ins_query)
+        ins_occ_logits = torch.einsum("btqc,btchw->bqthw", ins_occ_query, future_states)
+
+        return mask_preds, ins_occ_logits
+
+    def merge_queries(self, outs_dict, detach_query_pos=True):
+        ins_query = outs_dict.get("traj_query", None)
+        track_query = outs_dict["track_query"]
+        track_query_pos = outs_dict["track_query_pos"]
+
+        if detach_query_pos:
+            track_query_pos = track_query_pos.detach()
+
+        ins_query = ins_query[-1]
+        ins_query = self.mode_fuser(ins_query).max(2)[0]
+        ins_query = self.multi_query_fuser(
+            torch.cat([ins_query, track_query, track_query_pos], dim=-1)
+        )
+
+        return ins_query
+
+    def forward_test(
+        self,
+        bev_feat,
+        outs_dict,
+        no_query=False,
+        gt_segmentation=None,
+        gt_instance=None,
+        gt_img_is_valid=None,
+    ):
+        gt_segmentation, gt_instance, gt_img_is_valid = self.get_occ_labels(
+            gt_segmentation, gt_instance, gt_img_is_valid
+        )
+
+        out_dict = dict()
+        out_dict["seg_gt"] = gt_segmentation[:, : 1 + self.n_future]
+        out_dict["ins_seg_gt"] = self.get_ins_seg_gt(
+            gt_instance[:, : 1 + self.n_future]
+        )
+        if no_query:
+            out_dict["seg_out"] = torch.zeros_like(out_dict["seg_gt"]).long()
+            out_dict["ins_seg_out"] = torch.zeros_like(out_dict["ins_seg_gt"]).long()
+            return out_dict
+
+        ins_query = self.merge_queries(outs_dict, self.detach_query_pos)
+
+        _, pred_ins_logits = self(bev_feat, ins_query=ins_query)
+
+        out_dict["pred_ins_logits"] = pred_ins_logits
+
+        pred_ins_logits = pred_ins_logits[:, :, : 1 + self.n_future]
+        pred_ins_sigmoid = pred_ins_logits.sigmoid()
+
+        if self.test_with_track_score:
+            track_scores = outs_dict["track_scores"].to(pred_ins_sigmoid)
+            track_scores = track_scores[:, :, None, None, None]
+            pred_ins_sigmoid = pred_ins_sigmoid * track_scores
+
+        out_dict["pred_ins_sigmoid"] = pred_ins_sigmoid
+        pred_seg_scores = pred_ins_sigmoid.max(1)[0]
+        seg_out = (pred_seg_scores > self.test_seg_thresh).long().unsqueeze(2)
+        out_dict["seg_out"] = seg_out
+        if self.pan_eval:
+            pred_consistent_instance_seg = (
+                predict_instance_segmentation_and_trajectories(
+                    seg_out, pred_ins_sigmoid
+                )
+            )
+
+            out_dict["ins_seg_out"] = pred_consistent_instance_seg
+
+        return out_dict
+
+    def get_ins_seg_gt(self, gt_instance):
+        ins_gt_old = gt_instance
+        ins_gt_new = torch.zeros_like(ins_gt_old).to(ins_gt_old)
+        ins_inds_unique = torch.unique(ins_gt_old)
+        new_id = 1
+        for uni_id in ins_inds_unique:
+            if uni_id.item() in [0, self.ignore_index]:
+                continue
+            ins_gt_new[ins_gt_old == uni_id] = new_id
+            new_id += 1
+        return ins_gt_new
+
+    def get_occ_labels(self, gt_segmentation, gt_instance, gt_img_is_valid):
+        if not self.training:
+            gt_segmentation = gt_segmentation[0]
+            gt_instance = gt_instance[0]
+            gt_img_is_valid = gt_img_is_valid[0]
+
+        gt_segmentation = gt_segmentation[0][:, : self.n_future + 1].long().unsqueeze(2)
+        gt_instance = gt_instance[0][:, : self.n_future + 1].long()
+        gt_img_is_valid = gt_img_is_valid[:, : self.receptive_field + self.n_future]
+        return gt_segmentation, gt_instance, gt_img_is_valid

--- a/uniad/pytorch/src/occ_utils.py
+++ b/uniad/pytorch/src/occ_utils.py
@@ -1,0 +1,777 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+import torch.utils.checkpoint as checkpoint
+import torch
+from torchmetrics import Metric
+from torchmetrics.functional.classification import multiclass_stat_scores
+from torchmetrics.utilities.data import dim_zero_mean
+from torch import nn
+import torch.nn.functional as F
+from einops import rearrange
+from collections import OrderedDict
+from third_party.tt_forge_models.uniad.pytorch.src.utils import *
+from third_party.tt_forge_models.uniad.pytorch.src.transformer import *
+
+
+class DetrTransformerDecoderLayer(BaseTransformerLayer):
+    """Decoder layer in DETR transformer."""
+
+    def __init__(
+        self,
+        attn_cfgs={
+            "type": "MultiheadAttention",
+            "embed_dims": 256,
+            "num_heads": 8,
+            "attn_drop": 0.0,
+            "proj_drop": 0.0,
+            "dropout_layer": None,
+            "batch_first": False,
+        },
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=2048,
+            num_fcs=2,
+            ffn_drop=0.0,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=("self_attn", "norm", "cross_attn", "norm", "ffn", "norm"),
+        norm_cfg=dict(type="LN"),
+        **kwargs
+    ):
+
+        super().__init__(
+            attn_cfgs=attn_cfgs,
+            ffn_cfgs=ffn_cfgs,
+            operation_order=operation_order,
+            norm_cfg=norm_cfg,
+            **kwargs
+        )
+
+        assert len(operation_order) == 6
+        assert set(operation_order) == set(["self_attn", "norm", "cross_attn", "ffn"])
+        self.num_attn = sum([op.endswith("attn") for op in operation_order])
+
+
+class DetrTransformerDecoder(TransformerLayerSequence):
+    """Implements the decoder in DETR transformer.
+
+    Args:
+        return_intermediate (bool): Whether to return intermediate outputs.
+        post_norm_cfg (dict): Config of last normalization layer. Default：
+            `LN`.
+    """
+
+    def __init__(
+        self,
+        *args,
+        post_norm_cfg=dict(type="LN"),
+        return_intermediate=False,
+        num_layers=5,
+        **kwargs
+    ):
+
+        super().__init__(
+            transformerlayers=DetrTransformerDecoderLayer, num_layers=num_layers
+        )
+        self.return_intermediate = return_intermediate
+        self.post_norm = torch.nn.LayerNorm((256,), eps=1e-05, elementwise_affine=True)
+
+    def forward(self, query, *args, **kwargs):
+        """Forward function for `TransformerDecoder`.
+
+        Args:
+            query (Tensor): Input query with shape
+                `(num_query, bs, embed_dims)`.
+
+        Returns:
+            Tensor: Results with shape [1, num_query, bs, embed_dims] when
+                return_intermediate is `False`, otherwise it has shape
+                [num_layers, num_query, bs, embed_dims].
+        """
+        if not self.return_intermediate:
+            x = super().forward(query, *args, **kwargs)
+            if self.post_norm:
+                x = self.post_norm(x)[None]
+            return x
+
+        intermediate = []
+        for layer in self.layers:
+            query = layer(query, *args, **kwargs)
+
+        return torch.stack(intermediate)
+
+
+def calculate_birds_eye_view_parameters(x_bounds, y_bounds, z_bounds):
+    """
+    Parameters
+    ----------
+        x_bounds: Forward direction in the ego-car.
+        y_bounds: Sides
+        z_bounds: Height
+
+    Returns
+    -------
+        bev_resolution: Bird's-eye view bev_resolution
+        bev_start_position Bird's-eye view first element
+        bev_dimension Bird's-eye view tensor spatial dimension
+    """
+    bev_resolution = torch.tensor([row[2] for row in [x_bounds, y_bounds, z_bounds]])
+    bev_start_position = torch.tensor(
+        [row[0] + row[2] / 2.0 for row in [x_bounds, y_bounds, z_bounds]]
+    )
+    bev_dimension = torch.tensor(
+        [(row[1] - row[0]) / row[2] for row in [x_bounds, y_bounds, z_bounds]],
+        dtype=torch.long,
+    )
+
+    return bev_resolution, bev_start_position, bev_dimension
+
+
+class IntersectionOverUnion(Metric):
+    """Computes intersection-over-union."""
+
+    def __init__(
+        self,
+        n_classes: int,
+        ignore_index: Optional[int] = None,
+        absent_score: float = 0.0,
+        reduction: str = "none",
+        compute_on_step: bool = False,
+    ):
+        super().__init__(compute_on_step=compute_on_step)
+
+        self.n_classes = n_classes
+        self.ignore_index = ignore_index
+        self.absent_score = absent_score
+        self.reduction = reduction
+
+        self.add_state(
+            "true_positive", default=torch.zeros(n_classes), dist_reduce_fx="sum"
+        )
+        self.add_state(
+            "false_positive", default=torch.zeros(n_classes), dist_reduce_fx="sum"
+        )
+        self.add_state(
+            "false_negative", default=torch.zeros(n_classes), dist_reduce_fx="sum"
+        )
+        self.add_state("support", default=torch.zeros(n_classes), dist_reduce_fx="sum")
+
+    def update(self, prediction: torch.Tensor, target: torch.Tensor):
+        tps, fps, _, fns, sups = multiclass_stat_scores(
+            prediction, target, self.n_classes
+        )
+
+        self.true_positive += tps
+        self.false_positive += fps
+        self.false_negative += fns
+        self.support += sups
+
+    def compute(self):
+        scores = torch.zeros(self.n_classes, dtype=torch.float32)
+
+        for class_idx in range(self.n_classes):
+            if class_idx == self.ignore_index:
+                continue
+
+            tp = self.true_positive[class_idx]
+            fp = self.false_positive[class_idx]
+            fn = self.false_negative[class_idx]
+            sup = self.support[class_idx]
+
+            if sup + tp + fp == 0:
+                scores[class_idx] = self.absent_score
+                continue
+
+            denominator = tp + fp + fn
+            score = tp.to(torch.float) / denominator
+            scores[class_idx] = score
+
+        if (self.ignore_index is not None) and (
+            0 <= self.ignore_index < self.n_classes
+        ):
+            scores = torch.cat(
+                [scores[: self.ignore_index], scores[self.ignore_index + 1 :]]
+            )
+
+        return dim_zero_mean(scores)
+
+
+class PanopticMetric(Metric):
+    def __init__(
+        self,
+        n_classes: int,
+        temporally_consistent: bool = True,
+        vehicles_id: int = 1,
+        compute_on_step: bool = False,
+    ):
+        super().__init__(compute_on_step=compute_on_step)
+
+        self.n_classes = n_classes
+        self.temporally_consistent = temporally_consistent
+        self.vehicles_id = vehicles_id
+        self.keys = ["iou", "true_positive", "false_positive", "false_negative"]
+
+        self.add_state("iou", default=torch.zeros(n_classes), dist_reduce_fx="sum")
+        self.add_state(
+            "true_positive", default=torch.zeros(n_classes), dist_reduce_fx="sum"
+        )
+        self.add_state(
+            "false_positive", default=torch.zeros(n_classes), dist_reduce_fx="sum"
+        )
+        self.add_state(
+            "false_negative", default=torch.zeros(n_classes), dist_reduce_fx="sum"
+        )
+
+    def update(self, pred_instance, gt_instance):
+        """
+        Update state with predictions and targets.
+
+        Parameters
+        ----------
+            pred_instance: (b, s, h, w)
+                Temporally consistent instance segmentation prediction.
+            gt_instance: (b, s, h, w)
+                Ground truth instance segmentation.
+        """
+        batch_size, sequence_length = gt_instance.shape[:2]
+        assert gt_instance.min() == 0, "ID 0 of gt_instance must be background"
+        pred_segmentation = (pred_instance > 0).long()
+        gt_segmentation = (gt_instance > 0).long()
+
+        for b in range(batch_size):
+            unique_id_mapping = {}
+            for t in range(sequence_length):
+                result = self.panoptic_metrics(
+                    pred_segmentation[b, t].detach(),
+                    pred_instance[b, t].detach(),
+                    gt_segmentation[b, t],
+                    gt_instance[b, t],
+                    unique_id_mapping,
+                )
+
+                self.iou += result["iou"]
+                self.true_positive += result["true_positive"]
+                self.false_positive += result["false_positive"]
+                self.false_negative += result["false_negative"]
+
+    def compute(self):
+        denominator = torch.maximum(
+            (self.true_positive + self.false_positive / 2 + self.false_negative / 2),
+            torch.ones_like(self.true_positive),
+        )
+        pq = self.iou / denominator
+        sq = self.iou / torch.maximum(
+            self.true_positive, torch.ones_like(self.true_positive)
+        )
+        rq = self.true_positive / denominator
+
+        return {
+            "pq": pq,
+            "sq": sq,
+            "rq": rq,
+            "denominator": (
+                self.true_positive + self.false_positive / 2 + self.false_negative / 2
+            ),
+        }
+
+    def panoptic_metrics(
+        self,
+        pred_segmentation,
+        pred_instance,
+        gt_segmentation,
+        gt_instance,
+        unique_id_mapping,
+    ):
+        """
+        Computes panoptic quality metric components.
+
+        Parameters
+        ----------
+            pred_segmentation: [H, W] range {0, ..., n_classes-1} (>= n_classes is void)
+            pred_instance: [H, W] range {0, ..., n_instances} (zero means background)
+            gt_segmentation: [H, W] range {0, ..., n_classes-1} (>= n_classes is void)
+            gt_instance: [H, W] range {0, ..., n_instances} (zero means background)
+            unique_id_mapping: instance id mapping to check consistency
+        """
+        n_classes = self.n_classes
+
+        result = {key: torch.zeros(n_classes, dtype=torch.float32) for key in self.keys}
+
+        assert pred_segmentation.dim() == 2
+        assert (
+            pred_segmentation.shape
+            == pred_instance.shape
+            == gt_segmentation.shape
+            == gt_instance.shape
+        )
+
+        n_instances = int(torch.cat([pred_instance, gt_instance]).max().item())
+        n_all_things = n_instances + n_classes
+        n_things_and_void = n_all_things + 1
+
+        prediction, pred_to_cls = self.combine_mask(
+            pred_segmentation, pred_instance, n_classes, n_all_things
+        )
+        target, target_to_cls = self.combine_mask(
+            gt_segmentation, gt_instance, n_classes, n_all_things
+        )
+        x = prediction + n_things_and_void * target
+        bincount_2d = torch.bincount(x.long(), minlength=n_things_and_void**2)
+        if bincount_2d.shape[0] != n_things_and_void**2:
+            raise ValueError("Incorrect bincount size.")
+        conf = bincount_2d.reshape((n_things_and_void, n_things_and_void))
+        conf = conf[1:, 1:]
+
+        union = conf.sum(0).unsqueeze(0) + conf.sum(1).unsqueeze(1) - conf
+        iou = torch.where(
+            union > 0,
+            (conf.float() + 1e-9) / (union.float() + 1e-9),
+            torch.zeros_like(union).float(),
+        )
+
+        mapping = (iou > 0.5).nonzero(as_tuple=False)
+
+        is_matching = pred_to_cls[mapping[:, 1]] == target_to_cls[mapping[:, 0]]
+        mapping = mapping[is_matching]
+        tp_mask = torch.zeros_like(conf, dtype=torch.bool)
+        tp_mask[mapping[:, 0], mapping[:, 1]] = True
+
+        for target_id, pred_id in mapping:
+            cls_id = pred_to_cls[pred_id]
+
+            if self.temporally_consistent and cls_id == self.vehicles_id:
+                if (
+                    target_id.item() in unique_id_mapping
+                    and unique_id_mapping[target_id.item()] != pred_id.item()
+                ):
+                    result["false_negative"][target_to_cls[target_id]] += 1
+                    result["false_positive"][pred_to_cls[pred_id]] += 1
+                    unique_id_mapping[target_id.item()] = pred_id.item()
+                    continue
+
+            result["true_positive"][cls_id] += 1
+            result["iou"][cls_id] += iou[target_id][pred_id]
+            unique_id_mapping[target_id.item()] = pred_id.item()
+
+        for target_id in range(n_classes, n_all_things):
+            if tp_mask[target_id, n_classes:].any():
+                continue
+            if target_to_cls[target_id] != -1:
+                result["false_negative"][target_to_cls[target_id]] += 1
+
+        for pred_id in range(n_classes, n_all_things):
+            if tp_mask[n_classes:, pred_id].any():
+                continue
+            if pred_to_cls[pred_id] != -1 and (conf[:, pred_id] > 0).any():
+                result["false_positive"][pred_to_cls[pred_id]] += 1
+
+        return result
+
+    def combine_mask(
+        self,
+        segmentation: torch.Tensor,
+        instance: torch.Tensor,
+        n_classes: int,
+        n_all_things: int,
+    ):
+        """Shifts all things ids by num_classes and combines things and stuff into a single mask
+
+        Returns a combined mask + a mapping from id to segmentation class.
+        """
+        instance = instance.view(-1)
+        instance_mask = instance > 0
+        instance = instance - 1 + n_classes
+
+        segmentation = segmentation.clone().view(-1)
+        segmentation_mask = segmentation < n_classes
+
+        instance_id_to_class_tuples = torch.cat(
+            (
+                instance[instance_mask & segmentation_mask].unsqueeze(1),
+                segmentation[instance_mask & segmentation_mask].unsqueeze(1),
+            ),
+            dim=1,
+        )
+        instance_id_to_class = -instance_id_to_class_tuples.new_ones((n_all_things,))
+        instance_id_to_class[
+            instance_id_to_class_tuples[:, 0]
+        ] = instance_id_to_class_tuples[:, 1]
+        instance_id_to_class[torch.arange(n_classes)] = torch.arange(n_classes)
+
+        segmentation[instance_mask] = instance[instance_mask]
+        segmentation += 1
+        segmentation[~segmentation_mask] = 0
+
+        return segmentation, instance_id_to_class
+
+
+class BevFeatureSlicer(nn.Module):
+    def __init__(self, grid_conf, map_grid_conf):
+        super().__init__()
+        self.identity_mapping = False
+        (
+            bev_resolution,
+            bev_start_position,
+            bev_dimension,
+        ) = calculate_birds_eye_view_parameters(
+            grid_conf["xbound"], grid_conf["ybound"], grid_conf["zbound"]
+        )
+
+        (
+            map_bev_resolution,
+            map_bev_start_position,
+            map_bev_dimension,
+        ) = calculate_birds_eye_view_parameters(
+            map_grid_conf["xbound"],
+            map_grid_conf["ybound"],
+            map_grid_conf["zbound"],
+        )
+
+        self.map_x = torch.arange(
+            map_bev_start_position[0],
+            map_grid_conf["xbound"][1],
+            map_bev_resolution[0],
+        )
+
+        self.map_y = torch.arange(
+            map_bev_start_position[1],
+            map_grid_conf["ybound"][1],
+            map_bev_resolution[1],
+        )
+
+        self.norm_map_x = self.map_x / (-bev_start_position[0])
+        self.norm_map_y = self.map_y / (-bev_start_position[1])
+
+        tmp_m, tmp_n = torch.meshgrid(self.norm_map_x, self.norm_map_y)
+        tmp_m, tmp_n = tmp_m.T, tmp_n.T
+
+        self.map_grid = torch.stack([tmp_m, tmp_n], dim=2)
+
+    def forward(self, x):
+        grid = self.map_grid.unsqueeze(0).type_as(x).repeat(x.shape[0], 1, 1, 1)
+        return F.grid_sample(x, grid=grid, mode="bilinear", align_corners=True)
+
+
+class MLP(nn.Module):
+    """Very simple multi-layer perceptron (also called FFN)"""
+
+    def __init__(self, input_dim, hidden_dim, output_dim, num_layers):
+        super().__init__()
+        self.num_layers = num_layers
+        h = [hidden_dim] * (num_layers - 1)
+        self.layers = nn.ModuleList(
+            nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim])
+        )
+
+    def forward(self, x):
+        for i, layer in enumerate(self.layers):
+            x = F.relu(layer(x)) if i < self.num_layers - 1 else layer(x)
+        return x
+
+
+class ConvModule(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, kernel_size, stride=1, padding=0, bias=False
+    ):
+        super().__init__()
+        self.conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            bias=bias,
+        )
+        self.bn = nn.BatchNorm2d(out_channels)
+        self.activate = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        x = self.activate(x)
+        return x
+
+
+class SimpleConv2d(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, conv_channels=64, num_conv=1, bias=False
+    ):
+        super().__init__()
+        self.out_channels = out_channels
+        if num_conv == 1:
+            conv_channels = in_channels
+
+        conv_layers = []
+        c_in = in_channels
+        for i in range(num_conv - 1):
+            conv_layers.append(
+                ConvModule(
+                    in_channels=c_in,
+                    out_channels=conv_channels,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                    bias=bias,
+                )
+            )
+            c_in = conv_channels
+
+        conv_layers.append(
+            nn.Conv2d(
+                in_channels=conv_channels,
+                out_channels=out_channels,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+                bias=True,
+            )
+        )
+
+        self.conv_layers = nn.Sequential(*conv_layers)
+
+    def forward(self, x):
+        b, c_in, h_in, w_in = x.size()
+        out = self.conv_layers(x)
+        assert out.size() == (b, self.out_channels, h_in, w_in)
+        return out
+
+
+class CVT_DecoderBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        skip_dim,
+        residual,
+        factor,
+        upsample,
+        with_relu=True,
+    ):
+        super().__init__()
+
+        dim = out_channels // factor
+
+        self.conv = nn.Sequential(
+            nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True),
+            nn.Conv2d(in_channels, dim, 3, padding=1, bias=False),
+            nn.BatchNorm2d(dim),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(dim, out_channels, 1, padding=0, bias=False),
+            nn.BatchNorm2d(out_channels),
+        )
+
+        self.up = nn.Conv2d(skip_dim, out_channels, 1)
+
+        self.with_relu = with_relu
+        if self.with_relu:
+            self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x, skip):
+        x = self.conv(x)
+
+        if self.up is not None:
+            up = self.up(skip)
+            up = F.interpolate(up, x.shape[-2:])
+
+            x = x + up
+        if self.with_relu:
+            return self.relu(x)
+        return x
+
+
+class CVT_Decoder(nn.Module):
+    def __init__(
+        self, dim, blocks, residual=True, factor=2, upsample=True, use_checkpoint=False
+    ):
+        super().__init__()
+
+        layers = []
+        channels = dim
+
+        for i, out_channels in enumerate(blocks):
+            with_relu = i < len(blocks) - 1
+            layer = CVT_DecoderBlock(
+                channels,
+                out_channels,
+                dim,
+                residual,
+                factor,
+                upsample,
+                with_relu=with_relu,
+            )
+            layers.append(layer)
+
+            channels = out_channels
+
+        self.layers = nn.Sequential(*layers)
+        self.out_channels = channels
+        self.use_checkpoint = use_checkpoint
+
+    def forward(self, x):
+        b, t = x.size(0), x.size(1)
+        x = rearrange(x, "b t c h w -> (b t) c h w")
+        y = x
+        for layer in self.layers:
+            if self.use_checkpoint:
+                y = checkpoint(layer, y, x)
+            else:
+                y = layer(y, x)
+        y = rearrange(y, "(b t) c h w -> b t c h w", b=b, t=t)
+        return y
+
+
+class UpsamplingAdd(nn.Module):
+    def __init__(self, in_channels, out_channels, scale_factor=2):
+        super().__init__()
+        self.upsample_layer = nn.Sequential(
+            nn.Upsample(
+                scale_factor=scale_factor, mode="bilinear", align_corners=False
+            ),
+            nn.Conv2d(in_channels, out_channels, kernel_size=1, padding=0, bias=False),
+            nn.BatchNorm2d(out_channels),
+        )
+
+    def forward(self, x, x_skip):
+        x = self.upsample_layer(x)
+        return x + x_skip
+
+
+class Bottleneck(nn.Module):
+    """
+    Defines a bottleneck module with a residual connection
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels=None,
+        kernel_size=3,
+        dilation=1,
+        groups=1,
+        upsample=False,
+        downsample=False,
+        dropout=0.0,
+    ):
+        super().__init__()
+        self._downsample = downsample
+        bottleneck_channels = int(in_channels / 2)
+        out_channels = out_channels or in_channels
+        padding_size = ((kernel_size - 1) * dilation + 1) // 2
+
+        assert dilation == 1
+        bottleneck_conv = nn.Conv2d(
+            bottleneck_channels,
+            bottleneck_channels,
+            kernel_size=kernel_size,
+            bias=False,
+            dilation=dilation,
+            stride=2,
+            padding=padding_size,
+            groups=groups,
+        )
+
+        self.layers = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "conv_down_project",
+                        nn.Conv2d(
+                            in_channels, bottleneck_channels, kernel_size=1, bias=False
+                        ),
+                    ),
+                    (
+                        "abn_down_project",
+                        nn.Sequential(
+                            nn.BatchNorm2d(bottleneck_channels), nn.ReLU(inplace=True)
+                        ),
+                    ),
+                    ("conv", bottleneck_conv),
+                    (
+                        "abn",
+                        nn.Sequential(
+                            nn.BatchNorm2d(bottleneck_channels), nn.ReLU(inplace=True)
+                        ),
+                    ),
+                    (
+                        "conv_up_project",
+                        nn.Conv2d(
+                            bottleneck_channels, out_channels, kernel_size=1, bias=False
+                        ),
+                    ),
+                    (
+                        "abn_up_project",
+                        nn.Sequential(
+                            nn.BatchNorm2d(out_channels), nn.ReLU(inplace=True)
+                        ),
+                    ),
+                    ("dropout", nn.Dropout2d(p=dropout)),
+                ]
+            )
+        )
+
+        projection = OrderedDict()
+        projection.update({"upsample_skip_proj": nn.MaxPool2d(kernel_size=2, stride=2)})
+        projection.update(
+            {
+                "conv_skip_proj": nn.Conv2d(
+                    in_channels, out_channels, kernel_size=1, bias=False
+                ),
+                "bn_skip_proj": nn.BatchNorm2d(out_channels),
+            }
+        )
+        self.projection = nn.Sequential(projection)
+
+    def forward(self, *args):
+        (x,) = args
+        x_residual = self.layers(x)
+        if self.projection is not None:
+            if self._downsample:
+                x = nn.functional.pad(
+                    x, (0, x.shape[-1] % 2, 0, x.shape[-2] % 2), value=0
+                )
+            return x_residual + self.projection(x)
+        return x_residual + x
+
+
+def update_instance_ids(instance_seg, old_ids, new_ids):
+    """
+    Parameters
+    ----------
+        instance_seg: torch.Tensor arbitrary shape
+        old_ids: 1D tensor containing the list of old ids, must be all present in instance_seg.
+        new_ids: 1D tensor with the new ids, aligned with old_ids
+
+    Returns
+        new_instance_seg: torch.Tensor same shape as instance_seg with new ids
+    """
+    indices = torch.arange(old_ids.max() + 1)
+    for old_id, new_id in zip(old_ids, new_ids):
+        indices[old_id] = new_id
+
+    return indices[instance_seg].long()
+
+
+def make_instance_seg_consecutive(instance_seg):
+    unique_ids = torch.unique(instance_seg)
+    new_ids = torch.arange(len(unique_ids))
+    instance_seg = update_instance_ids(instance_seg, unique_ids, new_ids)
+    return instance_seg
+
+
+def predict_instance_segmentation_and_trajectories(
+    foreground_masks,
+    ins_sigmoid,
+    vehicles_id=1,
+):
+    if foreground_masks.dim() == 5 and foreground_masks.shape[2] == 1:
+        foreground_masks = foreground_masks.squeeze(2)
+    foreground_masks = foreground_masks == vehicles_id
+
+    argmax_ins = ins_sigmoid.argmax(dim=1)
+    argmax_ins = argmax_ins + 1
+    instance_seg = (argmax_ins * foreground_masks.float()).long()
+    instance_seg = make_instance_seg_consecutive(instance_seg).long()
+    return instance_seg

--- a/uniad/pytorch/src/panseg_head.py
+++ b/uniad/pytorch/src/panseg_head.py
@@ -1,0 +1,1352 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from third_party.tt_forge_models.uniad.pytorch.src.panseg_utils import *
+from third_party.tt_forge_models.uniad.pytorch.src.utils import *
+from third_party.tt_forge_models.uniad.pytorch.src.transformer import *
+from abc import ABCMeta
+from functools import partial
+from typing import Optional
+import copy
+from torch import Tensor
+
+
+class SegDETRHead(nn.Module, metaclass=ABCMeta):
+    """Implements the DETR transformer head.
+
+    See `paper: End-to-End Object Detection with Transformers
+    <https://arxiv.org/pdf/2005.12872>`_ for details.
+
+    Args:
+        num_classes (int): Number of categories excluding the background.
+        in_channels (int): Number of channels in the input feature map.
+        num_query (int): Number of query in Transformer.
+        num_reg_fcs (int, optional): Number of fully-connected layers used in
+            `FFN`, which is then used for the regression head. Default 2.
+        transformer (obj:`mmcv.ConfigDict`|dict): Config for transformer.
+            Default: None.
+        sync_cls_avg_factor (bool): Whether to sync the avg_factor of
+            all ranks. Default to False.
+        positional_encoding (obj:`mmcv.ConfigDict`|dict):
+            Config for position encoding.
+        test_cfg (obj:`mmcv.ConfigDict`|dict): Testing config of
+            transformer head.
+    """
+
+    _version = 2
+
+    def __init__(
+        self,
+        bev_h=200,
+        bev_w=200,
+        canvas_size=(200, 200),
+        pc_range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+        num_classes=4,
+        num_things_classes=3,
+        num_stuff_classes=1,
+        in_channels=2048,
+        num_query=300,
+        num_reg_fcs=2,
+        sync_cls_avg_factor=True,
+        as_two_stage=False,
+        with_box_refine=True,
+        transformer=SegDeformableTransformer(),
+        positional_encoding=SinePositionalEncoding(),
+        test_cfg=dict(max_per_img=100),
+        thing_transformer_head=dict(
+            type="SegMaskHead", d_model=256, nhead=8, num_decoder_layers=4
+        ),
+        stuff_transformer_head=dict(
+            type="SegMaskHead",
+            d_model=256,
+            nhead=8,
+            num_decoder_layers=6,
+            self_attn=True,
+        ),
+    ):
+
+        super(SegDETRHead, self).__init__()
+        self.bg_cls_weight = 0
+        self.sync_cls_avg_factor = sync_cls_avg_factor
+        class_weight = None
+        self.num_query = 300
+        self.num_classes = 4
+        self.num_things_classes = 3
+        self.num_stuff_classes = 1
+        self.in_channels = 2048
+        self.num_reg_fcs = num_reg_fcs
+        self.test_cfg = test_cfg
+        self.fp16_enabled = False
+
+        self.cls_out_channels = num_things_classes
+
+        self.positional_encoding = SinePositionalEncoding(
+            num_feats=128, normalize=True, offset=-0.5
+        )
+        self.transformer = SegDeformableTransformer()
+
+        self.embed_dims = self.transformer.embed_dims
+        num_feats = positional_encoding.num_feats
+        assert num_feats * 2 == self.embed_dims, (
+            "embed_dims should"
+            f" be exactly 2 times of num_feats. Found {self.embed_dims}"
+            f" and {num_feats}."
+        )
+        self._init_layers()
+
+    def _init_layers(self):
+        """Initialize layers of the transformer head."""
+        self.input_proj = nn.Conv2d(self.in_channels, self.embed_dims, kernel_size=1)
+        self.fc_cls = nn.Linear(self.embed_dims, self.cls_out_channels)
+        self.reg_ffn = FFN(
+            self.embed_dims,
+            self.embed_dims,
+            self.num_reg_fcs,
+            self.act_cfg,
+            dropout=0.0,
+            add_residual=False,
+        )
+        self.fc_reg = nn.Linear(self.embed_dims, 4)
+        self.query_embedding = nn.Embedding(self.num_query, self.embed_dims)
+
+    def forward(self, feats, img_metas):
+        """Forward function.
+
+        Args:
+            feats (tuple[Tensor]): Features from the upstream network, each is
+                a 4D-tensor.
+            img_metas (list[dict]): List of image information.
+
+        Returns:
+            tuple[list[Tensor], list[Tensor]]: Outputs for all scale levels.
+
+                - all_cls_scores_list (list[Tensor]): Classification scores \
+                    for each scale level. Each is a 4D-tensor with shape \
+                    [nb_dec, bs, num_query, cls_out_channels]. Note \
+                    `cls_out_channels` should includes background.
+                - all_bbox_preds_list (list[Tensor]): Sigmoid regression \
+                    outputs for each scale level. Each is a 4D-tensor with \
+                    normalized coordinate format (cx, cy, w, h) and shape \
+                    [nb_dec, bs, num_query, 4].
+        """
+        num_levels = len(feats)
+        img_metas_list = [img_metas for _ in range(num_levels)]
+        return multi_apply(self.forward_single, feats, img_metas_list)
+
+    def get_targets(
+        self,
+        cls_scores_list,
+        bbox_preds_list,
+        gt_bboxes_list,
+        gt_labels_list,
+        img_metas,
+        gt_bboxes_ignore_list=None,
+    ):
+        """"Compute regression and classification targets for a batch image.
+
+        Outputs from a single decoder layer of a single feature level are used.
+
+        Args:
+            cls_scores_list (list[Tensor]): Box score logits from a single
+                decoder layer for each image with shape [num_query,
+                cls_out_channels].
+            bbox_preds_list (list[Tensor]): Sigmoid outputs from a single
+                decoder layer for each image, with normalized coordinate
+                (cx, cy, w, h) and shape [num_query, 4].
+            gt_bboxes_list (list[Tensor]): Ground truth bboxes for each image
+                with shape (num_gts, 4) in [tl_x, tl_y, br_x, br_y] format.
+            gt_labels_list (list[Tensor]): Ground truth class indices for each
+                image with shape (num_gts, ).
+            img_metas (list[dict]): List of image meta information.
+            gt_bboxes_ignore_list (list[Tensor], optional): Bounding
+                boxes which can be ignored for each image. Default None.
+
+        Returns:
+            tuple: a tuple containing the following targets.
+
+                - labels_list (list[Tensor]): Labels for all images.
+                - label_weights_list (list[Tensor]): Label weights for all \
+                    images.
+                - bbox_targets_list (list[Tensor]): BBox targets for all \
+                    images.
+                - bbox_weights_list (list[Tensor]): BBox weights for all \
+                    images.
+                - num_total_pos (int): Number of positive samples in all \
+                    images.
+                - num_total_neg (int): Number of negative samples in all \
+                    images.
+        """
+        assert (
+            gt_bboxes_ignore_list is None
+        ), "Only supports for gt_bboxes_ignore setting to None."
+        num_imgs = len(cls_scores_list)
+        gt_bboxes_ignore_list = [gt_bboxes_ignore_list for _ in range(num_imgs)]
+
+        (
+            labels_list,
+            label_weights_list,
+            bbox_targets_list,
+            bbox_weights_list,
+            pos_inds_list,
+            neg_inds_list,
+        ) = multi_apply(
+            self._get_target_single,
+            cls_scores_list,
+            bbox_preds_list,
+            gt_bboxes_list,
+            gt_labels_list,
+            img_metas,
+            gt_bboxes_ignore_list,
+        )
+        num_total_pos = sum((inds.numel() for inds in pos_inds_list))
+        num_total_neg = sum((inds.numel() for inds in neg_inds_list))
+        return (
+            labels_list,
+            label_weights_list,
+            bbox_targets_list,
+            bbox_weights_list,
+            num_total_pos,
+            num_total_neg,
+        )
+
+    def get_bboxes(
+        self, all_cls_scores_list, all_bbox_preds_list, img_metas, rescale=False
+    ):
+        """Transform network outputs for a batch into bbox predictions.
+
+        Args:
+            all_cls_scores_list (list[Tensor]): Classification outputs
+                for each feature level. Each is a 4D-tensor with shape
+                [nb_dec, bs, num_query, cls_out_channels].
+            all_bbox_preds_list (list[Tensor]): Sigmoid regression
+                outputs for each feature level. Each is a 4D-tensor with
+                normalized coordinate format (cx, cy, w, h) and shape
+                [nb_dec, bs, num_query, 4].
+            img_metas (list[dict]): Meta information of each image.
+            rescale (bool, optional): If True, return boxes in original
+                image space. Default False.
+
+        Returns:
+            list[list[Tensor, Tensor]]: Each item in result_list is 2-tuple. \
+                The first item is an (n, 5) tensor, where the first 4 columns \
+                are bounding box positions (tl_x, tl_y, br_x, br_y) and the \
+                5-th column is a score between 0 and 1. The second item is a \
+                (n,) tensor where each item is the predicted class label of \
+                the corresponding box.
+        """
+
+        cls_scores = all_cls_scores_list[-1][-1]
+        bbox_preds = all_bbox_preds_list[-1][-1]
+
+        result_list = []
+        for img_id in range(len(img_metas)):
+            cls_score = cls_scores[img_id]
+            bbox_pred = bbox_preds[img_id]
+            img_shape = img_metas[img_id]["img_shape"]
+            scale_factor = img_metas[img_id]["scale_factor"]
+            proposals = self._get_bboxes_single(
+                cls_score, bbox_pred, img_shape, scale_factor, rescale
+            )
+            result_list.append(proposals)
+
+        return result_list
+
+
+class PansegformerHead(SegDETRHead):
+    """
+    Head of Panoptic SegFormer
+
+    Code is modified from the `official github repo
+    <https://github.com/open-mmlab/mmdetection>`_.
+
+    Args:
+        with_box_refine (bool): Whether to refine the reference points
+            in the decoder. Defaults to False.
+        as_two_stage (bool) : Whether to generate the proposal from
+            the outputs of encoder.
+        transformer (obj:`ConfigDict`): ConfigDict is used for building
+            the Encoder and Decoder.
+    """
+
+    def __init__(
+        self,
+        *args,
+        bev_h=200,
+        bev_w=200,
+        canvas_size=(200, 200),
+        pc_range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+        num_classes=4,
+        num_things_classes=3,
+        num_stuff_classes=1,
+        in_channels=2048,
+        num_query=300,
+        num_reg_fcs=2,
+        sync_cls_avg_factor=True,
+        as_two_stage=False,
+        with_box_refine=True,
+        transformer=SegDeformableTransformer(),
+        positional_encoding=SinePositionalEncoding(),
+        test_cfg=dict(max_per_img=100),
+        thing_transformer_head=dict(
+            type="SegMaskHead", d_model=256, nhead=8, num_decoder_layers=4
+        ),
+        stuff_transformer_head=dict(
+            type="SegMaskHead",
+            d_model=256,
+            nhead=8,
+            num_decoder_layers=6,
+            self_attn=True,
+        ),
+        quality_threshold_things=0.25,
+        quality_threshold_stuff=0.25,
+        overlap_threshold_things=0.4,
+        overlap_threshold_stuff=0.2,
+        **kwargs,
+    ):
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.canvas_size = canvas_size
+        self.pc_range = pc_range
+        self.real_w = self.pc_range[3] - self.pc_range[0]
+        self.real_h = self.pc_range[4] - self.pc_range[1]
+
+        self.with_box_refine = with_box_refine
+        self.as_two_stage = as_two_stage
+        self.quality_threshold_things = 0.1
+        self.quality_threshold_stuff = quality_threshold_stuff
+        self.overlap_threshold_things = overlap_threshold_things
+        self.overlap_threshold_stuff = overlap_threshold_stuff
+        self.fp16_enabled = False
+
+        if self.as_two_stage:
+            transformer["as_two_stage"] = self.as_two_stage
+        self.num_dec_things = 4
+        self.num_dec_stuff = 6
+        super(PansegformerHead, self).__init__(*args, transformer=transformer, **kwargs)
+
+        self.things_mask_head = SegMaskHead(d_model=256, nhead=8, num_decoder_layers=4)
+
+        self.stuff_mask_head = SegMaskHead(
+            d_model=256, nhead=8, num_decoder_layers=6, self_attn=True
+        )
+        self.count = 0
+
+    def _init_layers(self):
+        """Initialize classification branch and regression branch of head."""
+        if not self.as_two_stage:
+            self.bev_embedding = nn.Embedding(self.bev_h * self.bev_w, self.embed_dims)
+
+        fc_cls = nn.Linear(self.embed_dims, self.cls_out_channels)
+        fc_cls_stuff = nn.Linear(self.embed_dims, 1)
+        reg_branch = []
+        for _ in range(self.num_reg_fcs):
+            reg_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+            reg_branch.append(nn.ReLU())
+        reg_branch.append(nn.Linear(self.embed_dims, 4))
+        reg_branch = nn.Sequential(*reg_branch)
+
+        def _get_clones(module, N):
+            return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+        num_pred = (
+            (self.transformer.decoder.num_layers + 1)
+            if self.as_two_stage
+            else self.transformer.decoder.num_layers
+        )
+
+        self.cls_branches = _get_clones(fc_cls, num_pred)
+        self.reg_branches = _get_clones(reg_branch, num_pred)
+
+        if not self.as_two_stage:
+            self.query_embedding = nn.Embedding(self.num_query, self.embed_dims * 2)
+        self.stuff_query = nn.Embedding(self.num_stuff_classes, self.embed_dims * 2)
+        self.reg_branches2 = _get_clones(reg_branch, self.num_dec_things)
+        self.cls_thing_branches = _get_clones(fc_cls, self.num_dec_things)
+        self.cls_stuff_branches = _get_clones(fc_cls_stuff, self.num_dec_stuff)
+
+    def forward(self, bev_embed):
+        """Forward function.
+
+        Args:
+            bev_embed (tuple[Tensor]): Features from the upstream
+                network, each is a 4D-tensor with shape
+                (N, C, H, W).
+            img_metas (list[dict]): List of image information.
+
+        Returns:
+            all_cls_scores (Tensor): Outputs from the classification head, \
+                shape [nb_dec, bs, num_query, cls_out_channels]. Note \
+                cls_out_channels should includes background.
+            all_bbox_preds (Tensor): Sigmoid outputs from the regression \
+                head with normalized coordinate format (cx, cy, w, h). \
+                Shape [nb_dec, bs, num_query, 4].
+            enc_outputs_class (Tensor): The score of each point on encode \
+                feature map, has shape (N, h*w, num_class). Only when \
+                as_two_stage is True it would be returned, otherwise \
+                `None` would be returned.
+            enc_outputs_coord (Tensor): The proposal generate from the \
+                encode feature map, has shape (N, h*w, 4). Only when \
+                as_two_stage is True it would be returned, otherwise \
+                `None` would be returned.
+        """
+        _, bs, _ = bev_embed.shape
+
+        mlvl_feats = [
+            torch.reshape(bev_embed, (bs, self.bev_h, self.bev_w, -1)).permute(
+                0, 3, 1, 2
+            )
+        ]
+        img_masks = mlvl_feats[0].new_zeros((bs, self.bev_h, self.bev_w))
+
+        hw_lvl = [feat_lvl.shape[-2:] for feat_lvl in mlvl_feats]
+        mlvl_masks = []
+        mlvl_positional_encodings = []
+        for feat in mlvl_feats:
+            mlvl_masks.append(
+                F.interpolate(img_masks[None], size=feat.shape[-2:])
+                .to(torch.bool)
+                .squeeze(0)
+            )
+            mlvl_positional_encodings.append(self.positional_encoding(mlvl_masks[-1]))
+
+        query_embeds = None
+        if not self.as_two_stage:
+            query_embeds = self.query_embedding.weight
+        (
+            (memory, memory_pos, memory_mask, query_pos),
+            hs,
+            init_reference,
+            inter_references,
+            enc_outputs_class,
+            enc_outputs_coord,
+        ) = self.transformer(
+            mlvl_feats,
+            mlvl_masks,
+            query_embeds,
+            mlvl_positional_encodings,
+            reg_branches=self.reg_branches if self.with_box_refine else None,
+            cls_branches=self.cls_branches if self.as_two_stage else None,
+        )
+
+        memory = memory.permute(1, 0, 2)
+
+        query = hs[-1].permute(1, 0, 2)
+        query_pos = query_pos.permute(1, 0, 2)
+        memory_pos = memory_pos.permute(1, 0, 2)
+
+        args_tuple = [memory, memory_mask, memory_pos, query, None, query_pos, hw_lvl]
+
+        hs = hs.permute(0, 2, 1, 3)
+        outputs_classes = []
+        outputs_coords = []
+        for lvl in range(hs.shape[0]):
+            if lvl == 0:
+                reference = init_reference
+            else:
+                reference = inter_references[lvl - 1]
+            reference = inverse_sigmoid(reference)
+            outputs_class = self.cls_branches[lvl](hs[lvl])
+            tmp = self.reg_branches[lvl](hs[lvl])
+
+            if reference.shape[-1] == 4:
+                tmp += reference
+            else:
+                assert reference.shape[-1] == 2
+                tmp[..., :2] += reference
+            outputs_coord = tmp.sigmoid()
+            outputs_classes.append(outputs_class)
+            outputs_coords.append(outputs_coord)
+
+        outputs_classes = torch.stack(outputs_classes)
+        outputs_coords = torch.stack(outputs_coords)
+
+        outs = {
+            "bev_embed": None if self.as_two_stage else bev_embed,
+            "outputs_classes": outputs_classes,
+            "outputs_coords": outputs_coords,
+            "enc_outputs_class": enc_outputs_class if self.as_two_stage else None,
+            "enc_outputs_coord": enc_outputs_coord.sigmoid()
+            if self.as_two_stage
+            else None,
+            "args_tuple": args_tuple,
+            "reference": reference,
+        }
+
+        return outs
+
+    def filter_query(
+        self,
+        cls_scores_list,
+        bbox_preds_list,
+        gt_bboxes_list,
+        gt_labels_list,
+        img_metas,
+        gt_bboxes_ignore_list=None,
+    ):
+        """
+        This function aims to using the cost from the location decoder to filter out low-quality queries.
+        """
+        assert (
+            gt_bboxes_ignore_list is None
+        ), "Only supports for gt_bboxes_ignore setting to None."
+        num_imgs = len(cls_scores_list)
+        gt_bboxes_ignore_list = [gt_bboxes_ignore_list for _ in range(num_imgs)]
+
+        (
+            pos_inds_mask_list,
+            neg_inds_mask_list,
+            labels_list,
+            label_weights_list,
+            bbox_targets_list,
+            bbox_weights_list,
+            pos_inds_list,
+            neg_inds_list,
+        ) = multi_apply(
+            self._filter_query_single,
+            cls_scores_list,
+            bbox_preds_list,
+            gt_bboxes_list,
+            gt_labels_list,
+            img_metas,
+            gt_bboxes_ignore_list,
+        )
+        num_total_pos = sum((inds.numel() for inds in pos_inds_list))
+        num_total_neg = sum((inds.numel() for inds in neg_inds_list))
+
+        return (
+            pos_inds_mask_list,
+            neg_inds_mask_list,
+            labels_list,
+            label_weights_list,
+            bbox_targets_list,
+            bbox_weights_list,
+            num_total_pos,
+            num_total_neg,
+            pos_inds_list,
+            neg_inds_list,
+        )
+
+    def get_targets_with_mask(
+        self,
+        cls_scores_list,
+        bbox_preds_list,
+        masks_preds_list_thing,
+        gt_bboxes_list,
+        gt_labels_list,
+        gt_masks_list,
+        img_metas,
+        gt_bboxes_ignore_list=None,
+    ):
+        """ "Compute regression and classification targets for a batch image.
+
+        Outputs from a single decoder layer of a single feature level are used.
+
+        Args:
+            cls_scores_list (list[Tensor]): Box score logits from a single
+                decoder layer for each image with shape [num_query,
+                cls_out_channels].
+            bbox_preds_list (list[Tensor]): Sigmoid outputs from a single
+                decoder layer for each image, with normalized coordinate
+                (cx, cy, w, h) and shape [num_query, 4].
+            masks_preds_list_thing  (list[Tensor]):
+            gt_bboxes_list (list[Tensor]): Ground truth bboxes for each image
+                with shape (num_gts, 4) in [tl_x, tl_y, br_x, br_y] format.
+            gt_labels_list (list[Tensor]): Ground truth class indices for each
+                image with shape (num_gts, ).
+            img_metas (list[dict]): List of image meta information.
+            gt_bboxes_ignore_list (list[Tensor], optional): Bounding
+                boxes which can be ignored for each image. Default None.
+        """
+        assert (
+            gt_bboxes_ignore_list is None
+        ), "Only supports for gt_bboxes_ignore setting to None."
+        num_imgs = len(cls_scores_list)
+        gt_bboxes_ignore_list = [gt_bboxes_ignore_list for _ in range(num_imgs)]
+
+        (
+            labels_list,
+            label_weights_list,
+            bbox_targets_list,
+            bbox_weights_list,
+            mask_targets_list,
+            mask_weights_list,
+            pos_inds_list,
+            neg_inds_list,
+        ) = multi_apply(
+            self._get_target_single_with_mask,
+            cls_scores_list,
+            bbox_preds_list,
+            masks_preds_list_thing,
+            gt_bboxes_list,
+            gt_labels_list,
+            gt_masks_list,
+            img_metas,
+            gt_bboxes_ignore_list,
+        )
+        num_total_pos_thing = sum((inds.numel() for inds in pos_inds_list))
+        num_total_neg_thing = sum((inds.numel() for inds in neg_inds_list))
+        return (
+            labels_list,
+            label_weights_list,
+            bbox_targets_list,
+            bbox_weights_list,
+            mask_targets_list,
+            mask_weights_list,
+            num_total_pos_thing,
+            num_total_neg_thing,
+            pos_inds_list,
+        )
+
+    def _get_target_single_with_mask(
+        self,
+        cls_score,
+        bbox_pred,
+        masks_preds_things,
+        gt_bboxes,
+        gt_labels,
+        gt_masks,
+        img_meta,
+        gt_bboxes_ignore=None,
+    ):
+        """ """
+
+        num_bboxes = bbox_pred.size(0)
+
+        gt_masks = gt_masks.float()
+
+        assign_result = self.assigner_with_mask.assign(
+            bbox_pred,
+            cls_score,
+            masks_preds_things,
+            gt_bboxes,
+            gt_labels,
+            gt_masks,
+            img_meta,
+            gt_bboxes_ignore,
+        )
+        sampling_result = self.sampler_with_mask.sample(
+            assign_result, bbox_pred, gt_bboxes, gt_masks
+        )
+        pos_inds = sampling_result.pos_inds
+        neg_inds = sampling_result.neg_inds
+
+        labels = gt_bboxes.new_full(
+            (num_bboxes,), self.num_things_classes, dtype=torch.long
+        )
+        labels[pos_inds] = gt_labels[sampling_result.pos_assigned_gt_inds]
+        label_weights = gt_bboxes.new_ones(num_bboxes)
+
+        bbox_targets = torch.zeros_like(bbox_pred)
+        bbox_weights = torch.zeros_like(bbox_pred)
+        bbox_weights[pos_inds] = 1.0
+        img_h, img_w, _ = img_meta["img_shape"]
+
+        factor = bbox_pred.new_tensor([img_w, img_h, img_w, img_h]).unsqueeze(0)
+        pos_gt_bboxes_normalized = sampling_result.pos_gt_bboxes / factor
+        pos_gt_bboxes_targets = bbox_xyxy_to_cxcywh(pos_gt_bboxes_normalized)
+        bbox_targets[pos_inds] = pos_gt_bboxes_targets
+
+        mask_weights = masks_preds_things.new_zeros(num_bboxes)
+        mask_weights[pos_inds] = 1.0
+        pos_gt_masks = sampling_result.pos_gt_masks
+        _, w, h = pos_gt_masks.shape
+        mask_target = masks_preds_things.new_zeros([num_bboxes, w, h])
+        mask_target[pos_inds] = pos_gt_masks
+
+        return (
+            labels,
+            label_weights,
+            bbox_targets,
+            bbox_weights,
+            mask_target,
+            mask_weights,
+            pos_inds,
+            neg_inds,
+        )
+
+    def forward_test(
+        self,
+        pts_feats=None,
+        gt_lane_labels=None,
+        gt_lane_masks=None,
+        img_metas=None,
+        rescale=False,
+    ):
+        bbox_list = [dict() for i in range(len(img_metas))]
+
+        pred_seg_dict = self(pts_feats)
+        results = self.get_bboxes(
+            pred_seg_dict["outputs_classes"],
+            pred_seg_dict["outputs_coords"],
+            pred_seg_dict["enc_outputs_class"],
+            pred_seg_dict["enc_outputs_coord"],
+            pred_seg_dict["args_tuple"],
+            pred_seg_dict["reference"],
+            img_metas,
+            rescale=rescale,
+        )
+
+        with torch.no_grad():
+            drivable_pred = results[0]["drivable"]
+            drivable_gt = gt_lane_masks[0][0, -1]
+
+            drivable_iou, drivable_intersection, drivable_union = IOU(
+                drivable_pred.view(1, -1), drivable_gt.view(1, -1)
+            )
+
+            lane_pred = results[0]["lane"]
+            lanes_pred = (results[0]["lane"].sum(0) > 0).int()
+            lanes_gt = (gt_lane_masks[0][0][:-1].sum(0) > 0).int()
+            lanes_iou, lanes_intersection, lanes_union = IOU(
+                lanes_pred.view(1, -1), lanes_gt.view(1, -1)
+            )
+
+            divider_gt = (
+                gt_lane_masks[0][0][gt_lane_labels[0][0] == 0].sum(0) > 0
+            ).int()
+            crossing_gt = (
+                gt_lane_masks[0][0][gt_lane_labels[0][0] == 1].sum(0) > 0
+            ).int()
+            contour_gt = (
+                gt_lane_masks[0][0][gt_lane_labels[0][0] == 2].sum(0) > 0
+            ).int()
+            divider_iou, divider_intersection, divider_union = IOU(
+                lane_pred[0].view(1, -1), divider_gt.view(1, -1)
+            )
+            crossing_iou, crossing_intersection, crossing_union = IOU(
+                lane_pred[1].view(1, -1), crossing_gt.view(1, -1)
+            )
+            contour_iou, contour_intersection, contour_union = IOU(
+                lane_pred[2].view(1, -1), contour_gt.view(1, -1)
+            )
+
+            ret_iou = {
+                "drivable_intersection": drivable_intersection,
+                "drivable_union": drivable_union,
+                "lanes_intersection": lanes_intersection,
+                "lanes_union": lanes_union,
+                "divider_intersection": divider_intersection,
+                "divider_union": divider_union,
+                "crossing_intersection": crossing_intersection,
+                "crossing_union": crossing_union,
+                "contour_intersection": contour_intersection,
+                "contour_union": contour_union,
+                "drivable_iou": drivable_iou,
+                "lanes_iou": lanes_iou,
+                "divider_iou": divider_iou,
+                "crossing_iou": crossing_iou,
+                "contour_iou": contour_iou,
+            }
+        for result_dict, pts_bbox in zip(bbox_list, results):
+            result_dict["pts_bbox"] = pts_bbox
+            result_dict["ret_iou"] = ret_iou
+            result_dict["args_tuple"] = pred_seg_dict["args_tuple"]
+        return bbox_list
+
+    def _get_bboxes_single(
+        self, cls_score, bbox_pred, img_shape, scale_factor, rescale=False
+    ):
+        """ """
+        assert len(cls_score) == len(bbox_pred)
+        max_per_img = self.test_cfg.get("max_per_img", self.num_query)
+
+        cls_score = cls_score.sigmoid()
+        scores, indexes = cls_score.view(-1).topk(max_per_img)
+        det_labels = indexes % self.num_things_classes
+        bbox_index = indexes // self.num_things_classes
+        bbox_pred = bbox_pred[bbox_index]
+
+        det_bboxes = bbox_cxcywh_to_xyxy(bbox_pred)
+        det_bboxes[:, 0::2] = det_bboxes[:, 0::2] * img_shape[1]
+        det_bboxes[:, 1::2] = det_bboxes[:, 1::2] * img_shape[0]
+        det_bboxes[:, 0::2].clamp_(min=0, max=img_shape[1])
+        det_bboxes[:, 1::2].clamp_(min=0, max=img_shape[0])
+        if rescale:
+            det_bboxes /= det_bboxes.new_tensor(scale_factor)
+        det_bboxes = torch.cat((det_bboxes, scores.unsqueeze(1)), -1)
+
+        return bbox_index, det_bboxes, det_labels
+
+    def get_bboxes(
+        self,
+        all_cls_scores,
+        all_bbox_preds,
+        enc_cls_scores,
+        enc_bbox_preds,
+        args_tuple,
+        reference,
+        img_metas,
+        rescale=False,
+    ):
+        """ """
+        cls_scores = all_cls_scores[-1]
+        bbox_preds = all_bbox_preds[-1]
+        memory, memory_mask, memory_pos, query, _, query_pos, hw_lvl = args_tuple
+
+        seg_list = []
+        stuff_score_list = []
+        panoptic_list = []
+        bbox_list = []
+        labels_list = []
+        drivable_list = []
+        lane_list = []
+        lane_score_list = []
+        score_list = []
+        for img_id in range(len(img_metas)):
+            cls_score = cls_scores[img_id]
+            bbox_pred = bbox_preds[img_id]
+
+            img_shape = (self.canvas_size[0], self.canvas_size[1], 3)
+            ori_shape = (self.canvas_size[0], self.canvas_size[1], 3)
+            scale_factor = 1
+
+            index, bbox, labels = self._get_bboxes_single(
+                cls_score, bbox_pred, img_shape, scale_factor, rescale
+            )
+
+            i = img_id
+            thing_query = query[i : i + 1, index, :]
+            thing_query_pos = query_pos[i : i + 1, index, :]
+            joint_query = torch.cat(
+                [thing_query, self.stuff_query.weight[None, :, : self.embed_dims]], 1
+            )
+
+            stuff_query_pos = self.stuff_query.weight[None, :, self.embed_dims :]
+
+            mask_things, mask_inter_things, query_inter_things = self.things_mask_head(
+                memory[i : i + 1],
+                memory_mask[i : i + 1],
+                None,
+                joint_query[:, : -self.num_stuff_classes],
+                None,
+                None,
+                hw_lvl=hw_lvl,
+            )
+            mask_stuff, mask_inter_stuff, query_inter_stuff = self.stuff_mask_head(
+                memory[i : i + 1],
+                memory_mask[i : i + 1],
+                None,
+                joint_query[:, -self.num_stuff_classes :],
+                None,
+                stuff_query_pos,
+                hw_lvl=hw_lvl,
+            )
+
+            attn_map = torch.cat([mask_things, mask_stuff], 1)
+            attn_map = attn_map.squeeze(-1)
+
+            stuff_query = query_inter_stuff[-1]
+            scores_stuff = (
+                self.cls_stuff_branches[-1](stuff_query).sigmoid().reshape(-1)
+            )
+
+            mask_pred = attn_map.reshape(-1, *hw_lvl[0])
+
+            mask_pred = F.interpolate(
+                mask_pred.unsqueeze(0), size=ori_shape[:2], mode="bilinear"
+            ).squeeze(0)
+
+            masks_all = mask_pred
+            score_list.append(masks_all)
+            drivable_list.append(masks_all[-1] > 0.5)
+            masks_all = masks_all[: -self.num_stuff_classes]
+            seg_all = masks_all > 0.5
+            sum_seg_all = seg_all.sum((1, 2)).float() + 1
+
+            scores_all = bbox[:, -1]
+            bboxes_all = bbox
+            labels_all = labels
+
+            seg_scores = (masks_all * seg_all.float()).sum((1, 2)) / sum_seg_all
+            scores_all *= seg_scores**2
+
+            scores_all, index = torch.sort(scores_all, descending=True)
+
+            masks_all = masks_all[index]
+            labels_all = labels_all[index]
+            bboxes_all = bboxes_all[index]
+            seg_all = seg_all[index]
+
+            bboxes_all[:, -1] = scores_all
+
+            things_selected = labels_all < self.num_things_classes
+            stuff_selected = labels_all >= self.num_things_classes
+            bbox_th = bboxes_all[things_selected][:100]
+            labels_th = labels_all[things_selected][:100]
+            seg_th = seg_all[things_selected][:100]
+            labels_st = labels_all[stuff_selected]
+            scores_st = scores_all[stuff_selected]
+            masks_st = masks_all[stuff_selected]
+
+            stuff_score_list.append(scores_st)
+
+            results = torch.zeros((2, *mask_pred.shape[-2:])).to(torch.long)
+            id_unique = 1
+            lane = torch.zeros((self.num_things_classes, *mask_pred.shape[-2:])).to(
+                torch.long
+            )
+            lane_score = torch.zeros(
+                (self.num_things_classes, *mask_pred.shape[-2:])
+            ).to(mask_pred.dtype)
+            for i, scores in enumerate(scores_all):
+                if (
+                    labels_all[i] < self.num_things_classes
+                    and scores < self.quality_threshold_things
+                ):
+                    continue
+                elif (
+                    labels_all[i] >= self.num_things_classes
+                    and scores < self.quality_threshold_stuff
+                ):
+                    continue
+                _mask = masks_all[i] > 0.5
+                mask_area = _mask.sum().item()
+                intersect = _mask & (results[0] > 0)
+                intersect_area = intersect.sum().item()
+                if labels_all[i] < self.num_things_classes:
+                    if (
+                        mask_area == 0
+                        or (intersect_area * 1.0 / mask_area)
+                        > self.overlap_threshold_things
+                    ):
+                        continue
+                if intersect_area > 0:
+                    _mask = _mask & (results[0] == 0)
+                results[0, _mask] = labels_all[i]
+                if labels_all[i] < self.num_things_classes:
+                    lane[labels_all[i], _mask] = 1
+                    lane_score[labels_all[i], _mask] = masks_all[i][_mask]
+                    results[1, _mask] = id_unique
+                    id_unique += 1
+
+            panoptic_list.append((results.permute(1, 2, 0).numpy(), ori_shape))
+
+            bbox_list.append(bbox_th)
+            labels_list.append(labels_th)
+            seg_list.append(seg_th)
+            lane_list.append(lane)
+            lane_score_list.append(lane_score)
+        results = []
+        for i in range(len(img_metas)):
+            results.append(
+                {
+                    "bbox": bbox_list[i],
+                    "segm": seg_list[i],
+                    "labels": labels_list[i],
+                    "panoptic": panoptic_list[i],
+                    "drivable": drivable_list[i],
+                    "score_list": score_list[i],
+                    "lane": lane_list[i],
+                    "lane_score": lane_score_list[i],
+                    "stuff_score_list": stuff_score_list[i],
+                }
+            )
+        return results
+
+
+class Mlp(nn.Module):
+    def __init__(
+        self,
+        in_features,
+        hidden_features=None,
+        out_features=None,
+        act_layer=nn.GELU,
+        drop=0.0,
+    ):
+        super().__init__()
+        self.fp16_enabled = False
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features)
+
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+
+class SelfAttention(nn.Module):
+    def __init__(
+        self,
+        cfg,
+        dim,
+        num_heads=2,
+        qkv_bias=False,
+        qk_scale=None,
+        attn_drop=0.0,
+        proj_drop=0.0,
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.fp16_enabled = False
+        self.scale = qk_scale or head_dim**-0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x):
+        B, N, C = x.shape
+
+        qkv = (
+            self.qkv(x)
+            .reshape(B, N, 3, self.num_heads, C // self.num_heads)
+            .permute(2, 0, 3, 1, 4)
+            .contiguous()
+        )
+        q, k, v = qkv[0], qkv[1], qkv[2]
+
+        attn = (q @ k.transpose(-2, -1)) * self.scale
+
+        attn = attn.softmax(dim=-1)
+        attn = self.attn_drop(attn)
+        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+
+        return x
+
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        cfg,
+        dim,
+        num_heads=2,
+        qkv_bias=False,
+        qk_scale=None,
+        attn_drop=0.0,
+        proj_drop=0.0,
+    ):
+        super().__init__()
+        self.fp16_enabled = False
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+        self.q = nn.Linear(dim, dim, bias=qkv_bias)
+        self.k = nn.Linear(dim, dim, bias=qkv_bias)
+        self.v = nn.Linear(dim, dim, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.linear_l1 = nn.Sequential(
+            nn.Linear(self.num_heads, self.num_heads),
+            nn.ReLU(),
+        )
+        self.linear = nn.Sequential(
+            nn.Linear(self.num_heads, 1),
+            nn.ReLU(),
+        )
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def forward(self, query, key, value, key_padding_mask, hw_lvl):
+        B, N, C = query.shape
+        _, L, _ = key.shape
+        q = (
+            self.q(query)
+            .reshape(B, N, self.num_heads, C // self.num_heads)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+        k = (
+            self.k(key)
+            .reshape(B, L, self.num_heads, C // self.num_heads)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+
+        v = (
+            self.v(value)
+            .reshape(B, L, self.num_heads, C // self.num_heads)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+
+        attn = (q @ k.transpose(-2, -1).contiguous()) * self.scale
+
+        attn = attn.permute(0, 2, 3, 1)
+
+        new_feats = self.linear_l1(attn)
+        mask = self.linear(new_feats)
+
+        attn = attn.permute(0, 3, 1, 2)
+        attn = attn.softmax(dim=-1)
+        attn = self.attn_drop(attn)
+
+        x = (attn @ v).transpose(1, 2).contiguous().reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x, mask
+
+
+class AttentionTail(nn.Module):
+    def __init__(
+        self,
+        cfg,
+        dim,
+        num_heads=2,
+        qkv_bias=False,
+        qk_scale=None,
+        attn_drop=0.0,
+        proj_drop=0.0,
+    ):
+        super().__init__()
+        self.fp16_enabled = False
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim**-0.5
+        self.q = nn.Linear(dim, dim, bias=qkv_bias)
+        self.k = nn.Linear(dim, dim, bias=qkv_bias)
+
+        self.linear_l1 = nn.Sequential(
+            nn.Linear(self.num_heads, self.num_heads),
+            nn.ReLU(),
+        )
+
+        self.linear = nn.Sequential(
+            nn.Linear(self.num_heads, 1),
+            nn.ReLU(),
+        )
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def forward(self, query, key, key_padding_mask, hw_lvl=None):
+        B, N, C = query.shape
+        _, L, _ = key.shape
+        q = (
+            self.q(query)
+            .reshape(B, N, self.num_heads, C // self.num_heads)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+        k = (
+            self.k(key)
+            .reshape(B, L, self.num_heads, C // self.num_heads)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+        attn = (q @ k.transpose(-2, -1).contiguous()) * self.scale
+
+        attn = attn.permute(0, 2, 3, 1)
+
+        new_feats = self.linear_l1(attn)
+        mask = self.linear(new_feats)
+        return mask
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        cfg,
+        dim,
+        num_heads,
+        mlp_ratio=4.0,
+        qkv_bias=False,
+        qk_scale=None,
+        drop=0.0,
+        attn_drop=0.0,
+        drop_path=0.0,
+        act_layer=nn.GELU,
+        norm_layer=nn.LayerNorm,
+        self_attn=False,
+    ):
+        super().__init__()
+        self.fp16_enabled = False
+        self.head_norm1 = norm_layer(dim)
+        self.self_attn = self_attn
+        self.attn = Attention(
+            cfg,
+            dim,
+            num_heads=num_heads,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+            attn_drop=attn_drop,
+            proj_drop=drop,
+        )
+
+        self.drop_path = DropPath(drop_path) if drop_path > 0.0 else nn.Identity()
+        self.head_norm2 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(
+            in_features=dim,
+            hidden_features=mlp_hidden_dim,
+            act_layer=act_layer,
+            drop=drop,
+        )
+        if self.self_attn:
+            self.self_attention = SelfAttention(
+                cfg,
+                dim,
+                num_heads=num_heads,
+                qkv_bias=qkv_bias,
+                qk_scale=qk_scale,
+                attn_drop=attn_drop,
+                proj_drop=drop,
+            )
+            self.norm3 = norm_layer(dim)
+
+    def forward(self, query, key, value, key_padding_mask=None, hw_lvl=None):
+        if self.self_attn:
+            query = query + self.drop_path(self.self_attention(query))
+            query = self.norm3(query)
+        x, mask = self.attn(query, key, value, key_padding_mask, hw_lvl=hw_lvl)
+        query = query + self.drop_path(x)
+        query = self.head_norm1(query)
+
+        query = query + self.drop_path(self.mlp(query))
+        query = self.head_norm2(query)
+        return query, mask
+
+
+def drop_path(x, drop_prob: float = 0.0, training: bool = False):
+    """Drop paths (Stochastic Depth) per sample (when applied in main path of residual blocks).
+    This is the same as the DropConnect impl I created for EfficientNet, etc networks, however,
+    the original name is misleading as 'Drop Connect' is a different form of dropout in a separate paper...
+    See discussion: https://github.com/tensorflow/tpu/issues/494#issuecomment-53296self.num_heads956 ... I've opted for
+    changing the layer and argument names to 'drop path' rather than mix DropConnect as a layer name and use
+    'survival rate' as the argument.
+    """
+    if drop_prob == 0.0 or not training:
+        return x
+    keep_prob = 1 - drop_prob
+    shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+    random_tensor = keep_prob + torch.rand(shape, dtype=x.dtype)
+    random_tensor.floor_()
+    output = x.div(keep_prob) * random_tensor
+    return output
+
+
+def _get_clones(module, N):
+    return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+
+class DropPath(nn.Module):
+    """Drop paths (Stochastic Depth) per sample  (when applied in main path of residual blocks)."""
+
+    def __init__(self, drop_prob=None):
+        super(DropPath, self).__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x):
+        return drop_path(x, self.drop_prob, self.training)
+
+
+class SegMaskHead(nn.Module):
+    def __init__(
+        self,
+        cfg=None,
+        d_model=256,
+        nhead=8,
+        num_encoder_layers=4,
+        num_decoder_layers=6,
+        dim_feedforward=64,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+        self_attn=False,
+    ):
+        super().__init__()
+
+        self.fp16_enabled = False
+        mlp_ratio = 4
+        qkv_bias = True
+        qk_scale = None
+        drop_rate = 0
+        attn_drop_rate = 0
+
+        norm_layer = None
+        norm_layer = norm_layer or partial(nn.LayerNorm, eps=1e-6)
+        act_layer = None
+        act_layer = act_layer or nn.GELU
+        block = Block(
+            cfg,
+            dim=d_model,
+            num_heads=nhead,
+            mlp_ratio=mlp_ratio,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+            drop=drop_rate,
+            attn_drop=attn_drop_rate,
+            drop_path=0,
+            norm_layer=norm_layer,
+            act_layer=act_layer,
+            self_attn=self_attn,
+        )
+        self.blocks = _get_clones(block, num_decoder_layers)
+        self.attnen = AttentionTail(
+            cfg,
+            d_model,
+            num_heads=nhead,
+            qkv_bias=qkv_bias,
+            qk_scale=qk_scale,
+            attn_drop=attn_drop_rate,
+            proj_drop=0,
+        )
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def with_pos_embed(self, tensor, pos: Optional[Tensor]):
+        if pos is None:
+            return tensor
+        else:
+            return tensor + pos
+
+    def forward(
+        self,
+        memory,
+        mask_memory,
+        pos_memory,
+        query_embed,
+        mask_query,
+        pos_query,
+        hw_lvl,
+    ):
+        if mask_memory is not None and isinstance(mask_memory, torch.Tensor):
+            mask_memory = mask_memory.to(torch.bool)
+        masks = []
+        inter_query = []
+        for i, block in enumerate(self.blocks):
+            query_embed, mask = block(
+                self.with_pos_embed(query_embed, pos_query),
+                self.with_pos_embed(memory, pos_memory),
+                memory,
+                key_padding_mask=mask_memory,
+                hw_lvl=hw_lvl,
+            )
+            masks.append(mask)
+            inter_query.append(query_embed)
+        attn = self.attnen(
+            self.with_pos_embed(query_embed, pos_query),
+            self.with_pos_embed(memory, pos_memory),
+            key_padding_mask=mask_memory,
+            hw_lvl=hw_lvl,
+        )
+        return attn, masks, inter_query

--- a/uniad/pytorch/src/panseg_utils.py
+++ b/uniad/pytorch/src/panseg_utils.py
@@ -1,0 +1,975 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from torch import nn, Tensor
+from functools import partial
+import torch.distributed as dist
+import math
+import numpy as np
+from torch.nn.init import normal_
+import copy
+import warnings
+import torch.nn.functional as F
+from third_party.tt_forge_models.uniad.pytorch.src.utils import *
+from third_party.tt_forge_models.uniad.pytorch.src.transformer import *
+
+
+def IOU(intputs, targets):
+    numerator = (intputs * targets).sum(dim=1)
+    denominator = intputs.sum(dim=1) + targets.sum(dim=1) - numerator
+    loss = numerator / (denominator + 1e-13)
+
+    return loss, numerator, denominator
+
+
+def bias_init_with_prob(prior_prob):
+    """initialize conv/fc bias value according to a given probability value."""
+    bias_init = float(-np.log((1 - prior_prob) / prior_prob))
+    return bias_init
+
+
+def bbox_cxcywh_to_xyxy(bbox):
+    """Convert bbox coordinates from (cx, cy, w, h) to (x1, y1, x2, y2).
+
+    Args:
+        bbox (Tensor): Shape (n, 4) for bboxes.
+
+    Returns:
+        Tensor: Converted bboxes.
+    """
+    cx, cy, w, h = bbox.split((1, 1, 1, 1), dim=-1)
+    bbox_new = [(cx - 0.5 * w), (cy - 0.5 * h), (cx + 0.5 * w), (cy + 0.5 * h)]
+    return torch.cat(bbox_new, dim=-1)
+
+
+def bbox_xyxy_to_cxcywh(bbox):
+    """Convert bbox coordinates from (x1, y1, x2, y2) to (cx, cy, w, h).
+
+    Args:
+        bbox (Tensor): Shape (n, 4) for bboxes.
+
+    Returns:
+        Tensor: Converted bboxes.
+    """
+    x1, y1, x2, y2 = bbox.split((1, 1, 1, 1), dim=-1)
+    bbox_new = [(x1 + x2) / 2, (y1 + y2) / 2, (x2 - x1), (y2 - y1)]
+    return torch.cat(bbox_new, dim=-1)
+
+
+def multi_apply(func, *args, **kwargs):
+    """Apply function to a list of arguments.
+
+    Note:
+        This function applies the ``func`` to multiple inputs and
+        map the multiple outputs of the ``func`` into different
+        list. Each list contains the same type of outputs corresponding
+        to different inputs.
+
+    Args:
+        func (Function): A function that will be applied to a list of
+            arguments
+
+    Returns:
+        tuple(list): A tuple containing multiple list, each list contains \
+            a kind of returned results by the function
+    """
+    pfunc = partial(func, **kwargs) if kwargs else func
+    map_results = map(pfunc, *args)
+    return tuple(map(list, zip(*map_results)))
+
+
+class SinePositionalEncoding(nn.Module):
+    """Position encoding with sine and cosine functions.
+
+    See `End-to-End Object Detection with Transformers
+    <https://arxiv.org/pdf/2005.12872>`_ for details.
+
+    Args:
+        num_feats (int): The feature dimension for each position
+            along x-axis or y-axis. Note the final returned dimension
+            for each position is 2 times of this value.
+        temperature (int, optional): The temperature used for scaling
+            the position embedding. Defaults to 10000.
+        normalize (bool, optional): Whether to normalize the position
+            embedding. Defaults to False.
+        scale (float, optional): A scale factor that scales the position
+            embedding. The scale will be used only when `normalize` is True.
+            Defaults to 2*pi.
+        eps (float, optional): A value added to the denominator for
+            numerical stability. Defaults to 1e-6.
+        offset (float): offset add to embed when do the normalization.
+            Defaults to 0.
+    """
+
+    def __init__(
+        self,
+        num_feats=128,
+        temperature=10000,
+        normalize=True,
+        scale=2 * math.pi,
+        eps=1e-6,
+        offset=0.5,
+    ):
+        super().__init__()
+        if normalize:
+            assert isinstance(scale, (float, int)), (
+                "when normalize is set,"
+                "scale should be provided and in float or int type, "
+                f"found {type(scale)}"
+            )
+        self.num_feats = 128
+        self.temperature = 10000
+        self.normalize = normalize
+        self.scale = 6.283185307179586
+        self.eps = 1e-06
+        self.offset = -0.5
+
+    def forward(self, mask):
+        """Forward function for `SinePositionalEncoding`.
+
+        Args:
+            mask (Tensor): ByteTensor mask. Non-zero values representing
+                ignored positions, while zero values means valid positions
+                for this image. Shape [bs, h, w].
+
+        Returns:
+            pos (Tensor): Returned position embedding with shape
+                [bs, num_feats*2, h, w].
+        """
+
+        mask = mask.to(torch.int)
+        not_mask = 1 - mask
+        y_embed = not_mask.cumsum(1, dtype=torch.float32)
+        x_embed = not_mask.cumsum(2, dtype=torch.float32)
+        if self.normalize:
+            y_embed = (
+                (y_embed + self.offset) / (y_embed[:, -1:, :] + self.eps) * self.scale
+            )
+            x_embed = (
+                (x_embed + self.offset) / (x_embed[:, :, -1:] + self.eps) * self.scale
+            )
+        dim_t = torch.arange(self.num_feats, dtype=torch.float32)
+        dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_feats)
+        pos_x = x_embed[:, :, :, None] / dim_t
+        pos_y = y_embed[:, :, :, None] / dim_t
+        B, H, W = mask.size()
+        pos_x = torch.stack(
+            (pos_x[:, :, :, 0::2].sin(), pos_x[:, :, :, 1::2].cos()), dim=4
+        ).view(B, H, W, -1)
+        pos_y = torch.stack(
+            (pos_y[:, :, :, 0::2].sin(), pos_y[:, :, :, 1::2].cos()), dim=4
+        ).view(B, H, W, -1)
+        pos = torch.cat((pos_y, pos_x), dim=3).permute(0, 3, 1, 2)
+        return pos
+
+    def __repr__(self):
+        """str: a string that describes the module"""
+        repr_str = self.__class__.__name__
+        repr_str += f"(num_feats={self.num_feats}, "
+        repr_str += f"temperature={self.temperature}, "
+        repr_str += f"normalize={self.normalize}, "
+        repr_str += f"scale={self.scale}, "
+        repr_str += f"eps={self.eps})"
+        return repr_str
+
+
+class Transformer(nn.Module):
+    """Implements the DETR transformer.
+
+    Following the official DETR implementation, this module copy-paste
+    from torch.nn.Transformer with modifications:
+
+        * positional encodings are passed in MultiheadAttention
+        * extra LN at the end of encoder is removed
+        * decoder returns a stack of activations from all decoding layers
+
+    See `paper: End-to-End Object Detection with Transformers
+    <https://arxiv.org/pdf/2005.12872>`_ for details.
+
+    Args:
+        encoder (`mmcv.ConfigDict` | Dict): Config of
+            TransformerEncoder. Defaults to None.
+        decoder ((`mmcv.ConfigDict` | Dict)): Config of
+            TransformerDecoder. Defaults to None
+    """
+
+    def __init__(self, encoder=None, decoder=None):
+        super(Transformer, self).__init__()
+        self.encoder = DetrTransformerEncoder()
+        self.decoder = DeformableDetrTransformerDecoder()
+        self.embed_dims = self.encoder.embed_dims
+
+    def forward(self, x, mask, query_embed, pos_embed):
+        """Forward function for `Transformer`.
+
+        Args:
+            x (Tensor): Input query with shape [bs, c, h, w] where
+                c = embed_dims.
+            mask (Tensor): The key_padding_mask used for encoder and decoder,
+                with shape [bs, h, w].
+            query_embed (Tensor): The query embedding for decoder, with shape
+                [num_query, c].
+            pos_embed (Tensor): The positional encoding for encoder and
+                decoder, with the same shape as `x`.
+
+        Returns:
+            tuple[Tensor]: results of decoder containing the following tensor.
+
+                - out_dec: Output from decoder. If return_intermediate_dec \
+                      is True output has shape [num_dec_layers, bs,
+                      num_query, embed_dims], else has shape [1, bs, \
+                      num_query, embed_dims].
+                - memory: Output results from encoder, with shape \
+                      [bs, embed_dims, h, w].
+        """
+        bs, c, h, w = x.shape
+        x = x.view(bs, c, -1).permute(2, 0, 1)
+        pos_embed = pos_embed.view(bs, c, -1).permute(2, 0, 1)
+        query_embed = query_embed.unsqueeze(1).repeat(1, bs, 1)
+        mask = mask.view(bs, -1)
+        memory = self.encoder(
+            query=x,
+            key=None,
+            value=None,
+            query_pos=pos_embed,
+            query_key_padding_mask=mask,
+        )
+        target = torch.zeros_like(query_embed)
+        out_dec = self.decoder(
+            query=target,
+            key=memory,
+            value=memory,
+            key_pos=pos_embed,
+            query_pos=query_embed,
+            key_padding_mask=mask,
+        )
+        out_dec = out_dec.transpose(1, 2)
+        memory = memory.permute(1, 2, 0).reshape(bs, c, h, w)
+        return out_dec, memory
+
+
+class SegDeformableTransformer(Transformer):
+
+    """Implements the DeformableDETR transformer.
+
+    Args:
+        as_two_stage (bool): Generate query from encoder features.
+            Default: False.
+        num_feature_levels (int): Number of feature maps from FPN:
+            Default: 4.
+        two_stage_num_proposals (int): Number of proposals when set
+            `as_two_stage` as True. Default: 300.
+    """
+
+    def __init__(
+        self,
+        as_two_stage=False,
+        num_feature_levels=4,
+        two_stage_num_proposals=300,
+        **kwargs,
+    ):
+        super(SegDeformableTransformer, self).__init__(**kwargs)
+        self.fp16_enabled = False
+        self.as_two_stage = as_two_stage
+        self.num_feature_levels = num_feature_levels
+        self.two_stage_num_proposals = two_stage_num_proposals
+        self.embed_dims = self.encoder.embed_dims
+        self.init_layers()
+
+    def init_layers(self):
+        """Initialize layers of the DeformableDetrTransformer."""
+        self.level_embeds = nn.Parameter(
+            torch.Tensor(self.num_feature_levels, self.embed_dims)
+        )
+
+        self.reference_points = nn.Linear(self.embed_dims, 2)
+
+    def gen_encoder_output_proposals(self, memory, memory_padding_mask, spatial_shapes):
+        """Generate proposals from encoded memory.
+
+        Args:
+            memory (Tensor) : The output of encoder,
+                has shape (bs, num_key, embed_dim).  num_key is
+                equal the number of points on feature map from
+                all level.
+            memory_padding_mask (Tensor): Padding mask for memory.
+                has shape (bs, num_key).
+            spatial_shapes (Tensor): The shape of all feature maps.
+                has shape (num_level, 2).
+
+        Returns:
+            tuple: A tuple of feature map and bbox prediction.
+
+                - output_memory (Tensor): The input of decoder,  \
+                    has shape (bs, num_key, embed_dim).  num_key is \
+                    equal the number of points on feature map from \
+                    all levels.
+                - output_proposals (Tensor): The normalized proposal \
+                    after a inverse sigmoid, has shape \
+                    (bs, num_keys, 4).
+        """
+
+        N, S, C = memory.shape
+        proposals = []
+        _cur = 0
+        for lvl, (H, W) in enumerate(spatial_shapes):
+            mask_flatten_ = memory_padding_mask[:, _cur : (_cur + H * W)].view(
+                N, H, W, 1
+            )
+            valid_H = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
+            valid_W = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
+
+            grid_y, grid_x = torch.meshgrid(
+                torch.linspace(0, H - 1, H, dtype=torch.float32),
+                torch.linspace(0, W - 1, W, dtype=torch.float32),
+            )
+            grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)
+
+            scale = torch.cat([valid_W.unsqueeze(-1), valid_H.unsqueeze(-1)], 1).view(
+                N, 1, 1, 2
+            )
+            grid = (grid.unsqueeze(0).expand(N, -1, -1, -1) + 0.5) / scale
+            wh = torch.ones_like(grid) * 0.05 * (2.0**lvl)
+            proposal = torch.cat((grid, wh), -1).view(N, -1, 4)
+            proposals.append(proposal)
+            _cur += H * W
+        output_proposals = torch.cat(proposals, 1)
+        output_proposals_valid = (
+            (output_proposals > 0.01) & (output_proposals < 0.99)
+        ).all(-1, keepdim=True)
+        output_proposals = torch.log(output_proposals / (1 - output_proposals))
+        output_proposals = output_proposals.masked_fill(
+            memory_padding_mask.unsqueeze(-1), float("inf")
+        )
+        output_proposals = output_proposals.masked_fill(
+            ~output_proposals_valid, float("inf")
+        )
+
+        output_memory = memory
+        output_memory = output_memory.masked_fill(
+            memory_padding_mask.unsqueeze(-1), float(0)
+        )
+        output_memory = output_memory.masked_fill(~output_proposals_valid, float(0))
+        output_memory = self.enc_output_norm(self.enc_output(output_memory))
+        return output_memory, output_proposals
+
+    @staticmethod
+    def get_reference_points(spatial_shapes, valid_ratios):
+        """Get the reference points used in decoder.
+
+        Args:
+            spatial_shapes (Tensor): The shape of all
+                feature maps, has shape (num_level, 2).
+            valid_ratios (Tensor): The radios of valid
+                points on the feature map, has shape
+                (bs, num_levels, 2)
+
+
+        Returns:
+            Tensor: reference points used in decoder, has \
+                shape (bs, num_keys, num_levels, 2).
+        """
+        reference_points_list = []
+        for lvl, (H, W) in enumerate(spatial_shapes):
+            ref_y, ref_x = torch.meshgrid(
+                torch.linspace(0.5, H - 0.5, H, dtype=torch.float32),
+                torch.linspace(0.5, W - 0.5, W, dtype=torch.float32),
+            )
+            ref_y = ref_y.reshape(-1)[None] / (valid_ratios[:, None, lvl, 1] * H)
+            ref_x = ref_x.reshape(-1)[None] / (valid_ratios[:, None, lvl, 0] * W)
+            ref = torch.stack((ref_x, ref_y), -1)
+            reference_points_list.append(ref)
+        reference_points = torch.cat(reference_points_list, 1)
+        reference_points = reference_points[:, :, None] * valid_ratios[:, None]
+        return reference_points
+
+    def get_valid_ratio(self, mask):
+        """Get the valid radios of feature maps of all  level."""
+        _, H, W = mask.shape
+        valid_H = torch.sum(~mask[:, :, 0], 1)
+        valid_W = torch.sum(~mask[:, 0, :], 1)
+        valid_ratio_h = valid_H.float() / H
+        valid_ratio_w = valid_W.float() / W
+        valid_ratio = torch.stack([valid_ratio_w, valid_ratio_h], -1)
+        return valid_ratio
+
+    def get_proposal_pos_embed(self, proposals, num_pos_feats=128, temperature=10000):
+        """Get the position embedding of proposal."""
+        scale = 2 * math.pi
+        dim_t = torch.arange(num_pos_feats, dtype=torch.float32)
+        dim_t = temperature ** (2 * (dim_t // 2) / num_pos_feats)
+        proposals = proposals.sigmoid() * scale
+        pos = proposals[:, :, :, None] / dim_t
+        pos = torch.stack(
+            (pos[:, :, :, 0::2].sin(), pos[:, :, :, 1::2].cos()), dim=4
+        ).flatten(2)
+        return pos
+
+    def forward(
+        self,
+        mlvl_feats,
+        mlvl_masks,
+        query_embed,
+        mlvl_pos_embeds,
+        reg_branches=None,
+        cls_branches=None,
+        **kwargs,
+    ):
+        """Forward function for `Transformer`.
+
+        Args:
+            mlvl_feats (list(Tensor)): Input queries from
+                different level. Each element has shape
+                [bs, embed_dims, h, w].
+            mlvl_masks (list(Tensor)): The key_padding_mask from
+                different level used for encoder and decoder,
+                each element has shape  [bs, h, w].
+            query_embed (Tensor): The query embedding for decoder,
+                with shape [num_query, c].
+            mlvl_pos_embeds (list(Tensor)): The positional encoding
+                of feats from different level, has the shape
+                 [bs, embed_dims, h, w].
+            reg_branches (obj:`nn.ModuleList`): Regression heads for
+                feature maps from each decoder layer. Only would
+                be passed when
+                `with_box_refine` is True. Default to None.
+            cls_branches (obj:`nn.ModuleList`): Classification heads
+                for feature maps from each decoder layer. Only would
+                 be passed when `as_two_stage`
+                 is True. Default to None.
+
+
+        Returns:
+            tuple[Tensor]: results of decoder containing the following tensor.
+
+                - inter_states: Outputs from decoder. If
+                    return_intermediate_dec is True output has shape \
+                      (num_dec_layers, bs, num_query, embed_dims), else has \
+                      shape (1, bs, num_query, embed_dims).
+                - init_reference_out: The initial value of reference \
+                    points, has shape (bs, num_queries, 4).
+                - inter_references_out: The internal value of reference \
+                    points in decoder, has shape \
+                    (num_dec_layers, bs,num_query, embed_dims)
+                - enc_outputs_class: The classification score of \
+                    proposals generated from \
+                    encoder's feature maps, has shape \
+                    (batch, h*w, num_classes). \
+                    Only would be returned when `as_two_stage` is True, \
+                    otherwise None.
+                - enc_outputs_coord_unact: The regression results \
+                    generated from encoder's feature maps., has shape \
+                    (batch, h*w, 4). Only would \
+                    be returned when `as_two_stage` is True, \
+                    otherwise None.
+        """
+
+        assert self.as_two_stage or query_embed is not None
+        feat_flatten = []
+        mask_flatten = []
+        lvl_pos_embed_flatten = []
+        spatial_shapes = []
+        for lvl, (feat, mask, pos_embed) in enumerate(
+            zip(mlvl_feats, mlvl_masks, mlvl_pos_embeds)
+        ):
+            bs, c, h, w = feat.shape
+            spatial_shape = (h, w)
+            spatial_shapes.append(spatial_shape)
+            feat = feat.flatten(2).transpose(1, 2)
+            mask = mask.flatten(1)
+            pos_embed = pos_embed.flatten(2).transpose(1, 2)
+            lvl_pos_embed = pos_embed + self.level_embeds[lvl].view(1, 1, -1)
+            lvl_pos_embed_flatten.append(lvl_pos_embed)
+            feat_flatten.append(feat)
+            mask_flatten.append(mask)
+        feat_flatten = torch.cat(feat_flatten, 1)
+        mask_flatten = torch.cat(mask_flatten, 1)
+        lvl_pos_embed_flatten = torch.cat(lvl_pos_embed_flatten, 1)
+        spatial_shapes = torch.as_tensor(spatial_shapes, dtype=torch.long)
+        level_start_index = torch.cat(
+            (spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1])
+        )
+        valid_ratios = torch.stack([self.get_valid_ratio(m) for m in mlvl_masks], 1)
+
+        reference_points = self.get_reference_points(spatial_shapes, valid_ratios)
+
+        feat_flatten = feat_flatten.permute(1, 0, 2)
+        lvl_pos_embed_flatten = lvl_pos_embed_flatten.permute(1, 0, 2)
+        memory = self.encoder(
+            query=feat_flatten,
+            key=None,
+            value=None,
+            query_pos=lvl_pos_embed_flatten,
+            query_key_padding_mask=mask_flatten,
+            spatial_shapes=spatial_shapes,
+            reference_points=reference_points,
+            level_start_index=level_start_index,
+            valid_ratios=valid_ratios,
+            **kwargs,
+        )
+
+        memory = memory.permute(1, 0, 2)
+        bs, _, c = memory.shape
+
+        query_pos, query = torch.split(query_embed, c, dim=1)
+        query_pos = query_pos.unsqueeze(0).expand(bs, -1, -1)
+        query = query.unsqueeze(0).expand(bs, -1, -1)
+        reference_points = self.reference_points(query_pos).sigmoid()
+        init_reference_out = reference_points
+
+        query = query.permute(1, 0, 2)
+        memory = memory.permute(1, 0, 2)
+        query_pos = query_pos.permute(1, 0, 2)
+        inter_states, inter_references = self.decoder(
+            query=query,
+            key=None,
+            value=memory,
+            query_pos=query_pos,
+            key_padding_mask=mask_flatten,
+            reference_points=reference_points,
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+            valid_ratios=valid_ratios,
+            reg_branches=reg_branches,
+            **kwargs,
+        )
+        inter_references_out = inter_references
+        if self.as_two_stage:
+            return (
+                (memory, lvl_pos_embed_flatten, mask_flatten, query_pos),
+                inter_states,
+                init_reference_out,
+                inter_references_out,
+                enc_outputs_class,
+                enc_outputs_coord_unact,
+            )
+        return (
+            (memory, lvl_pos_embed_flatten, mask_flatten, query_pos),
+            inter_states,
+            init_reference_out,
+            inter_references_out,
+            None,
+            None,
+        )
+
+
+class DetrTransformerEncoder(TransformerLayerSequence):
+    """TransformerEncoder of DETR.
+
+    Args:
+        post_norm_cfg (dict): Config of last normalization layer. Default：
+            `LN`. Only used when `self.pre_norm` is `True`
+    """
+
+    def __init__(
+        self,
+        attn_cfgs={
+            "type": "MultiScaleDeformableAttention",
+            "embed_dims": 256,
+            "num_levels": 1,
+        },
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=512,
+            num_fcs=2,
+            ffn_drop=0.1,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=("self_attn", "norm", "ffn", "norm"),
+        post_norm_cfg=dict(type="LN"),
+        num_layers=6,
+        **kwargs,
+    ):
+
+        super().__init__(
+            transformerlayers=BaseTransformerLayer,
+            num_layers=num_layers,
+            attn_cfgs=attn_cfgs,
+            ffn_cfgs=ffn_cfgs,
+            operation_order=operation_order,
+            **kwargs,
+        )
+        self.post_norm = (
+            torch.nn.LayerNorm((256,), eps=1e-05, elementwise_affine=True)
+            if self.pre_norm
+            else None
+        )
+
+    def forward(self, *args, **kwargs):
+        """Forward function for `TransformerCoder`.
+
+        Returns:
+            Tensor: forwarded results with shape [num_query, bs, embed_dims].
+        """
+        x = super(DetrTransformerEncoder, self).forward(*args, **kwargs)
+        if self.post_norm is not None:
+            x = self.post_norm(x)
+        return x
+
+
+class DeformableDetrTransformerDecoder(TransformerLayerSequence):
+    """Implements the decoder in DETR transformer.
+
+    Args:
+        return_intermediate (bool): Whether to return intermediate outputs.
+        coder_norm_cfg (dict): Config of last normalization layer. Default：
+            `LN`.
+    """
+
+    def __init__(self, *args, return_intermediate=False, num_layers=6, **kwargs):
+
+        super().__init__(
+            transformerlayers=DetrTransformerDecoderLayer,
+            num_layers=num_layers,
+            *args,
+            **kwargs,
+        )
+        self.return_intermediate = True
+
+    def forward(
+        self,
+        query,
+        *args,
+        reference_points=None,
+        valid_ratios=None,
+        reg_branches=None,
+        **kwargs,
+    ):
+        """Forward function for `TransformerDecoder`.
+
+        Args:
+            query (Tensor): Input query with shape
+                `(num_query, bs, embed_dims)`.
+            reference_points (Tensor): The reference
+                points of offset. has shape
+                (bs, num_query, 4) when as_two_stage,
+                otherwise has shape ((bs, num_query, 2).
+            valid_ratios (Tensor): The radios of valid
+                points on the feature map, has shape
+                (bs, num_levels, 2)
+            reg_branch: (obj:`nn.ModuleList`): Used for
+                refining the regression results. Only would
+                be passed when with_box_refine is True,
+                otherwise would be passed a `None`.
+
+        Returns:
+            Tensor: Results with shape [1, num_query, bs, embed_dims] when
+                return_intermediate is `False`, otherwise it has shape
+                [num_layers, num_query, bs, embed_dims].
+        """
+        output = query
+        intermediate = []
+        intermediate_reference_points = []
+        for lid, layer in enumerate(self.layers):
+            if reference_points.shape[-1] == 4:
+                reference_points_input = (
+                    reference_points[:, :, None]
+                    * torch.cat([valid_ratios, valid_ratios], -1)[:, None]
+                )
+            else:
+                assert reference_points.shape[-1] == 2
+                reference_points_input = (
+                    reference_points[:, :, None] * valid_ratios[:, None]
+                )
+            output = layer(
+                output, *args, reference_points=reference_points_input, **kwargs
+            )
+            output = output.permute(1, 0, 2)
+
+            if reg_branches is not None:
+                tmp = reg_branches[lid](output)
+                if reference_points.shape[-1] == 4:
+                    new_reference_points = tmp + inverse_sigmoid(reference_points)
+                    new_reference_points = new_reference_points.sigmoid()
+                else:
+                    assert reference_points.shape[-1] == 2
+                    new_reference_points = tmp
+                    new_reference_points[..., :2] = tmp[..., :2] + inverse_sigmoid(
+                        reference_points
+                    )
+                    new_reference_points = new_reference_points.sigmoid()
+                reference_points = new_reference_points.detach()
+
+            output = output.permute(1, 0, 2)
+            if self.return_intermediate:
+                intermediate.append(output)
+                intermediate_reference_points.append(reference_points)
+
+        if self.return_intermediate:
+            return torch.stack(intermediate), torch.stack(intermediate_reference_points)
+
+        return output, reference_points
+
+
+class BaseDecoderTransformerLayer(nn.Module):
+    """Base `TransformerLayer` for vision transformer.
+
+    It can be built from `mmcv.ConfigDict` and support more flexible
+    customization, for example, using any number of `FFN or LN ` and
+    use different kinds of `attention` by specifying a list of `ConfigDict`
+    named `attn_cfgs`. It is worth mentioning that it supports `prenorm`
+    when you specifying `norm` as the first element of `operation_order`.
+    More details about the `prenorm`: `On Layer Normalization in the
+    Transformer Architecture <https://arxiv.org/abs/2002.04745>`_ .
+
+    Args:
+        attn_cfgs (list[`mmcv.ConfigDict`] | obj:`mmcv.ConfigDict` | None )):
+            Configs for `self_attention` or `cross_attention` modules,
+            The order of the configs in the list should be consistent with
+            corresponding attentions in operation_order.
+            If it is a dict, all of the attention modules in operation_order
+            will be built with this config. Default: None.
+        ffn_cfgs (list[`mmcv.ConfigDict`] | obj:`mmcv.ConfigDict` | None )):
+            Configs for FFN, The order of the configs in the list should be
+            consistent with corresponding ffn in operation_order.
+            If it is a dict, all of the attention modules in operation_order
+            will be built with this config.
+        operation_order (tuple[str]): The execution order of operation
+            in transformer. Such as ('self_attn', 'norm', 'ffn', 'norm').
+            Support `prenorm` when you specifying first element as `norm`.
+            Default：None.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: dict(type='LN').
+        batch_first (bool): Key, Query and Value are shape
+            of (batch, n, embed_dim)
+            or (n, batch, embed_dim). Default to False.
+    """
+
+    def __init__(
+        self,
+        attn_cfgs=None,
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=1024,
+            num_fcs=2,
+            ffn_drop=0.0,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=None,
+        norm_cfg=dict(type="LN"),
+        batch_first=False,
+        **kwargs,
+    ):
+
+        deprecated_args = dict(
+            feedforward_channels="feedforward_channels",
+            ffn_dropout="ffn_drop",
+            ffn_num_fcs="num_fcs",
+        )
+        for ori_name, new_name in deprecated_args.items():
+            if ori_name in kwargs:
+                warnings.warn(
+                    f"The arguments `{ori_name}` in BaseDecoderTransformerLayer "
+                    f"has been deprecated, now you should set `{new_name}` "
+                    f"and other FFN related arguments "
+                    f"to a dict named `ffn_cfgs`. ",
+                    DeprecationWarning,
+                )
+                ffn_cfgs[new_name] = kwargs[ori_name]
+
+        super().__init__()
+
+        self.batch_first = batch_first
+
+        assert set(operation_order) & {"self_attn", "norm", "ffn", "cross_attn"} == set(
+            operation_order
+        ), (
+            f"The operation_order of"
+            f" {self.__class__.__name__} should "
+            f"contains all four operation type "
+            f"{['self_attn', 'norm', 'ffn', 'cross_attn']}"
+        )
+
+        num_attn = operation_order.count("self_attn") + operation_order.count(
+            "cross_attn"
+        )
+
+        assert num_attn == len(attn_cfgs), (
+            f"The length "
+            f"of attn_cfg {num_attn} is "
+            f"not consistent with the number of attention"
+            f"in operation_order {operation_order}."
+        )
+
+        self.num_attn = num_attn
+        self.operation_order = operation_order
+        self.norm_cfg = norm_cfg
+        self.pre_norm = operation_order[0] == "norm"
+        self.attentions = nn.ModuleList()
+
+        index = 0
+        for operation_name in operation_order:
+            if operation_name in ["self_attn", "cross_attn"]:
+                attn_cfgs[index]["batch_first"] = self.batch_first
+                if operation_name == "self_attn":
+                    attention = MultiheadAttention()
+                else:
+                    attention = MultiScaleDeformableAttention()
+                self.attentions.append(attention)
+                index += 1
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        self.ffns = nn.ModuleList()
+        self.ffns.append(FFN(feedforward_channels=512, ffn_drop=0.1))
+
+        self.norms = nn.ModuleList()
+        num_norms = operation_order.count("norm")
+        for _ in range(num_norms):
+            self.norms.append(
+                torch.nn.LayerNorm((256,), eps=1e-05, elementwise_affine=True)
+            )
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        """Forward function for `TransformerDecoderLayer`.
+
+        **kwargs contains some specific arguments of attentions.
+
+        Args:
+            query (Tensor): The input query with shape
+                [num_queries, bs, embed_dims] if
+                self.batch_first is False, else
+                [bs, num_queries embed_dims].
+            key (Tensor): The key tensor with shape [num_keys, bs,
+                embed_dims] if self.batch_first is False, else
+                [bs, num_keys, embed_dims] .
+            value (Tensor): The value tensor with same shape as `key`.
+            query_pos (Tensor): The positional encoding for `query`.
+                Default: None.
+            key_pos (Tensor): The positional encoding for `key`.
+                Default: None.
+            attn_masks (List[Tensor] | None): 2D Tensor used in
+                calculation of corresponding attention. The length of
+                it should equal to the number of `attention` in
+                `operation_order`. Default: None.
+            query_key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_queries]. Only used in `self_attn` layer.
+                Defaults to None.
+            key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_keys]. Default: None.
+
+        Returns:
+            Tensor: forwarded results with shape [num_queries, bs, embed_dims].
+        """
+
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+
+        for layer in self.operation_order:
+            if layer == "self_attn":
+                temp_key = temp_value = query
+                query = self.attentions[attn_index](
+                    query,
+                    temp_key,
+                    temp_value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=query_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "norm":
+                query = self.norms[norm_index](query)
+                norm_index += 1
+
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+                ffn_index += 1
+
+        return query
+
+
+class DetrTransformerDecoderLayer(BaseDecoderTransformerLayer):
+    """Implements decoder layer in DETR transformer.
+
+    Args:
+        attn_cfgs (list[`mmcv.ConfigDict`] | list[dict] | dict )):
+            Configs for self_attention or cross_attention, the order
+            should be consistent with it in `operation_order`. If it is
+            a dict, it would be expand to the number of attention in
+            `operation_order`.
+        feedforward_channels (int): The hidden dimension for FFNs.
+        ffn_dropout (float): Probability of an element to be zeroed
+            in ffn. Default 0.0.
+        operation_order (tuple[str]): The execution order of operation
+            in transformer. Such as ('self_attn', 'norm', 'ffn', 'norm').
+            Default：None
+        act_cfg (dict): The activation config for FFNs. Default: `LN`
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: `LN`.
+        ffn_num_fcs (int): The number of fully-connected layers in FFNs.
+            Default：2.
+    """
+
+    def __init__(
+        self,
+        attn_cfgs=[
+            {
+                "type": "MultiheadAttention",
+                "embed_dims": 256,
+                "num_heads": 8,
+                "dropout": 0.1,
+            },
+            {
+                "type": "MultiScaleDeformableAttention",
+                "embed_dims": 256,
+                "num_levels": 1,
+            },
+        ],
+        feedforward_channels=512,
+        ffn_dropout=0.1,
+        operation_order=("self_attn", "norm", "cross_attn", "norm", "ffn", "norm"),
+        act_cfg=dict(type="ReLU", inplace=True),
+        norm_cfg=dict(type="LN"),
+        ffn_num_fcs=2,
+        **kwargs,
+    ):
+        super(DetrTransformerDecoderLayer, self).__init__(
+            attn_cfgs=attn_cfgs,
+            feedforward_channels=feedforward_channels,
+            ffn_dropout=ffn_dropout,
+            operation_order=operation_order,
+            act_cfg=act_cfg,
+            norm_cfg=norm_cfg,
+            ffn_num_fcs=ffn_num_fcs,
+            **kwargs,
+        )
+        assert len(operation_order) == 6
+        assert set(operation_order) == set(["self_attn", "norm", "cross_attn", "ffn"])

--- a/uniad/pytorch/src/planning_head.py
+++ b/uniad/pytorch/src/planning_head.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.nn as nn
+from einops import rearrange
+from third_party.tt_forge_models.uniad.pytorch.src.planning_utils import *
+import numpy as np
+import copy
+
+
+def bivariate_gaussian_activation(ip):
+    """
+    Activation function to output parameters of bivariate Gaussian distribution.
+
+    Args:
+        ip (torch.Tensor): Input tensor.
+
+    Returns:
+        torch.Tensor: Output tensor containing the parameters of the bivariate Gaussian distribution.
+    """
+    mu_x = ip[..., 0:1]
+    mu_y = ip[..., 1:2]
+    sig_x = ip[..., 2:3]
+    sig_y = ip[..., 3:4]
+    rho = ip[..., 4:5]
+    sig_x = torch.exp(sig_x)
+    sig_y = torch.exp(sig_y)
+    rho = torch.tanh(rho)
+    out = torch.cat([mu_x, mu_y, sig_x, sig_y, rho], dim=-1)
+    return out
+
+
+class PlanningHeadSingleMode(nn.Module):
+    def __init__(
+        self,
+        bev_h=200,
+        bev_w=200,
+        embed_dims=256,
+        planning_steps=6,
+        planning_eval=True,
+        use_col_optim=True,
+        col_optim_args=dict(
+            occ_filter_range=5.0,
+            sigma=1.0,
+            alpha_collision=5.0,
+        ),
+        with_adapter=True,
+    ):
+        """
+        Single Mode Planning Head for Autonomous Driving.
+
+        Args:
+            embed_dims (int): Embedding dimensions. Default: 256.
+            planning_steps (int): Number of steps for motion planning. Default: 6.
+            loss_planning (dict): Configuration for planning loss. Default: None.
+            loss_collision (dict): Configuration for collision loss. Default: None.
+            planning_eval (bool): Whether to use planning for evaluation. Default: False.
+            use_col_optim (bool): Whether to use collision optimization. Default: False.
+            col_optim_args (dict): Collision optimization arguments. Default: dict(occ_filter_range=5.0, sigma=1.0, alpha_collision=5.0).
+        """
+        super(PlanningHeadSingleMode, self).__init__()
+
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.navi_embed = nn.Embedding(3, embed_dims)
+        self.reg_branch = nn.Sequential(
+            nn.Linear(embed_dims, embed_dims),
+            nn.ReLU(),
+            nn.Linear(embed_dims, planning_steps * 2),
+        )
+        self.planning_steps = planning_steps
+        self.planning_eval = planning_eval
+
+        fuser_dim = 3
+        attn_module_layer = nn.TransformerDecoderLayer(
+            embed_dims,
+            8,
+            dim_feedforward=embed_dims * 2,
+            dropout=0.1,
+            batch_first=False,
+        )
+        self.attn_module = nn.TransformerDecoder(attn_module_layer, 3)
+
+        self.mlp_fuser = nn.Sequential(
+            nn.Linear(embed_dims * fuser_dim, embed_dims),
+            nn.LayerNorm(embed_dims),
+            nn.ReLU(inplace=True),
+        )
+
+        self.pos_embed = nn.Embedding(1, embed_dims)
+
+        self.use_col_optim = use_col_optim
+        self.occ_filter_range = col_optim_args["occ_filter_range"]
+        self.sigma = col_optim_args["sigma"]
+        self.alpha_collision = col_optim_args["alpha_collision"]
+
+        self.with_adapter = with_adapter
+        if with_adapter:
+            bev_adapter_block = nn.Sequential(
+                nn.Conv2d(embed_dims, embed_dims // 2, kernel_size=3, padding=1),
+                nn.ReLU(),
+                nn.Conv2d(embed_dims // 2, embed_dims, kernel_size=1),
+            )
+            N_Blocks = 3
+            bev_adapter = [copy.deepcopy(bev_adapter_block) for _ in range(N_Blocks)]
+            self.bev_adapter = nn.Sequential(*bev_adapter)
+
+    def forward_test(self, bev_embed, outs_motion={}, outs_occflow={}, command=None):
+        sdc_traj_query = outs_motion["sdc_traj_query"]
+        sdc_track_query = outs_motion["sdc_track_query"]
+        bev_pos = outs_motion["bev_pos"]
+        occ_mask = outs_occflow["seg_out"]
+
+        outs_planning = self(
+            bev_embed, occ_mask, bev_pos, sdc_traj_query, sdc_track_query, command
+        )
+        return outs_planning
+
+    def forward(
+        self, bev_embed, occ_mask, bev_pos, sdc_traj_query, sdc_track_query, command
+    ):
+        """
+        Forward pass for PlanningHeadSingleMode.
+
+        Args:
+            bev_embed (torch.Tensor): Bird's eye view feature embedding.
+            occ_mask (torch.Tensor): Instance mask for occupancy.
+            bev_pos (torch.Tensor): BEV position.
+            sdc_traj_query (torch.Tensor): SDC trajectory query.
+            sdc_track_query (torch.Tensor): SDC track query.
+            command (int): Driving command.
+
+        Returns:
+            dict: A dictionary containing SDC trajectory and all SDC trajectories.
+        """
+        sdc_track_query = sdc_track_query.detach()
+        sdc_traj_query = sdc_traj_query[-1]
+        P = sdc_traj_query.shape[1]
+        sdc_track_query = sdc_track_query[:, None].expand(-1, P, -1)
+
+        navi_embed = self.navi_embed.weight[command]
+        navi_embed = navi_embed[None].expand(-1, P, -1)
+        plan_query = torch.cat([sdc_traj_query, sdc_track_query, navi_embed], dim=-1)
+
+        plan_query = self.mlp_fuser(plan_query).max(1, keepdim=True)[0]
+        plan_query = rearrange(plan_query, "b p c -> p b c")
+
+        bev_pos = rearrange(bev_pos, "b c h w -> (h w) b c")
+        bev_feat = bev_embed + bev_pos
+
+        if self.with_adapter:
+            bev_feat = rearrange(
+                bev_feat, "(h w) b c -> b c h w", h=self.bev_h, w=self.bev_w
+            )
+            bev_feat = bev_feat + self.bev_adapter(bev_feat)
+            bev_feat = rearrange(bev_feat, "b c h w -> (h w) b c")
+
+        pos_embed = self.pos_embed.weight
+        plan_query = plan_query + pos_embed[None]
+
+        plan_query = self.attn_module(plan_query, bev_feat)
+
+        sdc_traj_all = self.reg_branch(plan_query).view((-1, self.planning_steps, 2))
+        sdc_traj_all[..., :2] = torch.cumsum(sdc_traj_all[..., :2], dim=1)
+        sdc_traj_all[0] = bivariate_gaussian_activation(sdc_traj_all[0])
+        if self.use_col_optim and not self.training:
+            assert occ_mask is not None
+            sdc_traj_all = self.collision_optimization(sdc_traj_all, occ_mask)
+
+        return dict(
+            sdc_traj=sdc_traj_all,
+            sdc_traj_all=sdc_traj_all,
+        )
+
+    def collision_optimization(self, sdc_traj_all, occ_mask):
+        """
+        Optimize SDC trajectory with occupancy instance mask.
+
+        Args:
+            sdc_traj_all (torch.Tensor): SDC trajectory tensor.
+            occ_mask (torch.Tensor): Occupancy flow instance mask.
+        Returns:
+            torch.Tensor: Optimized SDC trajectory tensor.
+        """
+        pos_xy_t = []
+        valid_occupancy_num = 0
+
+        if occ_mask.shape[2] == 1:
+            occ_mask = occ_mask.squeeze(2)
+        occ_horizon = occ_mask.shape[1]
+        assert occ_horizon == 5
+
+        for t in range(self.planning_steps):
+            cur_t = min(t + 1, occ_horizon - 1)
+            pos_xy = torch.nonzero(occ_mask[0][cur_t], as_tuple=False)
+            pos_xy = pos_xy[:, [1, 0]]
+            pos_xy[:, 0] = (pos_xy[:, 0] - self.bev_h // 2) * 0.5 + 0.25
+            pos_xy[:, 1] = (pos_xy[:, 1] - self.bev_w // 2) * 0.5 + 0.25
+
+            keep_index = (
+                torch.sum(
+                    (sdc_traj_all[0, t, :2][None, :] - pos_xy[:, :2]) ** 2, axis=-1
+                )
+                < self.occ_filter_range**2
+            )
+            pos_xy_t.append(pos_xy[keep_index].cpu().detach().numpy())
+            valid_occupancy_num += torch.sum(keep_index > 0)
+        if valid_occupancy_num == 0:
+            return sdc_traj_all
+
+        col_optimizer = CollisionNonlinearOptimizer(
+            self.planning_steps, 0.5, self.sigma, self.alpha_collision, pos_xy_t
+        )
+        col_optimizer.set_reference_trajectory(sdc_traj_all[0].cpu().detach().numpy())
+        sol = col_optimizer.solve()
+        sdc_traj_optim = np.stack(
+            [sol.value(col_optimizer.position_x), sol.value(col_optimizer.position_y)],
+            axis=-1,
+        )
+        return torch.tensor(sdc_traj_optim[None], dtype=sdc_traj_all.dtype)

--- a/uniad/pytorch/src/planning_utils.py
+++ b/uniad/pytorch/src/planning_utils.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.nn as nn
+from einops import rearrange
+import numpy as np
+import copy
+from typing import Any, Dict, Sequence, Tuple
+import numpy as np
+import numpy.typing as npt
+from casadi import DM, Opti, OptiSol, sumsqr, vertcat, exp
+
+Pose = Tuple[float, float, float]
+
+
+class CollisionNonlinearOptimizer:
+    """
+    Optimize planned trajectory with predicted occupancy
+    Solved with direct multiple-shooting.
+    modified from https://github.com/motional/nuplan-devkit
+    :param trajectory_len: trajectory length
+    :param dt: timestep (sec)
+    """
+
+    def __init__(
+        self, trajectory_len: int, dt: float, sigma, alpha_collision, obj_pixel_pos
+    ):
+        """
+        :param trajectory_len: the length of trajectory to be optimized.
+        :param dt: the time interval between trajectory points.
+        """
+        self.dt = dt
+        self.trajectory_len = trajectory_len
+        self.current_index = 0
+        self.sigma = sigma
+        self.alpha_collision = alpha_collision
+        self.obj_pixel_pos = obj_pixel_pos
+        self._dts: npt.NDArray[np.float32] = np.asarray([[dt] * trajectory_len])
+        self._init_optimization()
+
+    def _init_optimization(self) -> None:
+        """
+        Initialize related variables and constraints for optimization.
+        """
+        self.nx = 2
+
+        self._optimizer = Opti()
+        self._create_decision_variables()
+        self._create_parameters()
+        self._set_objective()
+
+        self._optimizer.solver(
+            "ipopt", {"ipopt.print_level": 0, "print_time": 0, "ipopt.sb": "yes"}
+        )
+
+    def set_reference_trajectory(self, reference_trajectory: Sequence[Pose]) -> None:
+        """
+        Set the reference trajectory that the smoother is trying to loosely track.
+        :param x_curr: current state of size nx (x, y)
+        :param reference_trajectory: N x 3 reference, where the second dim is for (x, y)
+        """
+        self._optimizer.set_value(self.ref_traj, DM(reference_trajectory).T)
+        self._set_initial_guess(reference_trajectory)
+
+    def set_solver_optimizerons(self, options: Dict[str, Any]) -> None:
+        """
+        Control solver options including verbosity.
+        :param options: Dictionary containing optimization criterias
+        """
+        self._optimizer.solver("ipopt", options)
+
+    def solve(self) -> OptiSol:
+        """
+        Solve the optimization problem. Assumes the reference trajectory was already set.
+        :return Casadi optimization class
+        """
+        return self._optimizer.solve()
+
+    def _create_decision_variables(self) -> None:
+        """
+        Define the decision variables for the trajectory optimization.
+        """
+        self.state = self._optimizer.variable(self.nx, self.trajectory_len)
+        self.position_x = self.state[0, :]
+        self.position_y = self.state[1, :]
+
+    def _create_parameters(self) -> None:
+        """
+        Define the expert trjactory and current position for the trajectory optimizaiton.
+        """
+        self.ref_traj = self._optimizer.parameter(2, self.trajectory_len)
+
+    def _set_objective(self) -> None:
+        """Set the objective function. Use care when modifying these weights."""
+        alpha_xy = 1.0
+        cost_stage = alpha_xy * sumsqr(
+            self.ref_traj[:2, :] - vertcat(self.position_x, self.position_y)
+        )
+
+        alpha_collision = self.alpha_collision
+
+        cost_collision = 0
+        normalizer = 1 / (2.507 * self.sigma)
+        for t in range(len(self.obj_pixel_pos)):
+            x, y = self.position_x[t], self.position_y[t]
+            for i in range(len(self.obj_pixel_pos[t])):
+                col_x, col_y = self.obj_pixel_pos[t][i]
+                cost_collision += (
+                    alpha_collision
+                    * normalizer
+                    * exp(-((x - col_x) ** 2 + (y - col_y) ** 2) / 2 / self.sigma**2)
+                )
+        self._optimizer.minimize(cost_stage + cost_collision)
+
+    def _set_initial_guess(self, reference_trajectory: Sequence[Pose]) -> None:
+        """Set a warm-start for the solver based on the reference trajectory."""
+        self._optimizer.set_initial(self.state[:2, :], DM(reference_trajectory).T)

--- a/uniad/pytorch/src/track_head.py
+++ b/uniad/pytorch/src/track_head.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import copy
+import torch
+import torch.nn as nn
+
+from third_party.tt_forge_models.uniad.pytorch.src.track_utils import *
+
+
+class BEVFormerTrackHead(DETRHead):
+    """Head of Detr3D.
+    Args:
+        with_box_refine (bool): Whether to refine the reference points
+            in the decoder. Defaults to False.
+        as_two_stage (bool) : Whether to generate the proposal from
+            the outputs of encoder.
+        transformer (obj:`ConfigDict`): ConfigDict is used for building
+            the Encoder and Decoder.
+        bev_h, bev_w (int): spatial shape of BEV queries.
+           bev_h=200,
+    """
+
+    def __init__(
+        self,
+        *args,
+        with_box_refine=True,
+        num_cls_fcs=2,
+        code_weights=None,
+        as_two_stage=False,
+        bbox_coder=DETRTrack3DCoder(),
+        bev_h=200,
+        bev_w=200,
+        fut_steps=4,
+        in_channels=256,
+        num_classes=10,
+        num_query=900,
+        past_steps=4,
+        positional_encoding=LearnedPositionalEncoding(),
+        sync_cls_avg_factor=True,
+        transformer=PerceptionTransformer(),
+        **kwargs
+    ):
+
+        self.bev_h = bev_h
+        self.bev_w = bev_w
+        self.fp16_enabled = False
+
+        self.with_box_refine = with_box_refine
+
+        assert as_two_stage is False, "as_two_stage is not supported yet."
+        self.as_two_stage = as_two_stage
+        if self.as_two_stage:
+            transformer["as_two_stage"] = self.as_two_stage
+
+        self.code_size = 10
+        self.code_weights = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2]
+
+        self.bbox_coder = DETRTrack3DCoder()
+        self.pc_range = self.bbox_coder.pc_range
+        self.real_w = self.pc_range[3] - self.pc_range[0]
+        self.real_h = self.pc_range[4] - self.pc_range[1]
+        self.num_cls_fcs = num_cls_fcs - 1
+        self.past_steps = past_steps
+        self.fut_steps = fut_steps
+        super(BEVFormerTrackHead, self).__init__(
+            *args, transformer=transformer, **kwargs
+        )
+        self.code_weights = nn.Parameter(
+            torch.tensor(self.code_weights, requires_grad=False), requires_grad=False
+        )
+
+    def _init_layers(self):
+        """Initialize classification branch and regression branch of head."""
+        cls_branch = []
+        for _ in range(self.num_reg_fcs):
+            cls_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+            cls_branch.append(nn.LayerNorm(self.embed_dims))
+            cls_branch.append(nn.ReLU(inplace=True))
+        cls_branch.append(nn.Linear(self.embed_dims, self.cls_out_channels))
+        fc_cls = nn.Sequential(*cls_branch)
+
+        reg_branch = []
+        for _ in range(self.num_reg_fcs):
+            reg_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+            reg_branch.append(nn.ReLU())
+        reg_branch.append(nn.Linear(self.embed_dims, self.code_size))
+        reg_branch = nn.Sequential(*reg_branch)
+
+        past_traj_reg_branch = []
+        for _ in range(self.num_reg_fcs):
+            past_traj_reg_branch.append(nn.Linear(self.embed_dims, self.embed_dims))
+            past_traj_reg_branch.append(nn.ReLU())
+        past_traj_reg_branch.append(
+            nn.Linear(self.embed_dims, (self.past_steps + self.fut_steps) * 2)
+        )
+        past_traj_reg_branch = nn.Sequential(*past_traj_reg_branch)
+
+        def _get_clones(module, N):
+            return nn.ModuleList([copy.deepcopy(module) for i in range(N)])
+
+        num_pred = (
+            (self.transformer.decoder.num_layers + 1)
+            if self.as_two_stage
+            else self.transformer.decoder.num_layers
+        )
+
+        self.cls_branches = _get_clones(fc_cls, num_pred)
+        self.reg_branches = _get_clones(reg_branch, num_pred)
+        self.past_traj_reg_branches = _get_clones(past_traj_reg_branch, num_pred)
+        if not self.as_two_stage:
+            self.bev_embedding = nn.Embedding(self.bev_h * self.bev_w, self.embed_dims)
+
+    def get_bev_features(self, mlvl_feats, img_metas, prev_bev=None):
+        bs, num_cam, _, _, _ = mlvl_feats[0].shape
+        dtype = mlvl_feats[0].dtype
+        bev_queries = self.bev_embedding.weight.to(dtype)
+
+        bev_mask = torch.zeros((bs, self.bev_h, self.bev_w)).to(dtype)
+        bev_pos = self.positional_encoding(bev_mask).to(dtype)
+        bev_embed = self.transformer.get_bev_features(
+            mlvl_feats,
+            bev_queries,
+            self.bev_h,
+            self.bev_w,
+            grid_length=(self.real_h / self.bev_h, self.real_w / self.bev_w),
+            bev_pos=bev_pos,
+            prev_bev=prev_bev,
+            img_metas=img_metas,
+        )
+        return bev_embed, bev_pos
+
+    def get_detections(
+        self,
+        bev_embed,
+        object_query_embeds=None,
+        ref_points=None,
+        img_metas=None,
+    ):
+        hs, init_reference, inter_references = self.transformer.get_states_and_refs(
+            bev_embed,
+            object_query_embeds,
+            self.bev_h,
+            self.bev_w,
+            reference_points=ref_points,
+            reg_branches=self.reg_branches if self.with_box_refine else None,
+            cls_branches=self.cls_branches if self.as_two_stage else None,
+            img_metas=img_metas,
+        )
+        hs = hs.permute(0, 2, 1, 3)
+        outputs_classes = []
+        outputs_coords = []
+        outputs_trajs = []
+        for lvl in range(hs.shape[0]):
+            if lvl == 0:
+                reference = ref_points.sigmoid()
+            reference = inverse_sigmoid(reference)
+            outputs_class = self.cls_branches[lvl](hs[lvl])
+            tmp = self.reg_branches[lvl](hs[lvl])
+            outputs_past_traj = self.past_traj_reg_branches[lvl](hs[lvl]).view(
+                tmp.shape[0], -1, self.past_steps + self.fut_steps, 2
+            )
+            assert reference.shape[-1] == 3
+            tmp[..., 0:2] += reference[..., 0:2]
+            tmp[..., 0:2] = tmp[..., 0:2].sigmoid()
+            tmp[..., 4:5] += reference[..., 2:3]
+            tmp[..., 4:5] = tmp[..., 4:5].sigmoid()
+
+            last_ref_points = torch.cat(
+                [tmp[..., 0:2], tmp[..., 4:5]],
+                dim=-1,
+            )
+
+            tmp[..., 0:1] = (
+                tmp[..., 0:1] * (self.pc_range[3] - self.pc_range[0]) + self.pc_range[0]
+            )
+            tmp[..., 1:2] = (
+                tmp[..., 1:2] * (self.pc_range[4] - self.pc_range[1]) + self.pc_range[1]
+            )
+            tmp[..., 4:5] = (
+                tmp[..., 4:5] * (self.pc_range[5] - self.pc_range[2]) + self.pc_range[2]
+            )
+
+            outputs_coord = tmp
+            outputs_classes.append(outputs_class)
+            outputs_coords.append(outputs_coord)
+            outputs_trajs.append(outputs_past_traj)
+        outputs_classes = torch.stack(outputs_classes)
+        outputs_coords = torch.stack(outputs_coords)
+        outputs_trajs = torch.stack(outputs_trajs)
+        last_ref_points = inverse_sigmoid(last_ref_points)
+        outs = {
+            "all_cls_scores": outputs_classes,
+            "all_bbox_preds": outputs_coords,
+            "all_past_traj_preds": outputs_trajs,
+            "enc_cls_scores": None,
+            "enc_bbox_preds": None,
+            "last_ref_points": last_ref_points,
+            "query_feats": hs,
+        }
+        return outs

--- a/uniad/pytorch/src/track_utils.py
+++ b/uniad/pytorch/src/track_utils.py
@@ -1,0 +1,2397 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from torch import nn
+import torch.nn.functional as F
+from abc import ABCMeta
+import numpy as np
+from torchvision.transforms.functional import rotate
+from torch.nn.init import normal_
+import copy
+import warnings
+import math
+import itertools
+from typing import Any, Dict, List, Tuple, Union
+from third_party.tt_forge_models.uniad.pytorch.src.utils import *
+from third_party.tt_forge_models.uniad.pytorch.src.transformer import *
+
+
+class ClipMatcher(nn.Module):
+    def __init__(
+        self,
+        num_classes=10,
+        weight_dict=None,
+        code_weights=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2, 0.2],
+    ):
+        """Create the criterion.
+        Parameters:
+            num_classes: number of object categories, omitting the special no-object category
+            weight_dict: dict containing as key the names of the losses and as values their relative weight.
+            eos_coef: relative classification weight applied to the no-object category
+        """
+        super().__init__()
+        self.num_classes = num_classes
+        self.register_buffer(
+            "code_weights", torch.tensor(code_weights, requires_grad=False)
+        )
+
+        self.weight_dict = weight_dict
+        self.loss_past_traj_weight = loss_past_traj_weight
+        self.losses = ["labels", "boxes", "past_trajs"]
+        self.focal_loss = True
+        self.losses_dict = {}
+        self._current_frame_idx = 0
+
+
+class BaseBBoxCoder(metaclass=ABCMeta):
+    """Base bounding box coder."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def encode(self, bboxes, gt_bboxes):
+        """Encode deltas between bboxes and ground truth boxes."""
+
+    def decode(self, bboxes, bboxes_pred):
+        """Decode the predicted bboxes according to prediction and base
+        boxes."""
+
+
+class DETRTrack3DCoder(BaseBBoxCoder):
+    """Bbox coder for DETR3D.
+    Args:
+        pc_range (list[float]): Range of point cloud.
+        post_center_range (list[float]): Limit of the center.
+            Default: None.
+        max_num (int): Max number to be kept. Default: 100.
+        score_threshold (float): Threshold to filter boxes based on score.
+            Default: None.
+        code_size (int): Code size of bboxes. Default: 9
+    """
+
+    def __init__(
+        self,
+        pc_range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+        post_center_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
+        max_num=300,
+        score_threshold=0.0,
+        num_classes=10,
+        with_nms=False,
+        iou_thres=0.3,
+    ):
+        self.pc_range = pc_range
+        self.post_center_range = post_center_range
+        self.max_num = max_num
+        self.score_threshold = score_threshold
+        self.num_classes = num_classes
+        self.with_nms = with_nms
+        self.nms_iou_thres = iou_thres
+
+    def encode(self):
+        pass
+
+    def decode_single(
+        self,
+        cls_scores,
+        bbox_preds,
+        track_scores,
+        obj_idxes,
+        with_mask=True,
+        img_metas=None,
+    ):
+        """Decode bboxes.
+        Args:
+            cls_scores (Tensor): Outputs from the classification head, \
+                shape [num_query, cls_out_channels]. Note \
+                cls_out_channels should includes background.
+            bbox_preds (Tensor): Outputs from the regression \
+                head with normalized coordinate format (cx, cy, w, l, cz, h, rot_sine, rot_cosine, vx, vy). \
+                Shape [num_query, 9].
+
+        Returns:
+            list[dict]: Decoded boxes.
+        """
+        max_num = self.max_num
+        max_num = min(cls_scores.size(0), self.max_num)
+
+        cls_scores = cls_scores.sigmoid()
+        _, indexs = cls_scores.max(dim=-1)
+        labels = indexs % self.num_classes
+
+        _, bbox_index = track_scores.topk(max_num)
+
+        labels = labels[bbox_index]
+        bbox_preds = bbox_preds[bbox_index]
+        track_scores = track_scores[bbox_index]
+        obj_idxes = obj_idxes[bbox_index]
+
+        scores = track_scores
+
+        final_box_preds = denormalize_bbox(bbox_preds, self.pc_range)
+        final_scores = track_scores
+        final_preds = labels
+
+        if self.score_threshold is not None:
+            thresh_mask = final_scores > self.score_threshold
+
+        if self.post_center_range is not None:
+            self.post_center_range = torch.tensor(self.post_center_range)
+            mask = (final_box_preds[..., :3] >= self.post_center_range[:3]).all(1)
+            mask &= (final_box_preds[..., :3] <= self.post_center_range[3:]).all(1)
+
+            if self.score_threshold:
+                mask &= thresh_mask
+            if not with_mask:
+                mask = torch.ones_like(mask) > 0
+
+            boxes3d = final_box_preds[mask]
+            scores = final_scores[mask]
+            labels = final_preds[mask]
+            track_scores = track_scores[mask]
+            obj_idxes = obj_idxes[mask]
+            predictions_dict = {
+                "bboxes": boxes3d,
+                "scores": scores,
+                "labels": labels,
+                "track_scores": track_scores,
+                "obj_idxes": obj_idxes,
+                "bbox_index": bbox_index,
+                "mask": mask,
+            }
+
+        return predictions_dict
+
+    def decode(self, preds_dicts, with_mask=True, img_metas=None):
+        """Decode bboxes.
+        Args:
+            cls_scores (Tensor): Outputs from the classification head, \
+                shape [nb_dec, bs, num_query, cls_out_channels]. Note \
+                cls_out_channels should includes background.
+                Note: before sigmoid!
+            bbox_preds (Tensor): Sigmoid outputs from the regression \
+                head with normalized coordinate format (cx, cy, w, l, cz, h, rot_sine, rot_cosine, vx, vy). \
+                Shape [nb_dec, bs, num_query, 9].
+
+        Returns:
+            list[dict]: Decoded boxes.
+        """
+        all_cls_scores = preds_dicts["cls_scores"]
+        all_bbox_preds = preds_dicts["bbox_preds"]
+        track_scores = preds_dicts["track_scores"]
+        obj_idxes = preds_dicts["obj_idxes"]
+
+        predictions_list = []
+        predictions_list.append(
+            self.decode_single(
+                all_cls_scores,
+                all_bbox_preds,
+                track_scores,
+                obj_idxes,
+                with_mask,
+                img_metas,
+            )
+        )
+        return predictions_list
+
+
+def denormalize_bbox(normalized_bboxes, pc_range):
+    rot_sine = normalized_bboxes[..., 6:7]
+
+    rot_cosine = normalized_bboxes[..., 7:8]
+    rot = torch.atan2(rot_sine, rot_cosine)
+
+    cx = normalized_bboxes[..., 0:1]
+    cy = normalized_bboxes[..., 1:2]
+    cz = normalized_bboxes[..., 4:5]
+
+    w = normalized_bboxes[..., 2:3]
+    l = normalized_bboxes[..., 3:4]
+    h = normalized_bboxes[..., 5:6]
+
+    w = w.exp()
+    l = l.exp()
+    h = h.exp()
+    if normalized_bboxes.size(-1) > 8:
+        vx = normalized_bboxes[:, 8:9]
+        vy = normalized_bboxes[:, 9:10]
+        denormalized_bboxes = torch.cat([cx, cy, cz, w, l, h, rot, vx, vy], dim=-1)
+    else:
+        denormalized_bboxes = torch.cat([cx, cy, cz, w, l, h, rot], dim=-1)
+    return denormalized_bboxes
+
+
+class LearnedPositionalEncoding(nn.Module):
+    """Position embedding with learnable embedding weights.
+
+    Args:
+        num_feats (int): The feature dimension for each position
+            along x-axis or y-axis. The final returned dimension for
+            each position is 2 times of this value.
+        row_num_embed (int, optional): The dictionary size of row embeddings.
+            Default 50.
+        col_num_embed (int, optional): The dictionary size of col embeddings.
+            Default 50.
+    """
+
+    def __init__(
+        self,
+        num_feats=128,
+        row_num_embed=200,
+        col_num_embed=200,
+    ):
+        super().__init__()
+        self.row_embed = nn.Embedding(row_num_embed, num_feats)
+        self.col_embed = nn.Embedding(col_num_embed, num_feats)
+        self.num_feats = 128
+        self.row_num_embed = 200
+        self.col_num_embed = 200
+
+    def forward(self, mask):
+        """Forward function for `LearnedPositionalEncoding`.
+
+        Args:
+            mask (Tensor): ByteTensor mask. Non-zero values representing
+                ignored positions, while zero values means valid positions
+                for this image. Shape [bs, h, w].
+
+        Returns:
+            pos (Tensor): Returned position embedding with shape
+                [bs, num_feats*2, h, w].
+        """
+        h, w = mask.shape[-2:]
+        x = torch.arange(w)
+        y = torch.arange(h)
+        x_embed = self.col_embed(x)
+        y_embed = self.row_embed(y)
+        pos = (
+            torch.cat(
+                (
+                    x_embed.unsqueeze(0).repeat(h, 1, 1),
+                    y_embed.unsqueeze(1).repeat(1, w, 1),
+                ),
+                dim=-1,
+            )
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            .repeat(mask.shape[0], 1, 1, 1)
+        )
+        return pos
+
+    def __repr__(self):
+        """str: a string that describes the module"""
+        repr_str = self.__class__.__name__
+        repr_str += f"(num_feats={self.num_feats}, "
+        repr_str += f"row_num_embed={self.row_num_embed}, "
+        repr_str += f"col_num_embed={self.col_num_embed})"
+        return repr_str
+
+
+class DETRHead(nn.Module, metaclass=ABCMeta):
+    """Implements the DETR transformer head.
+
+    See `paper: End-to-End Object Detection with Transformers
+    <https://arxiv.org/pdf/2005.12872>`_ for details.
+
+    Args:
+        num_classes (int): Number of categories excluding the background.
+        in_channels (int): Number of channels in the input feature map.
+        num_query (int): Number of query in Transformer.
+        num_reg_fcs (int, optional): Number of fully-connected layers used in
+            `FFN`, which is then used for the regression head. Default 2.
+        transformer (obj:`mmcv.ConfigDict`|dict): Config for transformer.
+            Default: None.
+        sync_cls_avg_factor (bool): Whether to sync the avg_factor of
+            all ranks. Default to False.
+        positional_encoding (obj:`mmcv.ConfigDict`|dict):
+            Config for position encoding.
+        test_cfg (obj:`mmcv.ConfigDict`|dict): Testing config of
+            transformer head.
+    """
+
+    _version = 2
+
+    def __init__(
+        self,
+        num_classes=10,
+        in_channels=256,
+        num_query=900,
+        num_reg_fcs=2,
+        transformer=None,
+        sync_cls_avg_factor=True,
+        positional_encoding=None,
+        test_cfg=None,
+        feat_channels=256,
+        stacked_convs=4,
+        strides=(4, 8, 16, 32, 64),
+        dcn_on_last_conv=False,
+        conv_bias="auto",
+        conv_cfg=None,
+        norm_cfg=None,
+        **kwargs,
+    ):
+
+        super().__init__()
+        self.feat_channels = feat_channels
+        self.stacked_convs = stacked_convs
+        self.strides = strides
+        assert conv_bias == "auto" or isinstance(conv_bias, bool)
+        self.conv_bias = conv_bias
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.bg_cls_weight = 0
+        self.sync_cls_avg_factor = sync_cls_avg_factor
+
+        self.num_query = num_query
+        self.num_classes = num_classes
+        self.in_channels = in_channels
+        self.num_reg_fcs = num_reg_fcs
+        self.test_cfg = test_cfg
+        self.fp16_enabled = False
+        self.cls_out_channels = num_classes
+        self.activate = nn.ReLU(inplace=True)
+        self.positional_encoding = LearnedPositionalEncoding()
+        self.transformer = PerceptionTransformer()
+        self.embed_dims = self.transformer.embed_dims
+        num_feats = self.positional_encoding.num_feats
+        assert num_feats * 2 == self.embed_dims, (
+            "embed_dims should"
+            f" be exactly 2 times of num_feats. Found {self.embed_dims}"
+            f" and {num_feats}."
+        )
+        self._init_layers()
+
+
+class PerceptionTransformer(nn.Module):
+    """Implements the Detr3D transformer.
+    Args:
+        as_two_stage (bool): Generate query from encoder features.
+            Default: False.
+        num_feature_levels (int): Number of feature maps from FPN:
+            Default: 4.
+        two_stage_num_proposals (int): Number of proposals when set
+            `as_two_stage` as True. Default: 300.
+    """
+
+    def __init__(
+        self,
+        num_feature_levels=4,
+        num_cams=6,
+        two_stage_num_proposals=300,
+        encoder=None,
+        decoder=None,
+        embed_dims=256,
+        rotate_prev_bev=True,
+        use_shift=True,
+        use_can_bus=True,
+        can_bus_norm=True,
+        use_cams_embeds=True,
+        rotate_center=[100, 100],
+        **kwargs,
+    ):
+        super(PerceptionTransformer, self).__init__(**kwargs)
+        self.encoder = BEVFormerEncoder()
+        self.decoder = DetectionTransformerDecoder()
+        self.embed_dims = embed_dims
+        self.num_feature_levels = num_feature_levels
+        self.num_cams = num_cams
+        self.fp16_enabled = False
+
+        self.rotate_prev_bev = rotate_prev_bev
+        self.use_shift = use_shift
+        self.use_can_bus = use_can_bus
+        self.can_bus_norm = can_bus_norm
+        self.use_cams_embeds = use_cams_embeds
+
+        self.two_stage_num_proposals = two_stage_num_proposals
+        self.init_layers()
+        self.rotate_center = rotate_center
+
+    def init_layers(self):
+        """Initialize layers of the Detr3DTransformer."""
+        self.level_embeds = nn.Parameter(
+            torch.Tensor(self.num_feature_levels, self.embed_dims)
+        )
+        self.cams_embeds = nn.Parameter(torch.Tensor(self.num_cams, self.embed_dims))
+        self.can_bus_mlp = nn.Sequential(
+            nn.Linear(18, self.embed_dims // 2),
+            nn.ReLU(inplace=True),
+            nn.Linear(self.embed_dims // 2, self.embed_dims),
+            nn.ReLU(inplace=True),
+        )
+        if self.can_bus_norm:
+            self.can_bus_mlp.add_module("norm", nn.LayerNorm(self.embed_dims))
+
+    def get_bev_features(
+        self,
+        mlvl_feats,
+        bev_queries,
+        bev_h,
+        bev_w,
+        grid_length=[0.512, 0.512],
+        bev_pos=None,
+        prev_bev=None,
+        img_metas=None,
+    ):
+        """
+        obtain bev features.
+        """
+
+        bs = mlvl_feats[0].size(0)
+        bev_queries = bev_queries.unsqueeze(1).repeat(1, bs, 1)
+        bev_pos = bev_pos.flatten(2).permute(2, 0, 1)
+        delta_x = np.array([each["can_bus"][0] for each in img_metas])
+        delta_y = np.array([each["can_bus"][1] for each in img_metas])
+        ego_angle = np.array([each["can_bus"][-2] / np.pi * 180 for each in img_metas])
+        grid_length_y = grid_length[0]
+        grid_length_x = grid_length[1]
+        translation_length = np.sqrt(delta_x**2 + delta_y**2)
+        translation_angle = np.arctan2(delta_y, delta_x) / np.pi * 180
+        bev_angle = ego_angle - translation_angle
+        shift_y = (
+            translation_length * np.cos(bev_angle / 180 * np.pi) / grid_length_y / bev_h
+        )
+        shift_x = (
+            translation_length * np.sin(bev_angle / 180 * np.pi) / grid_length_x / bev_w
+        )
+        shift_y = shift_y * self.use_shift
+        shift_x = shift_x * self.use_shift
+        shift_np = np.array([shift_x, shift_y])
+        shift = bev_queries.new_tensor(shift_np).permute(1, 0)
+
+        if prev_bev is not None:
+            if prev_bev.shape[1] == bev_h * bev_w:
+                prev_bev = prev_bev.permute(1, 0, 2)
+            if self.rotate_prev_bev:
+                for i in range(bs):
+                    rotation_angle = img_metas[i]["can_bus"][-1]
+                    tmp_prev_bev = (
+                        prev_bev[:, i].reshape(bev_h, bev_w, -1).permute(2, 0, 1)
+                    )
+                    tmp_prev_bev = rotate(
+                        tmp_prev_bev, rotation_angle, center=self.rotate_center
+                    )
+                    tmp_prev_bev = tmp_prev_bev.permute(1, 2, 0).reshape(
+                        bev_h * bev_w, 1, -1
+                    )
+                    prev_bev[:, i] = tmp_prev_bev[:, 0]
+
+        can_bus_np = np.array([each["can_bus"] for each in img_metas])
+        can_bus = bev_queries.new_tensor(can_bus_np)
+        can_bus = self.can_bus_mlp(can_bus)[None, :, :]
+        bev_queries = bev_queries + can_bus * self.use_can_bus
+
+        feat_flatten = []
+        spatial_shapes = []
+        for lvl, feat in enumerate(mlvl_feats):
+            bs, num_cam, c, h, w = feat.shape
+            spatial_shape = (h, w)
+            feat = feat.flatten(3).permute(1, 0, 3, 2)
+            if self.use_cams_embeds:
+                feat = feat + self.cams_embeds[:, None, None, :].to(feat.dtype)
+            feat = feat + self.level_embeds[None, None, lvl : lvl + 1, :].to(feat.dtype)
+            spatial_shapes.append(spatial_shape)
+            feat_flatten.append(feat)
+
+        feat_flatten = torch.cat(feat_flatten, 2)
+        spatial_shapes = torch.as_tensor(spatial_shapes, dtype=torch.long)
+        level_start_index = torch.cat(
+            (spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1])
+        )
+
+        feat_flatten = feat_flatten.permute(0, 2, 1, 3)
+
+        bev_embed = self.encoder(
+            bev_queries,
+            feat_flatten,
+            feat_flatten,
+            bev_h=bev_h,
+            bev_w=bev_w,
+            bev_pos=bev_pos,
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+            prev_bev=prev_bev,
+            shift=shift,
+            img_metas=img_metas,
+        )
+
+        return bev_embed
+
+    def get_states_and_refs(
+        self,
+        bev_embed,
+        object_query_embed,
+        bev_h,
+        bev_w,
+        reference_points,
+        reg_branches=None,
+        cls_branches=None,
+        img_metas=None,
+    ):
+        bs = bev_embed.shape[1]
+        query_pos, query = torch.split(object_query_embed, self.embed_dims, dim=1)
+        query_pos = query_pos.unsqueeze(0).expand(bs, -1, -1)
+        query = query.unsqueeze(0).expand(bs, -1, -1)
+
+        reference_points = reference_points.unsqueeze(0).expand(bs, -1, -1)
+        reference_points = reference_points.sigmoid()
+
+        init_reference_out = reference_points
+        query = query.permute(1, 0, 2)
+        query_pos = query_pos.permute(1, 0, 2)
+        inter_states, inter_references = self.decoder(
+            query=query,
+            key=None,
+            value=bev_embed,
+            query_pos=query_pos,
+            reference_points=reference_points,
+            reg_branches=reg_branches,
+            cls_branches=cls_branches,
+            spatial_shapes=torch.tensor([[bev_h, bev_w]]),
+            level_start_index=torch.tensor([0]),
+            img_metas=img_metas,
+        )
+        inter_references_out = inter_references
+
+        return inter_states, init_reference_out, inter_references_out
+
+
+class BEVFormerLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.attentions = nn.ModuleList(
+            [TemporalSelfAttention(), SpatialCrossAttention()]
+        )
+        self.ffns = nn.ModuleList([FFN(feedforward_channels=512, ffn_drop=0.1)])
+        self.norms = nn.ModuleList(
+            [
+                nn.LayerNorm((256,), eps=1e-5, elementwise_affine=True),
+                nn.LayerNorm((256,), eps=1e-5, elementwise_affine=True),
+                nn.LayerNorm((256,), eps=1e-5, elementwise_affine=True),
+            ]
+        )
+        self.num_attn = 2
+        self.pre_norm = False
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        bev_pos=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        ref_2d=None,
+        ref_3d=None,
+        bev_h=None,
+        bev_w=None,
+        reference_points_cam=None,
+        mask=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        prev_bev=None,
+        **kwargs,
+    ):
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+        else:
+            assert len(attn_masks) == self.num_attn, (
+                f"The length of "
+                f"attn_masks {len(attn_masks)} must be equal "
+                f"to the number of attention in "
+                f"operation_order {self.num_attn}"
+            )
+        x = self.attentions[0](
+            query,
+            prev_bev,
+            prev_bev,
+            identity if self.pre_norm else None,
+            query_pos=bev_pos,
+            key_pos=bev_pos,
+            attn_mask=attn_masks[attn_index],
+            key_padding_mask=query_key_padding_mask,
+            reference_points=ref_2d,
+            spatial_shapes=torch.tensor([[bev_h, bev_w]]),
+            level_start_index=torch.tensor([0]),
+            **kwargs,
+        )
+        x = self.norms[0](x)
+        x = self.attentions[1](
+            x,
+            key,
+            value,
+            identity if self.pre_norm else None,
+            query_pos=query_pos,
+            key_pos=key_pos,
+            reference_points=ref_3d,
+            reference_points_cam=reference_points_cam,
+            mask=mask,
+            attn_mask=attn_masks[attn_index],
+            key_padding_mask=key_padding_mask,
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+            **kwargs,
+        )
+        x = self.norms[1](x)
+        x = self.ffns[0](x)
+        x = self.norms[2](x)
+        return x
+
+
+class TemporalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=1,
+        num_points=4,
+        num_bev_queue=2,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+    ):
+
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(
+                f"embed_dims must be divisible by num_heads, "
+                f"but got {embed_dims} and {num_heads}"
+            )
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError(
+                    "invalid input for _is_power_of_2: {} (type: {})".format(n, type(n))
+                )
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = 256
+        self.num_levels = 1
+        self.num_heads = 8
+        self.num_points = 4
+        self.num_bev_queue = num_bev_queue
+        self.sampling_offsets = nn.Linear(in_features=512, out_features=128, bias=True)
+        self.attention_weights = nn.Linear(in_features=512, out_features=64, bias=True)
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        flag="decoder",
+        **kwargs,
+    ):
+
+        if value is None:
+            assert self.batch_first
+            bs, len_bev, c = query.shape
+            value = torch.stack([query, query], 1).reshape(bs * 2, len_bev, c)
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        if not self.batch_first:
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+        bs, num_query, embed_dims = query.shape
+        _, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+        assert self.num_bev_queue == 2
+
+        query = torch.cat([value[:bs], query], -1)
+        value = self.value_proj(value)
+
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+
+        value = value.reshape(bs * self.num_bev_queue, num_value, self.num_heads, -1)
+
+        sampling_offsets = self.sampling_offsets(query)
+        sampling_offsets = sampling_offsets.view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_bev_queue,
+            self.num_levels,
+            self.num_points,
+            2,
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_bev_queue,
+            self.num_levels * self.num_points,
+        )
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs,
+            num_query,
+            self.num_heads,
+            self.num_bev_queue,
+            self.num_levels,
+            self.num_points,
+        )
+
+        attention_weights = (
+            attention_weights.permute(0, 3, 1, 2, 4, 5)
+            .reshape(
+                bs * self.num_bev_queue,
+                num_query,
+                self.num_heads,
+                self.num_levels,
+                self.num_points,
+            )
+            .contiguous()
+        )
+        sampling_offsets = sampling_offsets.permute(0, 3, 1, 2, 4, 5, 6).reshape(
+            bs * self.num_bev_queue,
+            num_query,
+            self.num_heads,
+            self.num_levels,
+            self.num_points,
+            2,
+        )
+
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.stack(
+                [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1
+            )
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :]
+                + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+            )
+
+        elif reference_points.shape[-1] == 4:
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :2]
+                + sampling_offsets
+                / self.num_points
+                * reference_points[:, :, None, :, None, 2:]
+                * 0.5
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+
+        output = output.permute(1, 2, 0)
+
+        output = output.view(num_query, embed_dims, bs, self.num_bev_queue)
+        output = output.mean(-1)
+
+        output = output.permute(2, 0, 1)
+
+        output = self.output_proj(output)
+
+        if not self.batch_first:
+            output = output.permute(1, 0, 2)
+
+        return self.dropout(output) + identity
+
+
+class SpatialCrossAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_cams=6,
+        pc_range=None,
+        dropout=0.1,
+        batch_first=False,
+        deformable_attention=dict(
+            type="MSDeformableAttention3D",
+            embed_dims=256,
+            num_points=8,
+            num_levels=4,
+            num_heads=8,
+        ),
+        **kwargs,
+    ):
+        super().__init__()
+
+        self.dropout = nn.Dropout(dropout)
+        self.pc_range = [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0]
+        self.fp16_enabled = False
+        self.deformable_attention = MSDeformableAttention3D()
+        self.embed_dims = embed_dims
+        self.num_cams = num_cams
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+        self.batch_first = batch_first
+
+    def forward(
+        self,
+        query,
+        key,
+        value,
+        residual=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        reference_points_cam=None,
+        bev_mask=None,
+        level_start_index=None,
+        flag="encoder",
+        **kwargs,
+    ):
+
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+
+        if residual is None:
+            inp_residual = query
+            slots = torch.zeros_like(query)
+        if query_pos is not None:
+            query = query + query_pos
+
+        bs, num_query, _ = query.size()
+
+        D = reference_points_cam.size(3)
+        indexes = []
+        for i, mask_per_img in enumerate(bev_mask):
+            index_query_per_img = mask_per_img[0].sum(-1).nonzero().squeeze(-1)
+            indexes.append(index_query_per_img)
+        max_len = max([len(each) for each in indexes])
+
+        queries_rebatch = query.new_zeros([bs, self.num_cams, max_len, self.embed_dims])
+        reference_points_rebatch = reference_points_cam.new_zeros(
+            [bs, self.num_cams, max_len, D, 2]
+        )
+
+        for j in range(bs):
+            for i, reference_points_per_img in enumerate(reference_points_cam):
+                index_query_per_img = indexes[i]
+                queries_rebatch[j, i, : len(index_query_per_img)] = query[
+                    j, index_query_per_img
+                ]
+                reference_points_rebatch[
+                    j, i, : len(index_query_per_img)
+                ] = reference_points_per_img[j, index_query_per_img]
+
+        num_cams, l, bs, embed_dims = key.shape
+
+        key = key.permute(2, 0, 1, 3).reshape(bs * self.num_cams, l, self.embed_dims)
+        value = value.permute(2, 0, 1, 3).reshape(
+            bs * self.num_cams, l, self.embed_dims
+        )
+
+        queries = self.deformable_attention(
+            query=queries_rebatch.view(bs * self.num_cams, max_len, self.embed_dims),
+            key=key,
+            value=value,
+            reference_points=reference_points_rebatch.view(
+                bs * self.num_cams, max_len, D, 2
+            ),
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+        ).view(bs, self.num_cams, max_len, self.embed_dims)
+        for j in range(bs):
+            for i, index_query_per_img in enumerate(indexes):
+                slots[j, index_query_per_img] += queries[
+                    j, i, : len(index_query_per_img)
+                ]
+
+        count = bev_mask.sum(-1) > 0
+        count = count.permute(1, 2, 0).sum(-1)
+        count = torch.clamp(count, min=1.0)
+        slots = slots / count[..., None]
+        slots = self.output_proj(slots)
+
+        return self.dropout(slots) + inp_residual
+
+
+class MSDeformableAttention3D(nn.Module):
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=4,
+        num_points=8,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=True,
+        norm_cfg=None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(
+                f"embed_dims must be divisible by num_heads, "
+                f"but got {embed_dims} and {num_heads}"
+            )
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.batch_first = batch_first
+        self.output_proj = None
+        self.fp16_enabled = False
+
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError(
+                    "invalid input for _is_power_of_2: {} (type: {})".format(n, type(n))
+                )
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = 4
+        self.num_heads = 8
+        self.num_points = 8
+        self.sampling_offsets = nn.Linear(in_features=256, out_features=512, bias=True)
+        self.attention_weights = nn.Linear(in_features=256, out_features=256, bias=True)
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        **kwargs,
+    ):
+        if value is None:
+            value = query
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+
+        if not self.batch_first:
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+
+        value = self.value_proj(value)
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+        value = value.view(bs, num_value, self.num_heads, -1)
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_levels * self.num_points
+        )
+
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points
+        )
+
+        if reference_points.shape[-1] == 2:
+            """
+            For each BEV query, it owns `num_Z_anchors` in 3D space that having different heights.
+            After proejcting, each BEV query has `num_Z_anchors` reference points in each 2D image.
+            For each referent point, we sample `num_points` sampling points.
+            For `num_Z_anchors` reference points,  it has overall `num_points * num_Z_anchors` sampling points.
+            """
+            offset_normalizer = torch.stack(
+                [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1
+            )
+
+            bs, num_query, num_Z_anchors, xy = reference_points.shape
+            reference_points = reference_points[:, :, None, None, None, :, :]
+            sampling_offsets = (
+                sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+            )
+            (
+                bs,
+                num_query,
+                num_heads,
+                num_levels,
+                num_all_points,
+                xy,
+            ) = sampling_offsets.shape
+            sampling_offsets = sampling_offsets.view(
+                bs,
+                num_query,
+                num_heads,
+                num_levels,
+                num_all_points // num_Z_anchors,
+                num_Z_anchors,
+                xy,
+            )
+            sampling_locations = reference_points + sampling_offsets
+            (
+                bs,
+                num_query,
+                num_heads,
+                num_levels,
+                num_points,
+                num_Z_anchors,
+                xy,
+            ) = sampling_locations.shape
+            assert num_all_points == num_points * num_Z_anchors
+
+            sampling_locations = sampling_locations.view(
+                bs, num_query, num_heads, num_levels, num_all_points, xy
+            )
+
+        elif reference_points.shape[-1] == 4:
+            assert False
+        else:
+            raise ValueError(
+                f"Last dim of reference_points must be"
+                f" 2 or 4, but get {reference_points.shape[-1]} instead."
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+        if not self.batch_first:
+            output = output.permute(1, 0, 2)
+
+        return output
+
+
+class BEVFormerEncoder(TransformerLayerSequence):
+
+    """
+    Attention with both self and cross
+    Implements the decoder in DETR transformer.
+    Args:
+        return_intermediate (bool): Whether to return intermediate outputs.
+        coder_norm_cfg (dict): Config of last normalization layer. Default：
+            `LN`.
+    """
+
+    def __init__(
+        self,
+        *args,
+        pc_range=None,
+        num_points_in_pillar=4,
+        return_intermediate=False,
+        num_layers=6,
+        dataset_type="nuscenes",
+        **kwargs,
+    ):
+        super().__init__(
+            transformerlayers=BEVFormerLayer, num_layers=num_layers, *args, **kwargs
+        )
+        self.return_intermediate = False
+
+        self.num_points_in_pillar = 4
+        self.pc_range = [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0]
+        self.fp16_enabled = False
+
+    @staticmethod
+    def get_reference_points(
+        H, W, Z=8, num_points_in_pillar=4, dim="3d", bs=1, dtype=torch.float
+    ):
+        """Get the reference points used in SCA and TSA.
+        Args:
+            H, W: spatial shape of bev.
+            Z: hight of pillar.
+            D: sample D points uniformly from each pillar.
+        Returns:
+            Tensor: reference points used in decoder, has \
+                shape (bs, num_keys, num_levels, 2).
+        """
+
+        if dim == "3d":
+            zs = (
+                torch.linspace(0.5, Z - 0.5, num_points_in_pillar, dtype=dtype)
+                .view(-1, 1, 1)
+                .expand(num_points_in_pillar, H, W)
+                / Z
+            )
+            xs = (
+                torch.linspace(0.5, W - 0.5, W, dtype=dtype)
+                .view(1, 1, W)
+                .expand(num_points_in_pillar, H, W)
+                / W
+            )
+            ys = (
+                torch.linspace(0.5, H - 0.5, H, dtype=dtype)
+                .view(1, H, 1)
+                .expand(num_points_in_pillar, H, W)
+                / H
+            )
+            ref_3d = torch.stack((xs, ys, zs), -1)
+            ref_3d = ref_3d.permute(0, 3, 1, 2).flatten(2).permute(0, 2, 1)
+            ref_3d = ref_3d[None].repeat(bs, 1, 1, 1)
+            return ref_3d
+
+        elif dim == "2d":
+            ref_y, ref_x = torch.meshgrid(
+                torch.linspace(0.5, H - 0.5, H, dtype=dtype),
+                torch.linspace(0.5, W - 0.5, W, dtype=dtype),
+            )
+            ref_y = ref_y.reshape(-1)[None] / H
+            ref_x = ref_x.reshape(-1)[None] / W
+            ref_2d = torch.stack((ref_x, ref_y), -1)
+            ref_2d = ref_2d.repeat(bs, 1, 1).unsqueeze(2)
+            return ref_2d
+
+    def point_sampling(self, reference_points, pc_range, img_metas):
+
+        lidar2img = []
+        for img_meta in img_metas:
+            lidar2img.append(img_meta["lidar2img"])
+        lidar2img = np.asarray(lidar2img)
+        lidar2img = reference_points.new_tensor(lidar2img)
+        reference_points = reference_points.clone()
+
+        reference_points[..., 0:1] = (
+            reference_points[..., 0:1] * (pc_range[3] - pc_range[0]) + pc_range[0]
+        )
+        reference_points[..., 1:2] = (
+            reference_points[..., 1:2] * (pc_range[4] - pc_range[1]) + pc_range[1]
+        )
+        reference_points[..., 2:3] = (
+            reference_points[..., 2:3] * (pc_range[5] - pc_range[2]) + pc_range[2]
+        )
+
+        reference_points = torch.cat(
+            (reference_points, torch.ones_like(reference_points[..., :1])), -1
+        )
+
+        reference_points = reference_points.permute(1, 0, 2, 3)
+        D, B, num_query = reference_points.size()[:3]
+        num_cam = lidar2img.size(1)
+
+        reference_points = (
+            reference_points.view(D, B, 1, num_query, 4)
+            .repeat(1, 1, num_cam, 1, 1)
+            .unsqueeze(-1)
+        )
+
+        lidar2img = lidar2img.view(1, B, num_cam, 1, 4, 4).repeat(
+            D, 1, 1, num_query, 1, 1
+        )
+
+        reference_points_cam = torch.matmul(
+            lidar2img.to(torch.float32), reference_points.to(torch.float32)
+        ).squeeze(-1)
+        eps = 1e-5
+
+        bev_mask = reference_points_cam[..., 2:3] > eps
+        reference_points_cam = reference_points_cam[..., 0:2] / torch.maximum(
+            reference_points_cam[..., 2:3],
+            torch.ones_like(reference_points_cam[..., 2:3]) * eps,
+        )
+
+        reference_points_cam[..., 0] /= img_metas[0]["img_shape"][0][1]
+        reference_points_cam[..., 1] /= img_metas[0]["img_shape"][0][0]
+
+        bev_mask = (
+            bev_mask
+            & (reference_points_cam[..., 1:2] > 0.0)
+            & (reference_points_cam[..., 1:2] < 1.0)
+            & (reference_points_cam[..., 0:1] < 1.0)
+            & (reference_points_cam[..., 0:1] > 0.0)
+        )
+        bev_mask = torch.nan_to_num(bev_mask)
+
+        reference_points_cam = reference_points_cam.permute(2, 1, 3, 0, 4)
+        bev_mask = bev_mask.permute(2, 1, 3, 0, 4).squeeze(-1)
+
+        return reference_points_cam, bev_mask
+
+    def forward(
+        self,
+        bev_query,
+        key,
+        value,
+        *args,
+        bev_h=None,
+        bev_w=None,
+        bev_pos=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        valid_ratios=None,
+        prev_bev=None,
+        shift=0.0,
+        img_metas=None,
+        **kwargs,
+    ):
+        """Forward function for `TransformerDecoder`.
+        Args:
+            bev_query (Tensor): Input BEV query with shape
+                `(num_query, bs, embed_dims)`.
+            key & value (Tensor): Input multi-cameta features with shape
+                (num_cam, num_value, bs, embed_dims)
+            reference_points (Tensor): The reference
+                points of offset. has shape
+                (bs, num_query, 4) when as_two_stage,
+                otherwise has shape ((bs, num_query, 2).
+            valid_ratios (Tensor): The radios of valid
+                points on the feature map, has shape
+                (bs, num_levels, 2)
+        Returns:
+            Tensor: Results with shape [1, num_query, bs, embed_dims] when
+                return_intermediate is `False`, otherwise it has shape
+                [num_layers, num_query, bs, embed_dims].
+        """
+
+        output = bev_query
+        intermediate = []
+
+        ref_3d = self.get_reference_points(
+            bev_h,
+            bev_w,
+            self.pc_range[5] - self.pc_range[2],
+            self.num_points_in_pillar,
+            dim="3d",
+            bs=bev_query.size(1),
+            dtype=bev_query.dtype,
+        )
+        ref_2d = self.get_reference_points(
+            bev_h, bev_w, dim="2d", bs=bev_query.size(1), dtype=bev_query.dtype
+        )
+
+        reference_points_cam, bev_mask = self.point_sampling(
+            ref_3d, self.pc_range, img_metas
+        )
+
+        shift_ref_2d = ref_2d
+        shift_ref_2d += shift[:, None, None, :]
+
+        bev_query = bev_query.permute(1, 0, 2)
+        bev_pos = bev_pos.permute(1, 0, 2)
+        bs, len_bev, num_bev_level, _ = ref_2d.shape
+        if prev_bev is not None:
+            prev_bev = prev_bev.permute(1, 0, 2)
+            prev_bev = torch.stack([prev_bev, bev_query], 1).reshape(
+                bs * 2, len_bev, -1
+            )
+            hybird_ref_2d = torch.stack([shift_ref_2d, ref_2d], 1).reshape(
+                bs * 2, len_bev, num_bev_level, 2
+            )
+        else:
+            hybird_ref_2d = torch.stack([ref_2d, ref_2d], 1).reshape(
+                bs * 2, len_bev, num_bev_level, 2
+            )
+
+        for lid, layer in enumerate(self.layers):
+            output = layer(
+                bev_query,
+                key,
+                value,
+                *args,
+                bev_pos=bev_pos,
+                ref_2d=hybird_ref_2d,
+                ref_3d=ref_3d,
+                bev_h=bev_h,
+                bev_w=bev_w,
+                spatial_shapes=spatial_shapes,
+                level_start_index=level_start_index,
+                reference_points_cam=reference_points_cam,
+                bev_mask=bev_mask,
+                prev_bev=prev_bev,
+                **kwargs,
+            )
+
+            bev_query = output
+            if self.return_intermediate:
+                intermediate.append(output)
+
+        if self.return_intermediate:
+            return torch.stack(intermediate)
+
+        return output
+
+
+class DetectionTransformerDecoder(TransformerLayerSequence):
+    """Implements the decoder in DETR3D transformer.
+    Args:
+        return_intermediate (bool): Whether to return intermediate outputs.
+        coder_norm_cfg (dict): Config of last normalization layer. Default：
+            `LN`.
+    """
+
+    def __init__(self, *args, return_intermediate=False, num_layers=6, **kwargs):
+        super().__init__(
+            transformerlayers=DetrTransformerDecoderLayer,
+            num_layers=num_layers,
+            *args,
+            **kwargs,
+        )
+        self.return_intermediate = True
+        self.fp16_enabled = False
+
+    def forward(
+        self,
+        query,
+        *args,
+        reference_points=None,
+        reg_branches=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        """Forward function for `Detr3DTransformerDecoder`.
+        Args:
+            query (Tensor): Input query with shape
+                `(num_query, bs, embed_dims)`.
+            reference_points (Tensor): The reference
+                points of offset. has shape
+                (bs, num_query, 4) when as_two_stage,
+                otherwise has shape ((bs, num_query, 2).
+            reg_branch: (obj:`nn.ModuleList`): Used for
+                refining the regression results. Only would
+                be passed when with_box_refine is True,
+                otherwise would be passed a `None`.
+        Returns:
+            Tensor: Results with shape [1, num_query, bs, embed_dims] when
+                return_intermediate is `False`, otherwise it has shape
+                [num_layers, num_query, bs, embed_dims].
+        """
+        output = query
+        intermediate = []
+        intermediate_reference_points = []
+        for lid, layer in enumerate(self.layers):
+
+            reference_points_input = reference_points[..., :2].unsqueeze(2)
+            output = layer(
+                output,
+                *args,
+                reference_points=reference_points_input,
+                key_padding_mask=key_padding_mask,
+                **kwargs,
+            )
+            output = output.permute(1, 0, 2)
+
+            if reg_branches is not None:
+                tmp = reg_branches[lid](output)
+
+                assert reference_points.shape[-1] == 3
+
+                new_reference_points = torch.zeros_like(reference_points)
+                new_reference_points[..., :2] = tmp[..., :2] + inverse_sigmoid(
+                    reference_points[..., :2]
+                )
+                new_reference_points[..., 2:3] = tmp[..., 4:5] + inverse_sigmoid(
+                    reference_points[..., 2:3]
+                )
+
+                new_reference_points = new_reference_points.sigmoid()
+
+                reference_points = new_reference_points.detach()
+
+            output = output.permute(1, 0, 2)
+            if self.return_intermediate:
+                intermediate.append(output)
+                intermediate_reference_points.append(reference_points)
+
+        if self.return_intermediate:
+            return torch.stack(intermediate), torch.stack(intermediate_reference_points)
+
+        return output, reference_points
+
+
+class DetrTransformerDecoderLayer(BaseTransformerLayer):
+    """Implements decoder layer in DETR transformer.
+
+    Args:
+        attn_cfgs (list[`mmcv.ConfigDict`] | list[dict] | dict )):
+            Configs for self_attention or cross_attention, the order
+            should be consistent with it in `operation_order`. If it is
+            a dict, it would be expand to the number of attention in
+            `operation_order`.
+        feedforward_channels (int): The hidden dimension for FFNs.
+        ffn_dropout (float): Probability of an element to be zeroed
+            in ffn. Default 0.0.
+        operation_order (tuple[str]): The execution order of operation
+            in transformer. Such as ('self_attn', 'norm', 'ffn', 'norm').
+            Default：None
+        act_cfg (dict): The activation config for FFNs. Default: `LN`
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: `LN`.
+        ffn_num_fcs (int): The number of fully-connected layers in FFNs.
+            Default：2.
+    """
+
+    def __init__(
+        self,
+        attn_cfgs=[
+            {
+                "type": "MultiheadAttention",
+                "embed_dims": 256,
+                "num_heads": 8,
+                "dropout": 0.1,
+            },
+            {"type": "CustomMSDeformableAttention", "embed_dims": 256, "num_levels": 1},
+        ],
+        operation_order=("self_attn", "norm", "cross_attn", "norm", "ffn", "norm"),
+        norm_cfg=dict(type="LN"),
+        **kwargs,
+    ):
+        ffn_cfgs = dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=512,
+            num_fcs=2,
+            ffn_drop=0.0,
+            act_cfg=dict(type="ReLU", inplace=True),
+        )
+        super(DetrTransformerDecoderLayer, self).__init__(
+            attn_cfgs=attn_cfgs,
+            ffn_cfgs=ffn_cfgs,
+            operation_order=operation_order,
+            norm_cfg=norm_cfg,
+            **kwargs,
+        )
+        assert len(operation_order) == 6
+        assert set(operation_order) == set(["self_attn", "norm", "cross_attn", "ffn"])
+        self.num_attn = sum([op.endswith("attn") for op in operation_order])
+
+
+class GridMask(nn.Module):
+    def __init__(
+        self,
+        use_h=True,
+        use_w=True,
+        rotate=1,
+        offset=False,
+        ratio=0.5,
+        mode=0,
+        prob=1.0,
+    ):
+        super(GridMask, self).__init__()
+        self.use_h = use_h
+        self.use_w = use_w
+        self.rotate = rotate
+        self.offset = offset
+        self.ratio = ratio
+        self.mode = mode
+        self.st_prob = prob
+        self.prob = prob
+
+    def set_prob(self, epoch, max_epoch):
+        self.prob = self.st_prob * epoch / max_epoch
+
+    def _rotate_tensor(self, tensor, angle):
+        """
+        Rotate a 2D tensor by the given angle using PyTorch operations.
+        Args:
+            tensor: Input tensor of shape (H, W)
+            angle: Rotation angle in degrees
+        Returns:
+            Rotated tensor of same shape
+        """
+        tensor = tensor.unsqueeze(0)
+        angle_rad = torch.tensor(angle * np.pi / 180.0)
+        cos_val = torch.cos(angle_rad)
+        sin_val = torch.sin(angle_rad)
+        rotation_matrix = torch.tensor([[cos_val, -sin_val, 0], [sin_val, cos_val, 0]])
+        grid = F.affine_grid(
+            rotation_matrix.unsqueeze(0),
+            size=(1, 1, tensor.shape[1], tensor.shape[2]),
+            align_corners=False,
+        )
+        rotated_tensor = F.grid_sample(
+            tensor.unsqueeze(0), grid, align_corners=False, mode="bilinear"
+        )
+        return rotated_tensor.squeeze(0).squeeze(0)
+
+    def forward(self, x):
+        if np.random.rand() > self.prob or not self.training:
+            return x
+
+        n, c, h, w = x.size()
+        x = x.view(-1, h, w)
+        hh = int(1.5 * h)
+        ww = int(1.5 * w)
+        d = np.random.randint(2, min(h, w))
+        l = min(max(int(d * self.ratio + 0.5), 1), d - 1)
+
+        mask = torch.ones((hh, ww), dtype=x.dtype)
+        st_h = np.random.randint(d)
+        st_w = np.random.randint(d)
+
+        if self.use_h:
+            for i in range(hh // d):
+                s = d * i + st_h
+                t = min(s + l, hh)
+                mask[s:t, :] *= 0
+
+        if self.use_w:
+            for i in range(ww // d):
+                s = d * i + st_w
+                t = min(s + l, ww)
+                mask[:, s:t] *= 0
+
+        if self.rotate > 0:
+            r = np.random.randint(self.rotate)
+            mask = self._rotate_tensor(mask, r)
+
+        mask = mask[
+            (hh - h) // 2 : (hh - h) // 2 + h, (ww - w) // 2 : (ww - w) // 2 + w
+        ]
+
+        if self.mode == 1:
+            mask = 1 - mask
+
+        mask = mask.expand_as(x)
+        return x.view(n, c, h, w)
+
+
+class Instances:
+    """
+    This class represents a list of instances in an image.
+    It stores the attributes of instances (e.g., boxes, masks, labels, scores) as "fields".
+    All fields must have the same ``__len__`` which is the number of instances.
+    All other (non-field) attributes of this class are considered private:
+    they must start with '_' and are not modifiable by a user.
+    Some basic usage:
+    1. Set/get/check a field:
+       .. code-block:: python
+          instances.gt_boxes = Boxes(...)
+          print(instances.pred_masks)  # a tensor of shape (N, H, W)
+          print('gt_masks' in instances)
+    2. ``len(instances)`` returns the number of instances
+    3. Indexing: ``instances[indices]`` will apply the indexing on all the fields
+       and returns a new :class:`Instances`.
+       Typically, ``indices`` is a integer vector of indices,
+       or a binary mask of length ``num_instances``
+       .. code-block:: python
+          category_3_detections = instances[instances.pred_classes == 3]
+          confident_detections = instances[instances.scores > 0.9]
+    """
+
+    def __init__(self, image_size: Tuple[int, int], **kwargs: Any):
+        """
+        Args:
+            image_size (height, width): the spatial size of the image.
+            kwargs: fields to add to this `Instances`.
+        """
+        self._image_size = image_size
+        self._fields: Dict[str, Any] = {}
+
+        for k, v in kwargs.items():
+            self.set(k, v)
+
+    @property
+    def image_size(self) -> Tuple[int, int]:
+        """
+        Returns:
+            tuple: height, width
+        """
+        return self._image_size
+
+    def __setattr__(self, name: str, val: Any) -> None:
+        if name.startswith("_"):
+            super().__setattr__(name, val)
+        else:
+            self.set(name, val)
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "_fields" or name not in self._fields:
+            raise AttributeError(
+                "Cannot find field '{}' in the given Instances!".format(name)
+            )
+        return self._fields[name]
+
+    def set(self, name: str, value: Any) -> None:
+        """
+        Set the field named `name` to `value`.
+        The length of `value` must be the number of instances,
+        and must agree with other existing fields in this object.
+        """
+        data_len = len(value)
+        if len(self._fields):
+            assert (
+                len(self) == data_len
+            ), "Adding a field of length {} to a Instances of length {}".format(
+                data_len, len(self)
+            )
+        self._fields[name] = value
+
+    def has(self, name: str) -> bool:
+        """
+        Returns:
+            bool: whether the field called `name` exists.
+        """
+        return name in self._fields
+
+    def remove(self, name: str) -> None:
+        """
+        Remove the field called `name`.
+        """
+        del self._fields[name]
+
+    def get(self, name: str) -> Any:
+        """
+        Returns the field called `name`.
+        """
+        return self._fields[name]
+
+    def get_fields(self) -> Dict[str, Any]:
+        """
+        Returns:
+            dict: a dict which maps names (str) to data of the fields
+        Modifying the returned dict will modify this instance.
+        """
+        return self._fields
+
+    def numpy(self):
+        ret = Instances(self._image_size)
+        for k, v in self._fields.items():
+            if hasattr(v, "numpy"):
+                v = v.numpy()
+            ret.set(k, v)
+        return ret
+
+    def __getitem__(self, item: Union[int, slice, torch.BoolTensor]) -> "Instances":
+        """
+        Args:
+            item: an index-like object and will be used to index all the fields.
+        Returns:
+            If `item` is a string, return the data in the corresponding field.
+            Otherwise, returns an `Instances` where all fields are indexed by `item`.
+        """
+        if type(item) == int:
+            if item >= len(self) or item < -len(self):
+                raise IndexError("Instances index out of range!")
+            else:
+                item = slice(item, None, len(self))
+
+        ret = Instances(self._image_size)
+        for k, v in self._fields.items():
+            if k == "kalman_models" and isinstance(item, torch.Tensor):
+                ret_list = []
+                for i, if_true in enumerate(item):
+                    if if_true:
+                        ret_list.append(self.kalman_models[i])
+                ret.set(k, ret_list)
+
+            else:
+                ret.set(k, v[item])
+        return ret
+
+    def __len__(self) -> int:
+        for v in self._fields.values():
+            return v.__len__()
+        raise NotImplementedError("Empty Instances does not support __len__!")
+
+    def __iter__(self):
+        raise NotImplementedError("`Instances` object is not iterable!")
+
+    @staticmethod
+    def cat(instance_lists: List["Instances"]) -> "Instances":
+        """
+        Args:
+            instance_lists (list[Instances])
+        Returns:
+            Instances
+        """
+        assert all(isinstance(i, Instances) for i in instance_lists)
+        assert len(instance_lists) > 0
+        if len(instance_lists) == 1:
+            return instance_lists[0]
+
+        image_size = instance_lists[0].image_size
+        for i in instance_lists[1:]:
+            assert i.image_size == image_size
+        ret = Instances(image_size)
+        for k in instance_lists[0]._fields.keys():
+            values = [i.get(k) for i in instance_lists]
+            v0 = values[0]
+            if isinstance(v0, torch.Tensor):
+                values = torch.cat(values, dim=0)
+            elif isinstance(v0, list):
+                values = list(itertools.chain(*values))
+            elif hasattr(type(v0), "cat"):
+                values = type(v0).cat(values)
+            else:
+                raise ValueError(
+                    "Unsupported type {} for concatenation".format(type(v0))
+                )
+            ret.set(k, values)
+        return ret
+
+    def __str__(self) -> str:
+        s = self.__class__.__name__ + "("
+        s += "num_instances={}, ".format(len(self))
+        s += "image_height={}, ".format(self._image_size[0])
+        s += "image_width={}, ".format(self._image_size[1])
+        s += "fields=[{}])".format(
+            ", ".join((f"{k}: {v}" for k, v in self._fields.items()))
+        )
+        return s
+
+    __repr__ = __str__
+
+
+class MemoryBank(nn.Module):
+    def __init__(
+        self,
+        args,
+        dim_in,
+        hidden_dim,
+        dim_out,
+    ):
+        super().__init__()
+        self._build_layers(args, dim_in, hidden_dim, dim_out)
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def _build_layers(self, args, dim_in, hidden_dim, dim_out):
+        self.save_thresh = 0.0
+        self.save_period = 3
+        self.max_his_length = 4
+
+        self.save_proj = nn.Linear(dim_in, dim_in)
+
+        self.temporal_attn = nn.MultiheadAttention(dim_in, 8, dropout=0)
+        self.temporal_fc1 = nn.Linear(dim_in, hidden_dim)
+        self.temporal_fc2 = nn.Linear(hidden_dim, dim_in)
+        self.temporal_norm1 = nn.LayerNorm(dim_in)
+        self.temporal_norm2 = nn.LayerNorm(dim_in)
+
+    def update(self, track_instances):
+        embed = track_instances.output_embedding[:, None]
+        scores = track_instances.scores
+        mem_padding_mask = track_instances.mem_padding_mask
+
+        save_period = track_instances.save_period
+        if self.training:
+            saved_idxes = scores > 0
+        else:
+            saved_idxes = (save_period == 0) & (scores > self.save_thresh)
+            save_period[save_period > 0] -= 1
+            save_period[saved_idxes] = self.save_period
+
+        saved_embed = embed[saved_idxes]
+        if len(saved_embed) > 0:
+            prev_embed = track_instances.mem_bank[saved_idxes]
+            save_embed = self.save_proj(saved_embed)
+            mem_padding_mask[saved_idxes] = torch.cat(
+                [
+                    mem_padding_mask[saved_idxes, 1:],
+                    torch.zeros((len(saved_embed), 1), dtype=torch.bool),
+                ],
+                dim=1,
+            )
+            track_instances.mem_bank = track_instances.mem_bank.clone()
+            track_instances.mem_bank[saved_idxes] = torch.cat(
+                [prev_embed[:, 1:], save_embed], dim=1
+            )
+
+    def _forward_temporal_attn(self, track_instances):
+        if len(track_instances) == 0:
+            return track_instances
+
+        key_padding_mask = track_instances.mem_padding_mask
+
+        valid_idxes = key_padding_mask[:, -1] == 0
+        embed = track_instances.output_embedding[valid_idxes]
+
+        if len(embed) > 0:
+            prev_embed = track_instances.mem_bank[valid_idxes]
+            key_padding_mask = key_padding_mask[valid_idxes]
+            embed2 = self.temporal_attn(
+                embed[None],
+                prev_embed.transpose(0, 1),
+                prev_embed.transpose(0, 1),
+                key_padding_mask=key_padding_mask,
+            )[0][0]
+
+            embed = self.temporal_norm1(embed + embed2)
+            embed2 = self.temporal_fc2(F.relu(self.temporal_fc1(embed)))
+            embed = self.temporal_norm2(embed + embed2)
+            track_instances.output_embedding = track_instances.output_embedding.clone()
+            track_instances.output_embedding[valid_idxes] = embed
+
+        return track_instances
+
+    def forward_temporal_attn(self, track_instances):
+        return self._forward_temporal_attn(track_instances)
+
+    def forward(self, track_instances: Instances, update_bank=True) -> Instances:
+        track_instances = self._forward_temporal_attn(track_instances)
+        if update_bank:
+            self.update(track_instances)
+        return track_instances
+
+
+class QueryInteractionBase(nn.Module):
+    def __init__(self, args, dim_in, hidden_dim, dim_out):
+        super().__init__()
+        self.args = args
+        self._build_layers(args, dim_in, hidden_dim, dim_out)
+        self._reset_parameters()
+
+    def _build_layers(self, args, dim_in, hidden_dim, dim_out):
+        raise NotImplementedError()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def _select_active_tracks(self, data: dict) -> Instances:
+        raise NotImplementedError()
+
+    def _update_track_embedding(self, track_instances):
+        raise NotImplementedError()
+
+
+class QueryInteractionModule(QueryInteractionBase):
+    def __init__(self, args, dim_in, hidden_dim, dim_out):
+        self.update_query_pos = True
+        super().__init__(args, dim_in, hidden_dim, dim_out)
+        self.random_drop = 0.1
+        self.fp_ratio = 0.3
+
+    def _build_layers(self, args, dim_in, hidden_dim, dim_out):
+        dropout = 0
+
+        self.self_attn = nn.MultiheadAttention(dim_in, 8, dropout)
+        self.linear1 = nn.Linear(dim_in, hidden_dim)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(hidden_dim, dim_in)
+
+        if self.update_query_pos:
+            self.linear_pos1 = nn.Linear(dim_in, hidden_dim)
+            self.linear_pos2 = nn.Linear(hidden_dim, dim_in)
+            self.dropout_pos1 = nn.Dropout(dropout)
+            self.dropout_pos2 = nn.Dropout(dropout)
+            self.norm_pos = nn.LayerNorm(dim_in)
+
+        self.linear_feat1 = nn.Linear(dim_in, hidden_dim)
+        self.linear_feat2 = nn.Linear(hidden_dim, dim_in)
+        self.dropout_feat1 = nn.Dropout(dropout)
+        self.dropout_feat2 = nn.Dropout(dropout)
+        self.norm_feat = nn.LayerNorm(dim_in)
+
+        self.norm1 = nn.LayerNorm(dim_in)
+        self.norm2 = nn.LayerNorm(dim_in)
+
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
+        self.activation = F.relu
+
+    def _update_track_embedding(self, track_instances: Instances) -> Instances:
+        if len(track_instances) == 0:
+            return track_instances
+        dim = track_instances.query.shape[1]
+        out_embed = track_instances.output_embedding
+        query_pos = track_instances.query[:, : dim // 2]
+        query_feat = track_instances.query[:, dim // 2 :]
+        q = k = query_pos + out_embed
+
+        tgt = out_embed
+        tgt2 = self.self_attn(q[:, None], k[:, None], value=tgt[:, None])[0][:, 0]
+        tgt = tgt + self.dropout1(tgt2)
+        tgt = self.norm1(tgt)
+
+        tgt2 = self.linear2(self.dropout(self.activation(self.linear1(tgt))))
+        tgt = tgt + self.dropout2(tgt2)
+        tgt = self.norm2(tgt)
+
+        if self.update_query_pos:
+            query_pos2 = self.linear_pos2(
+                self.dropout_pos1(self.activation(self.linear_pos1(tgt)))
+            )
+            query_pos = query_pos + self.dropout_pos2(query_pos2)
+            query_pos = self.norm_pos(query_pos)
+            track_instances.query[:, : dim // 2] = query_pos
+
+        query_feat2 = self.linear_feat2(
+            self.dropout_feat1(self.activation(self.linear_feat1(tgt)))
+        )
+        query_feat = query_feat + self.dropout_feat2(query_feat2)
+        query_feat = self.norm_feat(query_feat)
+        track_instances.query[:, dim // 2 :] = query_feat
+        return track_instances
+
+    def _random_drop_tracks(self, track_instances: Instances) -> Instances:
+        drop_probability = self.random_drop
+        if drop_probability > 0 and len(track_instances) > 0:
+            keep_idxes = torch.rand_like(track_instances.scores) > drop_probability
+            track_instances = track_instances[keep_idxes]
+        return track_instances
+
+    def _add_fp_tracks(
+        self, track_instances: Instances, active_track_instances: Instances
+    ) -> Instances:
+        """
+        self.fp_ratio is used to control num(add_fp) / num(active)
+        """
+        inactive_instances = track_instances[track_instances.obj_idxes < 0]
+
+        fp_prob = torch.ones_like(active_track_instances.scores) * self.fp_ratio
+        selected_active_track_instances = active_track_instances[
+            torch.bernoulli(fp_prob).bool()
+        ]
+        num_fp = len(selected_active_track_instances)
+
+        if len(inactive_instances) > 0 and num_fp > 0:
+            if num_fp >= len(inactive_instances):
+                fp_track_instances = inactive_instances
+            else:
+                fp_indexes = torch.argsort(inactive_instances.scores)[-num_fp:]
+                fp_track_instances = inactive_instances[fp_indexes]
+
+            merged_track_instances = Instances.cat(
+                [active_track_instances, fp_track_instances]
+            )
+            return merged_track_instances
+
+        return active_track_instances
+
+    def _select_active_tracks(self, data: dict) -> Instances:
+        track_instances: Instances = data["track_instances"]
+        if self.training:
+            active_idxes = (track_instances.obj_idxes >= 0) & (
+                track_instances.iou > 0.5
+            )
+            active_track_instances = track_instances[active_idxes]
+            active_track_instances = self._random_drop_tracks(active_track_instances)
+            if self.fp_ratio > 0:
+                active_track_instances = self._add_fp_tracks(
+                    track_instances, active_track_instances
+                )
+        else:
+            active_track_instances = track_instances[track_instances.obj_idxes >= 0]
+
+        return active_track_instances
+
+    def forward(self, data) -> Instances:
+        active_track_instances = self._select_active_tracks(data)
+        active_track_instances = self._update_track_embedding(active_track_instances)
+        init_track_instances: Instances = data["init_track_instances"]
+        merged_track_instances = Instances.cat(
+            [init_track_instances, active_track_instances]
+        )
+        return merged_track_instances
+
+
+class RuntimeTrackerBase(object):
+    def __init__(self, score_thresh=0.5, filter_score_thresh=0.4, miss_tolerance=5):
+        self.score_thresh = score_thresh
+        self.filter_score_thresh = filter_score_thresh
+        self.miss_tolerance = miss_tolerance
+        self.max_obj_id = 0
+
+    def clear(self):
+        self.max_obj_id = 0
+
+    def update(self, track_instances: Instances, iou_thre=None):
+        track_instances.disappear_time[track_instances.scores >= self.score_thresh] = 0
+        for i in range(len(track_instances)):
+            if (
+                track_instances.obj_idxes[i] == -1
+                and track_instances.scores[i] >= self.score_thresh
+            ):
+                if (
+                    iou_thre is not None
+                    and track_instances.pred_boxes[
+                        track_instances.obj_idxes >= 0
+                    ].shape[0]
+                    != 0
+                ):
+                    iou3ds = iou_3d(
+                        denormalize_bbox(
+                            track_instances.pred_boxes[i].unsqueeze(0), None
+                        )[..., :7],
+                        denormalize_bbox(
+                            track_instances.pred_boxes[track_instances.obj_idxes >= 0],
+                            None,
+                        )[..., :7],
+                    )
+                    if iou3ds.max() > iou_thre:
+                        continue
+
+                track_instances.obj_idxes[i] = self.max_obj_id
+                self.max_obj_id += 1
+            elif (
+                track_instances.obj_idxes[i] >= 0
+                and track_instances.scores[i] < self.filter_score_thresh
+            ):
+                track_instances.disappear_time[i] += 1
+                if track_instances.disappear_time[i] >= self.miss_tolerance:
+                    track_instances.obj_idxes[i] = -1
+
+
+class BaseInstance3DBoxes(object):
+    """Base class for 3D Boxes.
+
+    Note:
+        The box is bottom centered, i.e. the relative position of origin in
+        the box is (0.5, 0.5, 0).
+
+    Args:
+        tensor (torch.Tensor | np.ndarray | list): a N x box_dim matrix.
+        box_dim (int): Number of the dimension of a box.
+            Each row is (x, y, z, x_size, y_size, z_size, yaw).
+            Defaults to 7.
+        with_yaw (bool): Whether the box is with yaw rotation.
+            If False, the value of yaw will be set to 0 as minmax boxes.
+            Defaults to True.
+        origin (tuple[float], optional): Relative position of the box origin.
+            Defaults to (0.5, 0.5, 0). This will guide the box be converted to
+            (0.5, 0.5, 0) mode.
+
+    Attributes:
+        tensor (torch.Tensor): Float matrix of N x box_dim.
+        box_dim (int): Integer indicating the dimension of a box.
+            Each row is (x, y, z, x_size, y_size, z_size, yaw, ...).
+        with_yaw (bool): If True, the value of yaw will be set to 0 as minmax
+            boxes.
+    """
+
+    def __init__(self, tensor, box_dim=7, with_yaw=True, origin=(0.5, 0.5, 0)):
+
+        tensor = torch.as_tensor(tensor, dtype=torch.float32)
+        if tensor.numel() == 0:
+
+            tensor = tensor.reshape((0, box_dim)).to(dtype=torch.float32)
+        assert tensor.dim() == 2 and tensor.size(-1) == box_dim, tensor.size()
+
+        if tensor.shape[-1] == 6:
+            assert box_dim == 6
+            fake_rot = tensor.new_zeros(tensor.shape[0], 1)
+            tensor = torch.cat((tensor, fake_rot), dim=-1)
+            self.box_dim = box_dim + 1
+            self.with_yaw = False
+        else:
+            self.box_dim = box_dim
+            self.with_yaw = with_yaw
+        self.tensor = tensor.clone()
+
+        if origin != (0.5, 0.5, 0):
+            dst = self.tensor.new_tensor((0.5, 0.5, 0))
+            src = self.tensor.new_tensor(origin)
+            self.tensor[:, :3] += self.tensor[:, 3:6] * (dst - src)
+
+    @property
+    def volume(self):
+        """torch.Tensor: A vector with volume of each box."""
+        return self.tensor[:, 3] * self.tensor[:, 4] * self.tensor[:, 5]
+
+    @property
+    def dims(self):
+        """torch.Tensor: Size dimensions of each box in shape (N, 3)."""
+        return self.tensor[:, 3:6]
+
+    @property
+    def yaw(self):
+        """torch.Tensor: A vector with yaw of each box in shape (N, )."""
+        return self.tensor[:, 6]
+
+    @property
+    def height(self):
+        """torch.Tensor: A vector with height of each box in shape (N, )."""
+        return self.tensor[:, 5]
+
+    @property
+    def top_height(self):
+        """torch.Tensor:
+        A vector with the top height of each box in shape (N, )."""
+        return self.bottom_height + self.height
+
+    @property
+    def bottom_height(self):
+        """torch.Tensor:
+        A vector with bottom's height of each box in shape (N, )."""
+        return self.tensor[:, 2]
+
+    @property
+    def center(self):
+        """Calculate the center of all the boxes.
+
+        Note:
+            In MMDetection3D's convention, the bottom center is
+            usually taken as the default center.
+
+            The relative position of the centers in different kinds of
+            boxes are different, e.g., the relative center of a boxes is
+            (0.5, 1.0, 0.5) in camera and (0.5, 0.5, 0) in lidar.
+            It is recommended to use ``bottom_center`` or ``gravity_center``
+            for clearer usage.
+
+        Returns:
+            torch.Tensor: A tensor with center of each box in shape (N, 3).
+        """
+        return self.bottom_center
+
+    @property
+    def bottom_center(self):
+        """torch.Tensor: A tensor with center of each box in shape (N, 3)."""
+        return self.tensor[:, :3]
+
+    @property
+    def gravity_center(self):
+        """torch.Tensor: A tensor with center of each box."""
+        bottom_center = self.bottom_center
+        gravity_center = torch.zeros_like(bottom_center)
+        gravity_center[:, :2] = bottom_center[:, :2]
+        gravity_center[:, 2] = bottom_center[:, 2] + self.tensor[:, 5] * 0.5
+        return gravity_center
+
+    @property
+    def corners(self):
+        """torch.Tensor:
+        a tensor with 8 corners of each box in shape (N, 8, 3)."""
+        pass
+
+    @property
+    def bev(self):
+        """torch.Tensor: 2D BEV box of each box with rotation
+        in XYWHR format, in shape (N, 5)."""
+        return self.tensor[:, [0, 1, 3, 4, 6]]
+
+    def in_range_bev(self, box_range):
+        """Check whether the boxes are in the given range.
+
+        Args:
+            box_range (list | torch.Tensor): the range of box
+                (x_min, y_min, x_max, y_max)
+
+        Note:
+            The original implementation of SECOND checks whether boxes in
+            a range by checking whether the points are in a convex
+            polygon, we reduce the burden for simpler cases.
+
+        Returns:
+            torch.Tensor: Whether each box is inside the reference range.
+        """
+        in_range_flags = (
+            (self.bev[:, 0] > box_range[0])
+            & (self.bev[:, 1] > box_range[1])
+            & (self.bev[:, 0] < box_range[2])
+            & (self.bev[:, 1] < box_range[3])
+        )
+        return in_range_flags
+
+    def rotate(self, angle, points=None):
+        """Rotate boxes with points (optional) with the given angle or rotation
+        matrix.
+
+        Args:
+            angle (float | torch.Tensor | np.ndarray):
+                Rotation angle or rotation matrix.
+            points (torch.Tensor | numpy.ndarray |
+                :obj:`BasePoints`, optional):
+                Points to rotate. Defaults to None.
+        """
+        pass
+
+    def flip(self, bev_direction="horizontal"):
+        """Flip the boxes in BEV along given BEV direction.
+
+        Args:
+            bev_direction (str, optional): Direction by which to flip.
+                Can be chosen from 'horizontal' and 'vertical'.
+                Defaults to 'horizontal'.
+        """
+        pass
+
+    def translate(self, trans_vector):
+        """Translate boxes with the given translation vector.
+
+        Args:
+            trans_vector (torch.Tensor): Translation vector of size (1, 3).
+        """
+        if not isinstance(trans_vector, torch.Tensor):
+            trans_vector = self.tensor.new_tensor(trans_vector)
+        self.tensor[:, :3] += trans_vector
+
+    def in_range_3d(self, box_range):
+        """Check whether the boxes are in the given range.
+
+        Args:
+            box_range (list | torch.Tensor): The range of box
+                (x_min, y_min, z_min, x_max, y_max, z_max)
+
+        Note:
+            In the original implementation of SECOND, checking whether
+            a box in the range checks whether the points are in a convex
+            polygon, we try to reduce the burden for simpler cases.
+
+        Returns:
+            torch.Tensor: A binary vector indicating whether each box is
+                inside the reference range.
+        """
+        in_range_flags = (
+            (self.tensor[:, 0] > box_range[0])
+            & (self.tensor[:, 1] > box_range[1])
+            & (self.tensor[:, 2] > box_range[2])
+            & (self.tensor[:, 0] < box_range[3])
+            & (self.tensor[:, 1] < box_range[4])
+            & (self.tensor[:, 2] < box_range[5])
+        )
+        return in_range_flags
+
+    def convert_to(self, dst, rt_mat=None):
+        """Convert self to ``dst`` mode.
+
+        Args:
+            dst (:obj:`Box3DMode`): The target Box mode.
+            rt_mat (np.ndarray | torch.Tensor, optional): The rotation and
+                translation matrix between different coordinates.
+                Defaults to None.
+                The conversion from `src` coordinates to `dst` coordinates
+                usually comes along the change of sensors, e.g., from camera
+                to LiDAR. This requires a transformation matrix.
+
+        Returns:
+            :obj:`BaseInstance3DBoxes`: The converted box of the same type
+                in the `dst` mode.
+        """
+        pass
+
+    def scale(self, scale_factor):
+        """Scale the box with horizontal and vertical scaling factors.
+
+        Args:
+            scale_factors (float): Scale factors to scale the boxes.
+        """
+        self.tensor[:, :6] *= scale_factor
+        self.tensor[:, 7:] *= scale_factor
+
+    def nonempty(self, threshold=0.0):
+        """Find boxes that are non-empty.
+
+        A box is considered empty,
+        if either of its side is no larger than threshold.
+
+        Args:
+            threshold (float, optional): The threshold of minimal sizes.
+                Defaults to 0.0.
+
+        Returns:
+            torch.Tensor: A binary vector which represents whether each
+                box is empty (False) or non-empty (True).
+        """
+        box = self.tensor
+        size_x = box[..., 3]
+        size_y = box[..., 4]
+        size_z = box[..., 5]
+        keep = (size_x > threshold) & (size_y > threshold) & (size_z > threshold)
+        return keep
+
+    def __getitem__(self, item):
+        """
+        Note:
+            The following usage are allowed:
+            1. `new_boxes = boxes[3]`:
+                return a `Boxes` that contains only one box.
+            2. `new_boxes = boxes[2:10]`:
+                return a slice of boxes.
+            3. `new_boxes = boxes[vector]`:
+                where vector is a torch.BoolTensor with `length = len(boxes)`.
+                Nonzero elements in the vector will be selected.
+            Note that the returned Boxes might share storage with this Boxes,
+            subject to Pytorch's indexing semantics.
+
+        Returns:
+            :obj:`BaseInstance3DBoxes`: A new object of
+                :class:`BaseInstance3DBoxes` after indexing.
+        """
+        original_type = type(self)
+        if isinstance(item, int):
+            return original_type(
+                self.tensor[item].view(1, -1),
+                box_dim=self.box_dim,
+                with_yaw=self.with_yaw,
+            )
+        b = self.tensor[item]
+        assert b.dim() == 2, f"Indexing on Boxes with {item} failed to return a matrix!"
+        return original_type(b, box_dim=self.box_dim, with_yaw=self.with_yaw)
+
+    def __len__(self):
+        """int: Number of boxes in the current object."""
+        return self.tensor.shape[0]
+
+    def __repr__(self):
+        """str: Return a strings that describes the object."""
+        return self.__class__.__name__ + "(\n    " + str(self.tensor) + ")"
+
+    @classmethod
+    def cat(cls, boxes_list):
+        """Concatenate a list of Boxes into a single Boxes.
+
+        Args:
+            boxes_list (list[:obj:`BaseInstance3DBoxes`]): List of boxes.
+
+        Returns:
+            :obj:`BaseInstance3DBoxes`: The concatenated Boxes.
+        """
+        assert isinstance(boxes_list, (list, tuple))
+        if len(boxes_list) == 0:
+            return cls(torch.empty(0))
+        assert all(isinstance(box, cls) for box in boxes_list)
+
+        cat_boxes = cls(
+            torch.cat([b.tensor for b in boxes_list], dim=0),
+            box_dim=boxes_list[0].tensor.shape[1],
+            with_yaw=boxes_list[0].with_yaw,
+        )
+        return cat_boxes
+
+    def clone(self):
+        """Clone the Boxes.
+
+        Returns:
+            :obj:`BaseInstance3DBoxes`: Box object with the same properties
+                as self.
+        """
+        original_type = type(self)
+        return original_type(
+            self.tensor.clone(), box_dim=self.box_dim, with_yaw=self.with_yaw
+        )
+
+    def __iter__(self):
+        """Yield a box as a Tensor of shape (4,) at a time.
+
+        Returns:
+            torch.Tensor: A box of shape (4,).
+        """
+        yield from self.tensor
+
+
+class LiDARInstance3DBoxes(BaseInstance3DBoxes):
+    YAW_AXIS = 2

--- a/uniad/pytorch/src/transformer.py
+++ b/uniad/pytorch/src/transformer.py
@@ -1,0 +1,737 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from torch import nn
+import torch.nn.functional as F
+import torch
+import warnings
+import math
+import torch.distributed as dist
+import copy
+from third_party.tt_forge_models.uniad.pytorch.src.utils import MultiheadAttention
+from typing import Optional
+
+
+class FFN(nn.Module):
+    """Implements feed-forward networks (FFNs) with identity connection.
+
+    Args:
+        embed_dims (int): The feature dimension. Same as
+            `MultiheadAttention`. Defaults: 256.
+        feedforward_channels (int): The hidden dimension of FFNs.
+            Defaults: 1024.
+        num_fcs (int, optional): The number of fully-connected layers in
+            FFNs. Default: 2.
+        act_cfg (dict, optional): The activation config for FFNs.
+            Default: dict(type='ReLU')
+        ffn_drop (float, optional): Probability of an element to be
+            zeroed in FFN. Default 0.0.
+        add_identity (bool, optional): Whether to add the
+            identity connection. Default: `True`.
+        dropout_layer (obj:`ConfigDict`): The dropout_layer used
+            when adding the shortcut.
+    """
+
+    def __init__(
+        self,
+        embed_dims=256,
+        feedforward_channels=2048,
+        num_fcs=2,
+        act_cfg=dict(type="ReLU", inplace=True),
+        ffn_drop=0.0,
+        dropout_layer=None,
+        add_identity=True,
+        **kwargs,
+    ):
+        super(FFN, self).__init__()
+        assert num_fcs >= 2, "num_fcs should be no less " f"than 2. got {num_fcs}."
+        self.embed_dims = embed_dims
+        self.feedforward_channels = feedforward_channels
+        self.num_fcs = num_fcs
+        self.act_cfg = act_cfg
+        self.activate = torch.nn.ReLU(inplace=True)
+
+        layers = []
+        in_channels = embed_dims
+        for _ in range(num_fcs - 1):
+            layers.append(
+                nn.Sequential(
+                    nn.Linear(in_channels, feedforward_channels),
+                    self.activate,
+                    nn.Dropout(ffn_drop),
+                )
+            )
+            in_channels = feedforward_channels
+        layers.append(nn.Linear(feedforward_channels, embed_dims))
+        layers.append(nn.Dropout(ffn_drop))
+        self.layers = nn.Sequential(*layers)
+        self.dropout_layer = (
+            nn.Dropout(p=dropout_layer.get("drop_prob", 0.1))
+            if dropout_layer
+            else nn.Identity()
+        )
+        self.add_identity = add_identity
+
+    def forward(self, x, identity=None):
+        """Forward function for `FFN`.
+
+        The function would add x to the output tensor if residue is None.
+        """
+        out = self.layers(x)
+        if not self.add_identity:
+            return self.dropout_layer(out)
+        if identity is None:
+            identity = x
+        return identity + self.dropout_layer(out)
+
+
+class BaseTransformerLayer(nn.Module):
+    """Base `TransformerLayer` for vision transformer.
+
+    It can be built from `mmcv.ConfigDict` and support more flexible
+    customization, for example, using any number of `FFN or LN ` and
+    use different kinds of `attention` by specifying a list of `ConfigDict`
+    named `attn_cfgs`. It is worth mentioning that it supports `prenorm`
+    when you specifying `norm` as the first element of `operation_order`.
+    More details about the `prenorm`: `On Layer Normalization in the
+    Transformer Architecture <https://arxiv.org/abs/2002.04745>`_ .
+
+    Args:
+        attn_cfgs (list[`mmcv.ConfigDict`] | obj:`mmcv.ConfigDict` | None )):
+            Configs for `self_attention` or `cross_attention` modules,
+            The order of the configs in the list should be consistent with
+            corresponding attentions in operation_order.
+            If it is a dict, all of the attention modules in operation_order
+            will be built with this config. Default: None.
+        ffn_cfgs (list[`mmcv.ConfigDict`] | obj:`mmcv.ConfigDict` | None )):
+            Configs for FFN, The order of the configs in the list should be
+            consistent with corresponding ffn in operation_order.
+            If it is a dict, all of the attention modules in operation_order
+            will be built with this config.
+        operation_order (tuple[str]): The execution order of operation
+            in transformer. Such as ('self_attn', 'norm', 'ffn', 'norm').
+            Support `prenorm` when you specifying first element as `norm`.
+            Default：None.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: dict(type='LN').
+        batch_first (bool): Key, Query and Value are shape
+            of (batch, n, embed_dim)
+            or (n, batch, embed_dim). Default to False.
+    """
+
+    def __init__(
+        self,
+        attn_cfgs=None,
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=1024,
+            num_fcs=2,
+            ffn_drop=0.0,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=("self_attn", "norm", "cross_attn", "norm", "ffn", "norm"),
+        norm_cfg=dict(type="LN"),
+        batch_first=False,
+        **kwargs,
+    ):
+
+        deprecated_args = dict(
+            feedforward_channels="feedforward_channels",
+            ffn_dropout="ffn_drop",
+            ffn_num_fcs="num_fcs",
+        )
+        for ori_name, new_name in deprecated_args.items():
+            if ori_name in kwargs:
+                warnings.warn(
+                    f"The argument `{ori_name}` is deprecated, use `{new_name}` inside ffn_cfgs.",
+                    DeprecationWarning,
+                )
+                ffn_cfgs[new_name] = kwargs[ori_name]
+
+        super().__init__()
+        self.batch_first = batch_first
+        self.operation_order = operation_order
+        self.norm_cfg = norm_cfg
+        self.pre_norm = operation_order[0] == "norm"
+
+        self.num_attn = operation_order.count("self_attn") + operation_order.count(
+            "cross_attn"
+        )
+        if attn_cfgs is None:
+            attn_cfgs = [
+                {"type": "MultiheadAttention", "embed_dims": 256}
+                for _ in range(self.num_attn)
+            ]
+        elif isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(self.num_attn)]
+        else:
+            assert self.num_attn == len(
+                attn_cfgs
+            ), f"Expected {self.num_attn} attn_cfgs, got {len(attn_cfgs)}"
+
+        self.attentions = nn.ModuleList()
+        for idx, op_name in enumerate(
+            [op for op in operation_order if op in ["self_attn", "cross_attn"]]
+        ):
+            cfg = attn_cfgs[idx]
+            cfg.setdefault("batch_first", self.batch_first)
+
+            attn_type = cfg.get("type", "MultiheadAttention")
+            if attn_type == "MultiheadAttention":
+                attn = MultiheadAttention(
+                    **{k: v for k, v in cfg.items() if k != "type"}
+                )
+            elif attn_type == "MultiScaleDeformableAttention":
+                attn = MultiScaleDeformableAttention(
+                    **{k: v for k, v in cfg.items() if k != "type"}
+                )
+            elif attn_type == "CustomMSDeformableAttention":
+                attn = CustomMSDeformableAttention(
+                    **{k: v for k, v in cfg.items() if k != "type"}
+                )
+            else:
+                raise ValueError(f"Unknown attention type: {attn_type}")
+
+            attn.operation_name = op_name
+            self.attentions.append(attn)
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        self.ffns = nn.ModuleList(
+            [FFN(**{k: v for k, v in ffn_cfgs.items() if k != "type"})]
+        )
+
+        self.norms = nn.ModuleList(
+            [
+                torch.nn.LayerNorm(
+                    (self.embed_dims,), eps=1e-05, elementwise_affine=True
+                )
+                for _ in range(operation_order.count("norm"))
+            ]
+        )
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        """Forward function for `TransformerDecoderLayer`.
+
+        **kwargs contains some specific arguments of attentions.
+
+        Args:
+            query (Tensor): The input query with shape
+                [num_queries, bs, embed_dims] if
+                self.batch_first is False, else
+                [bs, num_queries embed_dims].
+            key (Tensor): The key tensor with shape [num_keys, bs,
+                embed_dims] if self.batch_first is False, else
+                [bs, num_keys, embed_dims] .
+            value (Tensor): The value tensor with same shape as `key`.
+            query_pos (Tensor): The positional encoding for `query`.
+                Default: None.
+            key_pos (Tensor): The positional encoding for `key`.
+                Default: None.
+            attn_masks (List[Tensor] | None): 2D Tensor used in
+                calculation of corresponding attention. The length of
+                it should equal to the number of `attention` in
+                `operation_order`. Default: None.
+            query_key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_queries]. Only used in `self_attn` layer.
+                Defaults to None.
+            key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_keys]. Default: None.
+
+        Returns:
+            Tensor: forwarded results with shape [num_queries, bs, embed_dims].
+        """
+
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+        else:
+            assert len(attn_masks) == self.num_attn, (
+                f"The length of "
+                f"attn_masks {len(attn_masks)} must be equal "
+                f"to the number of attention in "
+                f"operation_order {self.num_attn}"
+            )
+        for layer in self.operation_order:
+            if layer == "self_attn":
+                temp_key = temp_value = query
+                query = self.attentions[attn_index](
+                    query,
+                    temp_key,
+                    temp_value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=query_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "norm":
+                query = self.norms[norm_index](query)
+                norm_index += 1
+
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+                ffn_index += 1
+
+        return query
+
+
+def multi_scale_deformable_attn_pytorch(
+    value: torch.Tensor,
+    value_spatial_shapes: torch.Tensor,
+    sampling_locations: torch.Tensor,
+    attention_weights: torch.Tensor,
+) -> torch.Tensor:
+    """CPU version of multi-scale deformable attention.
+
+    Args:
+        value (torch.Tensor): The value has shape
+            (bs, num_keys, num_heads, embed_dims//num_heads)
+        value_spatial_shapes (torch.Tensor): Spatial shape of
+            each feature map, has shape (num_levels, 2),
+            last dimension 2 represent (h, w)
+        sampling_locations (torch.Tensor): The location of sampling points,
+            has shape
+            (bs ,num_queries, num_heads, num_levels, num_points, 2),
+            the last dimension 2 represent (x, y).
+        attention_weights (torch.Tensor): The weight of sampling points used
+            when calculate the attention, has shape
+            (bs ,num_queries, num_heads, num_levels, num_points),
+
+    Returns:
+        torch.Tensor: has shape (bs, num_queries, embed_dims)
+    """
+
+    bs, _, num_heads, embed_dims = value.shape
+    _, num_queries, num_heads, num_levels, num_points, _ = sampling_locations.shape
+    value_list = value.split([H_ * W_ for H_, W_ in value_spatial_shapes], dim=1)
+    sampling_grids = 2 * sampling_locations - 1
+    sampling_value_list = []
+    for level, (H_, W_) in enumerate(value_spatial_shapes):
+
+        value_l_ = (
+            value_list[level]
+            .flatten(2)
+            .transpose(1, 2)
+            .reshape(bs * num_heads, embed_dims, H_, W_)
+        )
+
+        sampling_grid_l_ = sampling_grids[:, :, :, level].transpose(1, 2).flatten(0, 1)
+        sampling_value_l_ = F.grid_sample(
+            value_l_,
+            sampling_grid_l_,
+            mode="bilinear",
+            padding_mode="zeros",
+            align_corners=False,
+        )
+        sampling_value_list.append(sampling_value_l_)
+    attention_weights = attention_weights.transpose(1, 2).reshape(
+        bs * num_heads, 1, num_queries, num_levels * num_points
+    )
+    output = (
+        (torch.stack(sampling_value_list, dim=-2).flatten(-2) * attention_weights)
+        .sum(-1)
+        .view(bs, num_heads * embed_dims, num_queries)
+    )
+    return output.transpose(1, 2).contiguous()
+
+
+class CustomMSDeformableAttention(nn.Module):
+    """An attention module used in Deformable-Detr.
+
+    `Deformable DETR: Deformable Transformers for End-to-End Object Detection.
+    <https://arxiv.org/pdf/2010.04159.pdf>`_.
+
+    Args:
+        embed_dims (int): The embedding dimension of Attention.
+            Default: 256.
+        num_heads (int): Parallel attention heads. Default: 64.
+        num_levels (int): The number of feature map used in
+            Attention. Default: 4.
+        num_points (int): The number of sampling points for
+            each query in each head. Default: 4.
+        im2col_step (int): The step used in image_to_column.
+            Default: 64.
+        dropout (float): A Dropout layer on `inp_identity`.
+            Default: 0.1.
+        batch_first (bool): Key, Query and Value are shape of
+            (batch, n, embed_dim)
+            or (n, batch, embed_dim). Default to False.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: None.
+    """
+
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        num_levels=1,
+        num_points=4,
+        im2col_step=64,
+        dropout=0.1,
+        batch_first=False,
+        norm_cfg=None,
+    ):
+        super().__init__()
+
+        if embed_dims % num_heads != 0:
+            raise ValueError(
+                f"embed_dims must be divisible by num_heads, "
+                f"but got {embed_dims} and {num_heads}"
+            )
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.batch_first = batch_first
+        self.fp16_enabled = False
+
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError(
+                    "invalid input for _is_power_of_2: {} (type: {})".format(n, type(n))
+                )
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.sampling_offsets = nn.Linear(
+            embed_dims, num_heads * num_levels * num_points * 2
+        )
+        self.attention_weights = nn.Linear(
+            embed_dims, num_heads * num_levels * num_points
+        )
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_padding_mask=None,
+        reference_points=None,
+        spatial_shapes=None,
+        level_start_index=None,
+        flag="decoder",
+        **kwargs,
+    ):
+        """Forward Function of MultiScaleDeformAttention.
+
+        Args:
+            query (Tensor): Query of Transformer with shape
+                (num_query, bs, embed_dims).
+            key (Tensor): The key tensor with shape
+                `(num_key, bs, embed_dims)`.
+            value (Tensor): The value tensor with shape
+                `(num_key, bs, embed_dims)`.
+            identity (Tensor): The tensor used for addition, with the
+                same shape as `query`. Default None. If None,
+                `query` will be used.
+            query_pos (Tensor): The positional encoding for `query`.
+                Default: None.
+            key_pos (Tensor): The positional encoding for `key`. Default
+                None.
+            reference_points (Tensor):  The normalized reference
+                points with shape (bs, num_query, num_levels, 2),
+                all elements is range in [0, 1], top-left (0,0),
+                bottom-right (1, 1), including padding area.
+                or (N, Length_{query}, num_levels, 4), add
+                additional two dimensions is (w, h) to
+                form reference boxes.
+            key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_key].
+            spatial_shapes (Tensor): Spatial shape of features in
+                different levels. With shape (num_levels, 2),
+                last dimension represents (h, w).
+            level_start_index (Tensor): The start index of each level.
+                A tensor has shape ``(num_levels, )`` and can be represented
+                as [0, h_0*w_0, h_0*w_0+h_1*w_1, ...].
+
+        Returns:
+             Tensor: forwarded results with shape [num_query, bs, embed_dims].
+        """
+        if value is None:
+            value = query
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        if not self.batch_first:
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+
+        value = self.value_proj(value)
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+        value = value.view(bs, num_value, self.num_heads, -1)
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_levels * self.num_points
+        )
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points
+        )
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.stack(
+                [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1
+            )
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :]
+                + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+            )
+        elif reference_points.shape[-1] == 4:
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :2]
+                + sampling_offsets
+                / self.num_points
+                * reference_points[:, :, None, :, None, 2:]
+                * 0.5
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+        output = self.output_proj(output)
+
+        if not self.batch_first:
+            output = output.permute(1, 0, 2)
+
+        return self.dropout(output) + identity
+
+
+class MultiScaleDeformableAttention(nn.Module):
+    """An attention module used in Deformable-Detr.
+
+    `Deformable DETR: Deformable Transformers for End-to-End Object Detection.
+    <https://arxiv.org/pdf/2010.04159.pdf>`_.
+
+    Args:
+        embed_dims (int): The embedding dimension of Attention.
+            Default: 256.
+        num_heads (int): Parallel attention heads. Default: 64.
+        num_levels (int): The number of feature map used in
+            Attention. Default: 4.
+        num_points (int): The number of sampling points for
+            each query in each head. Default: 4.
+        im2col_step (int): The step used in image_to_column.
+            Default: 64.
+        dropout (float): A Dropout layer on `inp_identity`.
+            Default: 0.1.
+        batch_first (bool): Key, Query and Value are shape of
+            (batch, n, embed_dim)
+            or (n, batch, embed_dim). Default to False.
+        norm_cfg (dict): Config dict for normalization layer.
+            Default: None.
+    """
+
+    def __init__(
+        self,
+        embed_dims: int = 256,
+        num_heads: int = 8,
+        num_levels: int = 1,
+        num_points: int = 4,
+        im2col_step: int = 64,
+        dropout: float = 0.1,
+        batch_first: bool = False,
+        norm_cfg: Optional[dict] = None,
+    ):
+        super().__init__()
+        if embed_dims % num_heads != 0:
+            raise ValueError(
+                f"embed_dims must be divisible by num_heads, "
+                f"but got {embed_dims} and {num_heads}"
+            )
+        dim_per_head = embed_dims // num_heads
+        self.norm_cfg = norm_cfg
+        self.dropout = nn.Dropout(dropout)
+        self.batch_first = batch_first
+
+        def _is_power_of_2(n):
+            if (not isinstance(n, int)) or (n < 0):
+                raise ValueError(
+                    "invalid input for _is_power_of_2: {} (type: {})".format(n, type(n))
+                )
+            return (n & (n - 1) == 0) and n != 0
+
+        if not _is_power_of_2(dim_per_head):
+            warnings.warn(
+                "You'd better set embed_dims in "
+                "MultiScaleDeformAttention to make "
+                "the dimension of each attention head a power of 2 "
+                "which is more efficient in our CUDA implementation."
+            )
+
+        self.im2col_step = im2col_step
+        self.embed_dims = embed_dims
+        self.num_levels = num_levels
+        self.num_heads = num_heads
+        self.num_points = num_points
+        self.sampling_offsets = nn.Linear(
+            embed_dims, num_heads * num_levels * num_points * 2
+        )
+        self.attention_weights = nn.Linear(
+            embed_dims, num_heads * num_levels * num_points
+        )
+        self.value_proj = nn.Linear(embed_dims, embed_dims)
+        self.output_proj = nn.Linear(embed_dims, embed_dims)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor] = None,
+        value: Optional[torch.Tensor] = None,
+        identity: Optional[torch.Tensor] = None,
+        query_pos: Optional[torch.Tensor] = None,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        reference_points: Optional[torch.Tensor] = None,
+        spatial_shapes: Optional[torch.Tensor] = None,
+        level_start_index: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Forward Function of MultiScaleDeformAttention.
+
+        Args:
+            query (torch.Tensor): Query of Transformer with shape
+                (num_query, bs, embed_dims).
+            key (torch.Tensor): The key tensor with shape
+                `(num_key, bs, embed_dims)`.
+            value (torch.Tensor): The value tensor with shape
+                `(num_key, bs, embed_dims)`.
+            identity (torch.Tensor): The tensor used for addition, with the
+                same shape as `query`. Default None. If None,
+                `query` will be used.
+            query_pos (torch.Tensor): The positional encoding for `query`.
+                Default: None.
+            key_padding_mask (torch.Tensor): ByteTensor for `query`, with
+                shape [bs, num_key].
+            reference_points (torch.Tensor):  The normalized reference
+                points with shape (bs, num_query, num_levels, 2),
+                all elements is range in [0, 1], top-left (0,0),
+                bottom-right (1, 1), including padding area.
+                or (N, Length_{query}, num_levels, 4), add
+                additional two dimensions is (w, h) to
+                form reference boxes.
+            spatial_shapes (torch.Tensor): Spatial shape of features in
+                different levels. With shape (num_levels, 2),
+                last dimension represents (h, w).
+            level_start_index (torch.Tensor): The start index of each level.
+                A tensor has shape ``(num_levels, )`` and can be represented
+                as [0, h_0*w_0, h_0*w_0+h_1*w_1, ...].
+
+        Returns:
+            torch.Tensor: forwarded results with shape
+            [num_query, bs, embed_dims].
+        """
+
+        if value is None:
+            value = query
+
+        if identity is None:
+            identity = query
+        if query_pos is not None:
+            query = query + query_pos
+        if not self.batch_first:
+            query = query.permute(1, 0, 2)
+            value = value.permute(1, 0, 2)
+
+        bs, num_query, _ = query.shape
+        bs, num_value, _ = value.shape
+        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+
+        value = self.value_proj(value)
+        if key_padding_mask is not None:
+            value = value.masked_fill(key_padding_mask[..., None], 0.0)
+        value = value.view(bs, num_value, self.num_heads, -1)
+        sampling_offsets = self.sampling_offsets(query).view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points, 2
+        )
+        attention_weights = self.attention_weights(query).view(
+            bs, num_query, self.num_heads, self.num_levels * self.num_points
+        )
+        attention_weights = attention_weights.softmax(-1)
+
+        attention_weights = attention_weights.view(
+            bs, num_query, self.num_heads, self.num_levels, self.num_points
+        )
+        if reference_points.shape[-1] == 2:
+            offset_normalizer = torch.stack(
+                [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1
+            )
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :]
+                + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
+            )
+        elif reference_points.shape[-1] == 4:
+            sampling_locations = (
+                reference_points[:, :, None, :, None, :2]
+                + sampling_offsets
+                / self.num_points
+                * reference_points[:, :, None, :, None, 2:]
+                * 0.5
+            )
+
+        output = multi_scale_deformable_attn_pytorch(
+            value, spatial_shapes, sampling_locations, attention_weights
+        )
+
+        output = self.output_proj(output)
+
+        if not self.batch_first:
+            output = output.permute(1, 0, 2)
+        return self.dropout(output) + identity

--- a/uniad/pytorch/src/uniad_e2e.py
+++ b/uniad/pytorch/src/uniad_e2e.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import copy
+from third_party.tt_forge_models.uniad.pytorch.src.uniad_track import UniADTrack
+from third_party.tt_forge_models.uniad.pytorch.src.planning_head import (
+    PlanningHeadSingleMode,
+)
+from third_party.tt_forge_models.uniad.pytorch.src.motion_head import MotionHead
+from third_party.tt_forge_models.uniad.pytorch.src.occ_head import OccHead
+from third_party.tt_forge_models.uniad.pytorch.src.panseg_head import PansegformerHead
+from third_party.tt_forge_models.uniad.pytorch.src.utils import *
+from third_party.tt_forge_models.uniad.pytorch.src.track_head import BEVFormerTrackHead
+
+
+class UniAD(UniADTrack):
+    """
+    UniAD: Unifying Detection, Tracking, Segmentation, Motion Forecasting, Occupancy Prediction and Planning for Autonomous Driving
+    """
+
+    def __init__(
+        self,
+        seg_head=True,
+        motion_head=True,
+        occ_head=True,
+        planning_head=True,
+        task_loss_weight=dict(track=1.0, map=1.0, motion=1.0, occ=1.0, planning=1.0),
+        filter_score_thresh=0.35,
+        freeze_bev_encoder=True,
+        freeze_bn=True,
+        freeze_img_backbone=True,
+        freeze_img_neck=True,
+        gt_iou_threshold=0.3,
+        img_backbone=ResNet(),
+        img_neck=FPN(),
+        num_classes=10,
+        num_query=900,
+        pc_range=[-51.2, -51.2, -5.0, 51.2, 51.2, 3.0],
+        pretrained=None,
+        pts_bbox_head=BEVFormerTrackHead(),
+        queue_length=3,
+        score_thresh=0.4,
+        test_cfg=None,
+        use_grid_mask=True,
+        vehicle_id_list=[0, 1, 2, 3, 4, 6, 7],
+        video_test_mode=True,
+    ):
+
+        super(UniAD, self).__init__(
+            filter_score_thresh=filter_score_thresh,
+            freeze_bev_encoder=freeze_bev_encoder,
+            freeze_bn=freeze_bn,
+            freeze_img_backbone=freeze_img_backbone,
+            freeze_img_neck=freeze_img_neck,
+            gt_iou_threshold=gt_iou_threshold,
+            img_backbone=img_backbone,
+            img_neck=img_neck,
+            num_classes=num_classes,
+            num_query=num_query,
+            pc_range=pc_range,
+            pretrained=pretrained,
+            pts_bbox_head=pts_bbox_head,
+            queue_length=queue_length,
+            score_thresh=score_thresh,
+            test_cfg=test_cfg,
+            use_grid_mask=use_grid_mask,
+            vehicle_id_list=vehicle_id_list,
+            video_test_mode=video_test_mode,
+        )
+        if seg_head:
+            self.seg_head = PansegformerHead()
+
+        if occ_head:
+            self.occ_head = OccHead()
+
+        if motion_head:
+            self.motion_head = MotionHead()
+
+        if planning_head:
+            self.planning_head = PlanningHeadSingleMode()
+
+        self.task_loss_weight = task_loss_weight
+        assert set(task_loss_weight.keys()) == {
+            "track",
+            "occ",
+            "motion",
+            "map",
+            "planning",
+        }
+
+    @property
+    def with_planning_head(self):
+        return hasattr(self, "planning_head") and self.planning_head is not None
+
+    @property
+    def with_occ_head(self):
+        return hasattr(self, "occ_head") and self.occ_head is not None
+
+    @property
+    def with_motion_head(self):
+        return hasattr(self, "motion_head") and self.motion_head is not None
+
+    @property
+    def with_seg_head(self):
+        return hasattr(self, "seg_head") and self.seg_head is not None
+
+    def forward_dummy(self, img):
+        dummy_metas = None
+        return self.forward_test(img=img, img_metas=[[dummy_metas]])
+
+    def forward(self, return_loss=True, **kwargs):
+        """Calls either forward_train or forward_test depending on whether
+        return_loss=True.
+        Note this setting will change the expected inputs. When
+        `return_loss=True`, img and img_metas are single-nested (i.e.
+        torch.Tensor and list[dict]), and when `resturn_loss=False`, img and
+        img_metas should be double nested (i.e.  list[torch.Tensor],
+        list[list[dict]]), with the outer list indicating test time
+        augmentations.
+        """
+        for k, v in kwargs.items():
+            if isinstance(v, torch.Tensor):
+                kwargs[k] = v.to("cpu")
+            elif isinstance(v, list):
+                kwargs[k] = [
+                    x.to("cpu") if isinstance(x, torch.Tensor) else x for x in v
+                ]
+        return self.forward_test(**kwargs)
+
+    def loss_weighted_and_prefixed(self, loss_dict, prefix=""):
+        loss_factor = self.task_loss_weight[prefix]
+        loss_dict = {f"{prefix}.{k}": v * loss_factor for k, v in loss_dict.items()}
+        return loss_dict
+
+    def forward_test(
+        self,
+        img=None,
+        img_metas=None,
+        l2g_t=None,
+        l2g_r_mat=None,
+        timestamp=None,
+        gt_lane_labels=None,
+        gt_lane_masks=None,
+        rescale=False,
+        sdc_planning=None,
+        sdc_planning_mask=None,
+        command=None,
+        gt_segmentation=None,
+        gt_instance=None,
+        gt_occ_img_is_valid=None,
+        **kwargs,
+    ):
+        """Test function"""
+        for var, name in [(img_metas, "img_metas")]:
+            if not isinstance(var, list):
+                raise TypeError("{} must be a list, but got {}".format(name, type(var)))
+        img = [img] if img is None else img
+
+        if img_metas[0][0]["scene_token"] != self.prev_frame_info["scene_token"]:
+            self.prev_frame_info["prev_bev"] = None
+        self.prev_frame_info["scene_token"] = img_metas[0][0]["scene_token"]
+
+        self.prev_frame_info["prev_bev"] = None
+
+        tmp_pos = copy.deepcopy(img_metas[0][0]["can_bus"][:3])
+        tmp_angle = copy.deepcopy(img_metas[0][0]["can_bus"][-1])
+        img_metas[0][0]["can_bus"][:3] -= self.prev_frame_info["prev_pos"]
+        img_metas[0][0]["can_bus"][-1] -= self.prev_frame_info["prev_angle"]
+        self.prev_frame_info["prev_pos"] = tmp_pos
+        self.prev_frame_info["prev_angle"] = tmp_angle
+
+        img = img[0]
+        img_metas = img_metas[0]
+        timestamp = timestamp[0] if timestamp is not None else None
+
+        result = [dict() for i in range(len(img_metas))]
+        result_track = self.simple_test_track(
+            img, l2g_t, l2g_r_mat, img_metas, timestamp
+        )
+        result_track[0] = self.upsample_bev_if_tiny(result_track[0])
+        bev_embed = result_track[0]["bev_embed"]
+
+        if self.with_seg_head:
+            result_seg = self.seg_head.forward_test(
+                bev_embed, gt_lane_labels, gt_lane_masks, img_metas, rescale
+            )
+
+        if self.with_motion_head:
+            result_motion, outs_motion = self.motion_head.forward_test(
+                bev_embed, outs_track=result_track[0], outs_seg=result_seg[0]
+            )
+            outs_motion["bev_pos"] = result_track[0]["bev_pos"]
+
+        outs_occ = dict()
+        if self.with_occ_head:
+            occ_no_query = outs_motion["track_query"].shape[1] == 0
+            outs_occ = self.occ_head.forward_test(
+                bev_embed,
+                outs_motion,
+                no_query=occ_no_query,
+                gt_segmentation=gt_segmentation,
+                gt_instance=gt_instance,
+                gt_img_is_valid=gt_occ_img_is_valid,
+            )
+            result[0]["occ"] = outs_occ
+
+        if self.with_planning_head:
+            planning_gt = dict(
+                segmentation=gt_segmentation,
+                sdc_planning=sdc_planning,
+                sdc_planning_mask=sdc_planning_mask,
+                command=command,
+            )
+            result_planning = self.planning_head.forward_test(
+                bev_embed, outs_motion, outs_occ, command
+            )
+            result[0]["planning"] = dict(
+                planning_gt=planning_gt,
+                result_planning=result_planning,
+            )
+
+        pop_track_list = [
+            "prev_bev",
+            "bev_pos",
+            "bev_embed",
+            "track_query_embeddings",
+            "sdc_embedding",
+        ]
+        result_track[0] = pop_elem_in_result(result_track[0], pop_track_list)
+
+        if self.with_seg_head:
+            result_seg[0] = pop_elem_in_result(
+                result_seg[0], pop_list=["pts_bbox", "args_tuple"]
+            )
+        if self.with_motion_head:
+            result_motion[0] = pop_elem_in_result(result_motion[0])
+        if self.with_occ_head:
+            result[0]["occ"] = pop_elem_in_result(
+                result[0]["occ"],
+                pop_list=[
+                    "seg_out_mask",
+                    "flow_out",
+                    "future_states_occ",
+                    "pred_ins_masks",
+                    "pred_raw_occ",
+                    "pred_ins_logits",
+                    "pred_ins_sigmoid",
+                ],
+            )
+
+        for i, res in enumerate(result):
+            res["token"] = img_metas[i]["sample_idx"]
+            res.update(result_track[i])
+            if self.with_motion_head:
+                res.update(result_motion[i])
+            if self.with_seg_head:
+                res.update(result_seg[i])
+
+        return result
+
+
+def pop_elem_in_result(task_result: dict, pop_list: list = None):
+    all_keys = list(task_result.keys())
+    for k in all_keys:
+        if k.endswith("query") or k.endswith("query_pos") or k.endswith("embedding"):
+            task_result.pop(k)
+
+    if pop_list is not None:
+        for pop_k in pop_list:
+            task_result.pop(pop_k, None)
+    return task_result

--- a/uniad/pytorch/src/uniad_track.py
+++ b/uniad/pytorch/src/uniad_track.py
@@ -1,0 +1,670 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.nn as nn
+import math
+import warnings
+from einops import rearrange
+from abc import abstractmethod, ABCMeta
+from third_party.tt_forge_models.uniad.pytorch.src.utils import FPN, ResNet
+from third_party.tt_forge_models.uniad.pytorch.src.track_head import BEVFormerTrackHead
+from third_party.tt_forge_models.uniad.pytorch.src.track_utils import *
+
+
+class BaseDetector(nn.Module, metaclass=ABCMeta):
+    """Base class for detectors."""
+
+    def __init__(self):
+        super(BaseDetector, self).__init__()
+        self.fp16_enabled = False
+
+    @property
+    def with_neck(self):
+        """bool: whether the detector has a neck"""
+        return hasattr(self, "neck") and self.neck is not None
+
+    @property
+    def with_shared_head(self):
+        """bool: whether the detector has a shared head in the RoI Head"""
+        return hasattr(self, "roi_head") and self.roi_head.with_shared_head
+
+    @property
+    def with_bbox(self):
+        """bool: whether the detector has a bbox head"""
+        return (hasattr(self, "roi_head") and self.roi_head.with_bbox) or (
+            hasattr(self, "bbox_head") and self.bbox_head is not None
+        )
+
+    @property
+    def with_mask(self):
+        """bool: whether the detector has a mask head"""
+        return (hasattr(self, "roi_head") and self.roi_head.with_mask) or (
+            hasattr(self, "mask_head") and self.mask_head is not None
+        )
+
+    def extract_feat(self, imgs):
+        """Extract features from images."""
+        pass
+
+    def extract_feats(self, imgs):
+        """Extract features from multiple images.
+
+        Args:
+            imgs (list[torch.Tensor]): A list of images. The images are
+                augmented from the same image but in different ways.
+
+        Returns:
+            list[torch.Tensor]: Features of different images
+        """
+        assert isinstance(imgs, list)
+        return [self.extract_feat(img) for img in imgs]
+
+    def simple_test(self, img, img_metas, **kwargs):
+        pass
+
+    @abstractmethod
+    def aug_test(self, imgs, img_metas, **kwargs):
+        """Test function with test time augmentation."""
+        pass
+
+    def forward_test(self, imgs, img_metas, **kwargs):
+        """
+        Args:
+            imgs (List[Tensor]): the outer list indicates test-time
+                augmentations and inner Tensor should have a shape NxCxHxW,
+                which contains all images in the batch.
+            img_metas (List[List[dict]]): the outer list indicates test-time
+                augs (multiscale, flip, etc.) and the inner list indicates
+                images in a batch.
+        """
+        for var, name in [(imgs, "imgs"), (img_metas, "img_metas")]:
+            if not isinstance(var, list):
+                raise TypeError(f"{name} must be a list, but got {type(var)}")
+
+        num_augs = len(imgs)
+        if num_augs != len(img_metas):
+            raise ValueError(
+                f"num of augmentations ({len(imgs)}) "
+                f"!= num of image meta ({len(img_metas)})"
+            )
+
+        for img, img_meta in zip(imgs, img_metas):
+            batch_size = len(img_meta)
+            for img_id in range(batch_size):
+                img_meta[img_id]["batch_input_shape"] = tuple(img.size()[-2:])
+
+    def forward(self, img, img_metas, return_loss=True, **kwargs):
+        """Calls either :func:`forward_train` or :func:`forward_test` depending
+        on whether ``return_loss`` is ``True``.
+        """
+
+        return self.forward_test(img, img_metas, **kwargs)
+
+
+class Base3DDetector(BaseDetector):
+    """Base class for detectors."""
+
+    def forward_test(self, points, img_metas, img=None, **kwargs):
+        """
+        Args:
+            points (list[torch.Tensor]): the outer list indicates test-time
+                augmentations and inner torch.Tensor should have a shape NxC,
+                which contains all points in the batch.
+            img_metas (list[list[dict]]): the outer list indicates test-time
+                augs (multiscale, flip, etc.) and the inner list indicates
+                images in a batch
+            img (list[torch.Tensor], optional): the outer
+                list indicates test-time augmentations and inner
+                torch.Tensor should have a shape NxCxHxW, which contains
+                all images in the batch. Defaults to None.
+        """
+        for var, name in [(points, "points"), (img_metas, "img_metas")]:
+            if not isinstance(var, list):
+                raise TypeError("{} must be a list, but got {}".format(name, type(var)))
+
+        num_augs = len(points)
+        if num_augs != len(img_metas):
+            raise ValueError(
+                "num of augmentations ({}) != num of image meta ({})".format(
+                    len(points), len(img_metas)
+                )
+            )
+
+    def forward(self, return_loss=True, **kwargs):
+        """Calls either forward_train or forward_test depending on whether
+        return_loss=True.
+
+        Note this setting will change the expected inputs. When
+        `return_loss=True`, img and img_metas are single-nested (i.e.
+        torch.Tensor and list[dict]), and when `resturn_loss=False`, img and
+        img_metas should be double nested (i.e.  list[torch.Tensor],
+        list[list[dict]]), with the outer list indicating test time
+        augmentations.
+        """
+
+        return self.forward_test(**kwargs)
+
+
+class MVXTwoStageDetector(Base3DDetector):
+    """Base class of Multi-modality VoxelNet."""
+
+    def __init__(
+        self,
+        pts_voxel_layer=None,
+        pts_voxel_encoder=None,
+        pts_middle_encoder=None,
+        pts_fusion_layer=None,
+        img_backbone=True,
+        pts_backbone=None,
+        img_neck=True,
+        pts_neck=None,
+        pts_bbox_head=True,
+        img_roi_head=None,
+        img_rpn_head=None,
+        test_cfg=None,
+        pretrained=None,
+    ):
+        super(MVXTwoStageDetector, self).__init__()
+
+        if pts_bbox_head:
+            self.pts_bbox_head = BEVFormerTrackHead()
+        if img_backbone:
+            self.img_backbone = ResNet()
+        if img_neck is not None:
+            self.img_neck = FPN()
+
+        self.test_cfg = test_cfg
+
+    @property
+    def with_img_backbone(self):
+        """bool: Whether the detector has a 2D image backbone."""
+        return hasattr(self, "img_backbone") and self.img_backbone is not None
+
+    @property
+    def with_pts_backbone(self):
+        """bool: Whether the detector has a 3D backbone."""
+        return hasattr(self, "pts_backbone") and self.pts_backbone is not None
+
+    @property
+    def with_img_neck(self):
+        """bool: Whether the detector has a neck in image branch."""
+        return hasattr(self, "img_neck") and self.img_neck is not None
+
+    def aug_test(self, points, img_metas, imgs=None, rescale=False):
+        """Test function with augmentaiton."""
+        img_feats, pts_feats = self.extract_feats(points, img_metas, imgs)
+
+        bbox_list = dict()
+
+        return [bbox_list]
+
+    def extract_feats(self, points, img_metas, imgs=None):
+        """Extract point and image features of multiple samples."""
+        if imgs is None:
+            imgs = [None] * len(img_metas)
+        img_feats, pts_feats = multi_apply(self.extract_feat, points, imgs, img_metas)
+        return img_feats, pts_feats
+
+
+class UniADTrack(MVXTwoStageDetector):
+    """UniAD tracking part"""
+
+    def __init__(
+        self,
+        use_grid_mask=True,
+        img_backbone=True,
+        img_neck=True,
+        pts_bbox_head=True,
+        test_cfg=None,
+        pretrained=None,
+        video_test_mode=False,
+        qim_args=None,
+        mem_args=None,
+        bbox_coder=DETRTrack3DCoder(),
+        pc_range=None,
+        embed_dims=256,
+        num_query=900,
+        num_classes=10,
+        vehicle_id_list=None,
+        score_thresh=0.2,
+        filter_score_thresh=0.1,
+        miss_tolerance=5,
+        gt_iou_threshold=0.0,
+        freeze_img_backbone=False,
+        freeze_img_neck=False,
+        freeze_bn=False,
+        freeze_bev_encoder=False,
+        queue_length=3,
+    ):
+        super(UniADTrack, self).__init__(
+            img_backbone=img_backbone,
+            img_neck=img_neck,
+            pts_bbox_head=pts_bbox_head,
+            test_cfg=test_cfg,
+            pretrained=pretrained,
+        )
+
+        self.grid_mask = GridMask(
+            True, True, rotate=1, offset=False, ratio=0.5, mode=1, prob=0.7
+        )
+        self.use_grid_mask = use_grid_mask
+        self.fp16_enabled = False
+        self.embed_dims = embed_dims
+        self.num_query = num_query
+        self.num_classes = num_classes
+        self.vehicle_id_list = vehicle_id_list
+        self.pc_range = pc_range
+        self.queue_length = queue_length
+        if freeze_img_backbone:
+            if freeze_bn:
+                self.img_backbone.eval()
+            for param in self.img_backbone.parameters():
+                param.requires_grad = False
+
+        if freeze_img_neck:
+            if freeze_bn:
+                self.img_neck.eval()
+            for param in self.img_neck.parameters():
+                param.requires_grad = False
+        self.prev_frame_info = {
+            "prev_bev": None,
+            "scene_token": None,
+            "prev_pos": 0,
+            "prev_angle": 0,
+        }
+        self.query_embedding = nn.Embedding(self.num_query + 1, self.embed_dims * 2)
+        self.reference_points = nn.Linear(self.embed_dims, 3)
+
+        self.track_base = RuntimeTrackerBase(
+            score_thresh=score_thresh,
+            filter_score_thresh=filter_score_thresh,
+            miss_tolerance=miss_tolerance,
+        )
+
+        self.query_interact = QueryInteractionModule(
+            qim_args,
+            dim_in=embed_dims,
+            hidden_dim=embed_dims,
+            dim_out=embed_dims,
+        )
+
+        self.bbox_coder = DETRTrack3DCoder()
+
+        self.memory_bank = MemoryBank(
+            mem_args,
+            dim_in=embed_dims,
+            hidden_dim=embed_dims,
+            dim_out=embed_dims,
+        )
+        self.mem_bank_len = (
+            0 if self.memory_bank is None else self.memory_bank.max_his_length
+        )
+
+        self.test_track_instances = None
+        self.l2g_r_mat = None
+        self.l2g_t = None
+        self.gt_iou_threshold = gt_iou_threshold
+        self.bev_h, self.bev_w = 200, 200
+        self.freeze_bev_encoder = freeze_bev_encoder
+
+    def extract_img_feat(self, img, len_queue=None):
+        """Extract features of images."""
+        if img is None:
+            return None
+        assert img[0].dim() == 5
+        B, N, C, H, W = img[0].size()
+        img = img[0].reshape(B * N, C, H, W)
+        if self.use_grid_mask:
+            img = self.grid_mask(img)
+        img_feats = self.img_backbone(img)
+        if isinstance(img_feats, dict):
+            img_feats = list(img_feats.values())
+        if self.with_img_neck:
+            img_feats = self.img_neck(img_feats)
+
+        img_feats_reshaped = []
+        for img_feat in img_feats:
+            _, c, h, w = img_feat.size()
+            img_feat_reshaped = img_feat.view(B, N, c, h, w)
+            img_feats_reshaped.append(img_feat_reshaped)
+        return img_feats_reshaped
+
+    def _generate_empty_tracks(self):
+        num_queries, dim = self.query_embedding.weight.shape
+        query = self.query_embedding.weight
+        track_instances = Instances((1, 1), query=query)
+        track_instances.ref_pts = self.reference_points(query[..., : dim // 2])
+        pred_boxes_init = torch.zeros((len(track_instances), 10), dtype=torch.float)
+        track_instances.query = query
+        track_instances.output_embedding = torch.zeros((num_queries, dim >> 1))
+        track_instances.obj_idxes = torch.full(
+            (len(track_instances),), -1, dtype=torch.long
+        )
+        track_instances.matched_gt_idxes = torch.full(
+            (len(track_instances),), -1, dtype=torch.long
+        )
+        track_instances.disappear_time = torch.zeros(
+            (len(track_instances),), dtype=torch.long
+        )
+        track_instances.iou = torch.zeros((len(track_instances),), dtype=torch.float)
+        track_instances.scores = torch.zeros((len(track_instances),), dtype=torch.float)
+        track_instances.track_scores = torch.zeros(
+            (len(track_instances),), dtype=torch.float
+        )
+        track_instances.pred_boxes = pred_boxes_init
+        track_instances.pred_logits = torch.zeros(
+            (len(track_instances), self.num_classes), dtype=torch.float
+        )
+        mem_bank_len = self.mem_bank_len
+        track_instances.mem_bank = torch.zeros(
+            (len(track_instances), mem_bank_len, dim // 2), dtype=torch.float32
+        )
+        track_instances.mem_padding_mask = torch.ones(
+            (len(track_instances), mem_bank_len), dtype=torch.bool
+        )
+        track_instances.save_period = torch.zeros(
+            (len(track_instances),), dtype=torch.float32
+        )
+        track_instances = track_instances
+        return track_instances
+
+    def get_bevs(
+        self, imgs, img_metas, prev_img=None, prev_img_metas=None, prev_bev=None
+    ):
+        if prev_img is not None and prev_img_metas is not None:
+            assert prev_bev is None
+            if isinstance(prev_img, torch.Tensor) and prev_img.dim() == 4:
+                prev_img = [prev_img.unsqueeze(0)]
+            prev_bev = self.get_history_bev(prev_img, prev_img_metas)
+
+        if isinstance(imgs, torch.Tensor) and imgs.dim() == 5:
+            imgs = [imgs]
+        img_feats = self.extract_img_feat(img=imgs)
+        if self.freeze_bev_encoder:
+            with torch.no_grad():
+                bev_embed, bev_pos = self.pts_bbox_head.get_bev_features(
+                    mlvl_feats=img_feats, img_metas=img_metas, prev_bev=prev_bev
+                )
+
+        if bev_embed.shape[1] == self.bev_h * self.bev_w:
+            bev_embed = bev_embed.permute(1, 0, 2)
+
+        return bev_embed, bev_pos
+
+    def select_active_track_query(
+        self, track_instances, active_index, img_metas, with_mask=True
+    ):
+        result_dict = self._track_instances2results(
+            track_instances[active_index], img_metas, with_mask=with_mask
+        )
+        result_dict["track_query_embeddings"] = track_instances.output_embedding[
+            active_index
+        ][result_dict["bbox_index"]][result_dict["mask"]]
+        result_dict["track_query_matched_idxes"] = track_instances.matched_gt_idxes[
+            active_index
+        ][result_dict["bbox_index"]][result_dict["mask"]]
+        return result_dict
+
+    def select_sdc_track_query(self, sdc_instance, img_metas):
+        out = dict()
+        result_dict = self._track_instances2results(
+            sdc_instance, img_metas, with_mask=False
+        )
+        out["sdc_boxes_3d"] = result_dict["boxes_3d"]
+        out["sdc_scores_3d"] = result_dict["scores_3d"]
+        out["sdc_track_scores"] = result_dict["track_scores"]
+        out["sdc_track_bbox_results"] = result_dict["track_bbox_results"]
+        out["sdc_embedding"] = sdc_instance.output_embedding[0]
+        return out
+
+    def upsample_bev_if_tiny(self, outs_track):
+        if outs_track["bev_embed"].size(0) == 100 * 100:
+            bev_embed = outs_track["bev_embed"]
+            dim, _, _ = bev_embed.size()
+            w = h = int(math.sqrt(dim))
+            assert h == w == 100
+
+            bev_embed = rearrange(bev_embed, "(h w) b c -> b c h w", h=h, w=w)
+            bev_embed = nn.Upsample(scale_factor=2)(bev_embed)
+            bev_embed = rearrange(bev_embed, "b c h w -> (h w) b c")
+            outs_track["bev_embed"] = bev_embed
+
+            prev_bev = outs_track.get("prev_bev", None)
+
+            bev_pos = outs_track["bev_pos"]
+            bev_pos = nn.Upsample(scale_factor=2)(bev_pos)
+            outs_track["bev_pos"] = bev_pos
+        return outs_track
+
+    def _forward_single_frame_inference(
+        self,
+        img,
+        img_metas,
+        track_instances,
+        prev_bev=None,
+        l2g_r1=None,
+        l2g_t1=None,
+        l2g_r2=None,
+        l2g_t2=None,
+        time_delta=None,
+    ):
+        """
+        img: B, num_cam, C, H, W = img.shape
+        """
+
+        """ velo update """
+        active_inst = track_instances[track_instances.obj_idxes >= 0]
+        other_inst = track_instances[track_instances.obj_idxes < 0]
+
+        track_instances = Instances.cat([other_inst, active_inst])
+        bev_embed, bev_pos = self.get_bevs(img, img_metas, prev_bev=prev_bev)
+
+        det_output = self.pts_bbox_head.get_detections(
+            bev_embed,
+            object_query_embeds=track_instances.query,
+            ref_points=track_instances.ref_pts,
+            img_metas=img_metas,
+        )
+
+        output_classes = det_output["all_cls_scores"]
+        output_coords = det_output["all_bbox_preds"]
+        last_ref_pts = det_output["last_ref_points"]
+        query_feats = det_output["query_feats"]
+
+        out = {
+            "pred_logits": output_classes,
+            "pred_boxes": output_coords,
+            "ref_pts": last_ref_pts,
+            "bev_embed": bev_embed,
+            "query_embeddings": query_feats,
+            "all_past_traj_preds": det_output["all_past_traj_preds"],
+            "bev_pos": bev_pos,
+        }
+
+        """ update track instances with predict results """
+        track_scores = output_classes[-1, 0, :].sigmoid().max(dim=-1).values
+        track_instances.scores = track_scores
+        track_instances.pred_logits = output_classes[-1, 0]
+        track_instances.pred_boxes = output_coords[-1, 0]
+        track_instances.output_embedding = query_feats[-1][0]
+        track_instances.ref_pts = last_ref_pts[0]
+        track_instances.obj_idxes[900] = -2
+        self.track_base.update(track_instances, None)
+        self.track_base.filter_score_thresh = 0.35
+        active_index = (track_instances.obj_idxes >= 0) & (
+            track_instances.scores >= self.track_base.filter_score_thresh
+        )
+        out.update(
+            self.select_active_track_query(track_instances, active_index, img_metas)
+        )
+        out.update(
+            self.select_sdc_track_query(
+                track_instances[track_instances.obj_idxes == -2], img_metas
+            )
+        )
+
+        """ update with memory_bank """
+        if self.memory_bank is not None:
+            track_instances = self.memory_bank(track_instances)
+
+        """  Update track instances using matcher """
+        tmp = {}
+        tmp["init_track_instances"] = self._generate_empty_tracks()
+        tmp["track_instances"] = track_instances
+        out_track_instances = self.query_interact(tmp)
+        out["track_instances_fordet"] = track_instances
+        out["track_instances"] = out_track_instances
+        out["track_obj_idxes"] = track_instances.obj_idxes
+        return out
+
+    def simple_test_track(
+        self,
+        img=None,
+        l2g_t=None,
+        l2g_r_mat=None,
+        img_metas=None,
+        timestamp=None,
+    ):
+        """only support bs=1 and sequential input"""
+        bs = img[0].size(0)
+
+        """ init track instances for first frame """
+        if (
+            self.test_track_instances is None
+            or img_metas[0]["scene_token"] != self.scene_token
+        ):
+            self.timestamp = timestamp
+            self.scene_token = img_metas[0]["scene_token"]
+            self.prev_bev = None
+        track_instances = self._generate_empty_tracks()
+        time_delta, l2g_r1, l2g_t1, l2g_r2, l2g_t2 = None, None, None, None, None
+
+        """ get time_delta and l2g r/t infos """
+        """ update frame info for next frame"""
+        self.timestamp = timestamp
+        self.l2g_t = l2g_t
+        self.l2g_r_mat = l2g_r_mat
+
+        """ predict and update """
+        prev_bev = self.prev_bev
+        frame_res = self._forward_single_frame_inference(
+            img,
+            img_metas,
+            track_instances,
+            prev_bev,
+            l2g_r1,
+            l2g_t1,
+            l2g_r2,
+            l2g_t2,
+            time_delta,
+        )
+
+        self.prev_bev = frame_res["bev_embed"]
+        track_instances = frame_res["track_instances"]
+        track_instances_fordet = frame_res["track_instances_fordet"]
+        self.test_track_instances = track_instances
+        results = [dict()]
+        get_keys = [
+            "bev_embed",
+            "bev_pos",
+            "track_query_embeddings",
+            "track_bbox_results",
+            "boxes_3d",
+            "scores_3d",
+            "labels_3d",
+            "track_scores",
+            "track_ids",
+        ]
+        if self.with_motion_head:
+            get_keys += [
+                "sdc_boxes_3d",
+                "sdc_scores_3d",
+                "sdc_track_scores",
+                "sdc_track_bbox_results",
+                "sdc_embedding",
+            ]
+        results[0].update({k: frame_res[k] for k in get_keys})
+        results = self._det_instances2results(
+            track_instances_fordet, results, img_metas
+        )
+        return results
+
+    def _track_instances2results(self, track_instances, img_metas, with_mask=True):
+        bbox_dict = dict(
+            cls_scores=track_instances.pred_logits,
+            bbox_preds=track_instances.pred_boxes,
+            track_scores=track_instances.scores,
+            obj_idxes=track_instances.obj_idxes,
+        )
+        bboxes_dict = self.bbox_coder.decode(
+            bbox_dict, with_mask=with_mask, img_metas=img_metas
+        )[0]
+        bboxes = bboxes_dict["bboxes"]
+        bboxes = img_metas[0]["box_type_3d"](bboxes, 9)
+        labels = bboxes_dict["labels"]
+        scores = bboxes_dict["scores"]
+        bbox_index = bboxes_dict["bbox_index"]
+
+        track_scores = bboxes_dict["track_scores"]
+        obj_idxes = bboxes_dict["obj_idxes"]
+        result_dict = dict(
+            boxes_3d=bboxes,
+            scores_3d=scores.cpu(),
+            labels_3d=labels.cpu(),
+            track_scores=track_scores.cpu(),
+            bbox_index=bbox_index.cpu(),
+            track_ids=obj_idxes.cpu(),
+            mask=bboxes_dict["mask"].cpu(),
+            track_bbox_results=[
+                [
+                    bboxes,
+                    scores.cpu(),
+                    labels.cpu(),
+                    bbox_index.cpu(),
+                    bboxes_dict["mask"].cpu(),
+                ]
+            ],
+        )
+        return result_dict
+
+    def _det_instances2results(self, instances, results, img_metas):
+        """
+        Outs:
+        active_instances. keys:
+        - 'pred_logits':
+        - 'pred_boxes': normalized bboxes
+        - 'scores'
+        - 'obj_idxes'
+        out_dict. keys:
+            - boxes_3d (torch.Tensor): 3D boxes.
+            - scores (torch.Tensor): Prediction scores.
+            - labels_3d (torch.Tensor): Box labels.
+            - attrs_3d (torch.Tensor, optional): Box attributes.
+            - track_ids
+            - tracking_score
+        """
+        if instances.pred_logits.numel() == 0:
+            return [None]
+        bbox_dict = dict(
+            cls_scores=instances.pred_logits,
+            bbox_preds=instances.pred_boxes,
+            track_scores=instances.scores,
+            obj_idxes=instances.obj_idxes,
+        )
+        bboxes_dict = self.bbox_coder.decode(bbox_dict, img_metas=img_metas)[0]
+        bboxes = bboxes_dict["bboxes"]
+        bboxes = img_metas[0]["box_type_3d"](bboxes, 9)
+        labels = bboxes_dict["labels"]
+        scores = bboxes_dict["scores"]
+
+        track_scores = bboxes_dict["track_scores"]
+        obj_idxes = bboxes_dict["obj_idxes"]
+        result_dict = results[0]
+        result_dict_det = dict(
+            boxes_3d_det=bboxes,
+            scores_3d_det=scores.cpu(),
+            labels_3d_det=labels.cpu(),
+        )
+        result_dict.update(result_dict_det)
+        return [result_dict]

--- a/uniad/pytorch/src/utils.py
+++ b/uniad/pytorch/src/utils.py
@@ -1,0 +1,958 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from torch import nn
+import torch.nn.functional as F
+import torch
+from torch.nn.modules.utils import _pair, _single
+import torchvision
+import warnings
+import math
+import torch.distributed as dist
+import copy
+
+
+def inverse_sigmoid(x, eps=1e-5):
+    """Inverse function of sigmoid.
+
+    Args:
+        x (Tensor): The tensor to do the
+            inverse.
+        eps (float): EPS avoid numerical
+            overflow. Defaults 1e-5.
+    Returns:
+        Tensor: The x has passed the inverse
+            function of sigmoid, has same
+            shape with input.
+    """
+    x = x.clamp(min=0, max=1)
+    x1 = x.clamp(min=eps)
+    x2 = (1 - x).clamp(min=eps)
+    return torch.log(x1 / x2)
+
+
+class ConvModule(nn.Module):
+    def __init__(self, in_channel, out_channel, kernel_size=1, stride=1, padding=False):
+        super().__init__()
+        self.in_channel = in_channel
+        self.out_channel = out_channel
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+        padding_value = 1 if self.padding else 0
+        self.conv = nn.Conv2d(
+            in_channels=self.in_channel,
+            out_channels=self.out_channel,
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=padding_value,
+        )
+
+    def forward(self, x):
+        x = self.conv(x)
+        return x
+
+
+class FPN(nn.Module):
+    r"""Feature Pyramid Network.
+
+    This is an implementation of paper `Feature Pyramid Networks for Object
+    Detection <https://arxiv.org/abs/1612.03144>`_.
+
+    Args:
+        in_channels (List[int]): Number of input channels per scale.
+        out_channels (int): Number of output channels (used at each scale)
+        num_outs (int): Number of output scales.
+        start_level (int): Index of the start input backbone level used to
+            build the feature pyramid. Default: 0.
+        end_level (int): Index of the end input backbone level (exclusive) to
+            build the feature pyramid. Default: -1, which means the last level.
+        add_extra_convs (bool | str): If bool, it decides whether to add conv
+            layers on top of the original feature maps. Default to False.
+            If True, it is equivalent to `add_extra_convs='on_input'`.
+            If str, it specifies the source feature map of the extra convs.
+            Only the following options are allowed
+
+            - 'on_input': Last feat map of neck inputs (i.e. backbone feature).
+            - 'on_lateral':  Last feature map after lateral convs.
+            - 'on_output': The last output feature map after fpn convs.
+        relu_before_extra_convs (bool): Whether to apply relu before the extra
+            conv. Default: False.
+        no_norm_on_lateral (bool): Whether to apply norm on lateral.
+            Default: False.
+        conv_cfg (dict): Config dict for convolution layer. Default: None.
+        norm_cfg (dict): Config dict for normalization layer. Default: None.
+        act_cfg (str): Config dict for activation layer in ConvModule.
+            Default: None.
+        upsample_cfg (dict): Config dict for interpolate layer.
+            Default: `dict(mode='nearest')`
+    """
+
+    def __init__(
+        self,
+        in_channels=[512, 1024, 2048],
+        out_channels=256,
+        num_outs=4,
+        start_level=0,
+        end_level=-1,
+        add_extra_convs="on_output",
+        relu_before_extra_convs=False,
+        no_norm_on_lateral=False,
+        conv_cfg=None,
+        norm_cfg=None,
+        act_cfg=None,
+        upsample_cfg=dict(mode="nearest"),
+    ):
+        super().__init__()
+        assert isinstance(in_channels, list)
+        self.in_channels = [512, 1024, 2048]
+        self.out_channels = 256
+        self.num_ins = 3
+        self.num_outs = 4
+        self.relu_before_extra_convs = True
+        self.no_norm_on_lateral = False
+        self.fp16_enabled = False
+        self.upsample_cfg = upsample_cfg.copy()
+
+        if end_level == -1:
+            self.backbone_end_level = self.num_ins
+            assert num_outs >= self.num_ins - start_level
+        self.start_level = start_level
+        self.end_level = end_level
+        self.add_extra_convs = add_extra_convs
+        assert isinstance(add_extra_convs, (str, bool))
+        if isinstance(add_extra_convs, str):
+            assert add_extra_convs in ("on_input", "on_lateral", "on_output")
+        elif add_extra_convs:
+            self.add_extra_convs = "on_input"
+
+        self.lateral_convs = nn.ModuleList()
+        self.fpn_convs = nn.ModuleList()
+
+        for i in range(self.start_level, self.backbone_end_level):
+            l_conv = ConvModule(
+                in_channels[i], out_channels, 1, stride=1, padding=False
+            )
+            fpn_conv = ConvModule(out_channels, out_channels, 3, stride=1, padding=True)
+
+            self.lateral_convs.append(l_conv)
+            self.fpn_convs.append(fpn_conv)
+
+        extra_levels = num_outs - self.backbone_end_level + self.start_level
+        if self.add_extra_convs and extra_levels >= 1:
+            for i in range(extra_levels):
+                if i == 0 and self.add_extra_convs == "on_input":
+                    in_channels = self.in_channels[self.backbone_end_level - 1]
+                else:
+                    in_channels = out_channels
+                extra_fpn_conv = ConvModule(
+                    in_channels, out_channels, 3, stride=2, padding=True
+                )
+                self.fpn_convs.append(extra_fpn_conv)
+
+    def forward(self, inputs):
+        """Forward function."""
+        assert len(inputs) == len(self.in_channels)
+
+        laterals = [
+            lateral_conv(inputs[i + self.start_level])
+            for i, lateral_conv in enumerate(self.lateral_convs)
+        ]
+
+        used_backbone_levels = len(laterals)
+        for i in range(used_backbone_levels - 1, 0, -1):
+            prev_shape = laterals[i - 1].shape[2:]
+            laterals[i - 1] += F.interpolate(
+                laterals[i], size=prev_shape, **self.upsample_cfg
+            )
+
+        outs = [self.fpn_convs[i](laterals[i]) for i in range(used_backbone_levels)]
+        if self.num_outs > len(outs):
+            if not self.add_extra_convs:
+                for i in range(self.num_outs - used_backbone_levels):
+                    outs.append(F.max_pool2d(outs[-1], 1, stride=2))
+            else:
+                if self.add_extra_convs == "on_input":
+                    extra_source = inputs[self.backbone_end_level - 1]
+                elif self.add_extra_convs == "on_lateral":
+                    extra_source = laterals[-1]
+                elif self.add_extra_convs == "on_output":
+                    extra_source = outs[-1]
+                else:
+                    raise NotImplementedError
+                outs.append(self.fpn_convs[used_backbone_levels](extra_source))
+                for i in range(used_backbone_levels + 1, self.num_outs):
+                    if self.relu_before_extra_convs:
+                        outs.append(self.fpn_convs[i](F.relu(outs[-1])))
+                    else:
+                        outs.append(self.fpn_convs[i](outs[-1]))
+        return tuple(outs)
+
+
+class ModulatedDeformConv2dPack(nn.Module):
+    """A ModulatedDeformable Conv Encapsulation that acts as normal Conv
+    layers.
+    Args:
+        in_channels (int): Same as nn.Conv2d.
+        out_channels (int): Same as nn.Conv2d.
+        kernel_size (int or tuple[int]): Same as nn.Conv2d.
+        stride (int): Same as nn.Conv2d, while tuple is not supported.
+        padding (int): Same as nn.Conv2d, while tuple is not supported.
+        dilation (int): Same as nn.Conv2d, while tuple is not supported.
+        groups (int): Same as nn.Conv2d.
+        bias (bool or str): If specified as `auto`, it will be decided by the
+            norm_cfg. Bias will be set as True if norm_cfg is None, otherwise
+            False.
+    """
+
+    _version = 2
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+        deform_groups=1,
+        bias=True,
+    ):
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = _pair(kernel_size)
+        self.stride = _pair(stride)
+        self.padding = _pair(padding)
+        self.dilation = _pair(dilation)
+        self.groups = groups
+        self.deform_groups = deform_groups
+        self.transposed = False
+        self.output_padding = _single(0)
+
+        self.weight = nn.Parameter(
+            torch.Tensor(out_channels, in_channels // groups, *self.kernel_size)
+        )
+        self.register_parameter("bias", None)
+        self.conv_offset = nn.Conv2d(
+            self.in_channels,
+            self.deform_groups * 3 * self.kernel_size[0] * self.kernel_size[1],
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            bias=True,
+        )
+
+    def forward(self, x):
+        out = self.conv_offset(x)
+        o1, o2, mask = torch.chunk(out, 3, dim=1)
+        offset = torch.cat((o1, o2), dim=1)
+        mask = torch.sigmoid(mask)
+        return torchvision.ops.deform_conv2d(
+            x,
+            offset,
+            self.weight,
+            self.bias,
+            self.stride,
+            self.padding,
+            self.dilation,
+            mask,
+        )
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        version = local_metadata.get("version", None)
+
+        if version is None or version < 2:
+            if (
+                prefix + "conv_offset.weight" not in state_dict
+                and prefix[:-1] + "_offset.weight" in state_dict
+            ):
+                state_dict[prefix + "conv_offset.weight"] = state_dict.pop(
+                    prefix[:-1] + "_offset.weight"
+                )
+            if (
+                prefix + "conv_offset.bias" not in state_dict
+                and prefix[:-1] + "_offset.bias" in state_dict
+            ):
+                state_dict[prefix + "conv_offset.bias"] = state_dict.pop(
+                    prefix[:-1] + "_offset.bias"
+                )
+
+        if version is not None and version > 1:
+            print(
+                f'ModulatedDeformConvPack {prefix.rstrip(".")} is upgraded to '
+                "version 2."
+            )
+
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+
+class ResLayer(nn.Sequential):
+    """ResLayer to build ResNet style backbone.
+
+    Args:
+        block (nn.Module): block used to build ResLayer.
+        inplanes (int): inplanes of block.
+        planes (int): planes of block.
+        num_blocks (int): number of blocks.
+        stride (int): stride of the first block. Default: 1
+        avg_down (bool): Use AvgPool instead of stride conv when
+            downsampling in the bottleneck. Default: False
+        conv_cfg (dict): dictionary to construct and config conv layer.
+            Default: None
+        norm_cfg (dict): dictionary to construct and config norm layer.
+            Default: dict(type='BN')
+        downsample_first (bool): Downsample at the first block or last block.
+            False for Hourglass, True for ResNet. Default: True
+    """
+
+    def __init__(
+        self,
+        block,
+        inplanes,
+        planes,
+        num_blocks,
+        stride=1,
+        avg_down=False,
+        conv_cfg=None,
+        norm_cfg=dict(type="BN"),
+        downsample_first=True,
+        **kwargs,
+    ):
+        self.block = block
+        downsample = None
+        if stride != 1 or inplanes != planes * block.expansion:
+            downsample = []
+            conv_stride = stride
+            if avg_down:
+                conv_stride = 1
+                downsample.append(
+                    nn.AvgPool2d(
+                        kernel_size=stride,
+                        stride=stride,
+                        ceil_mode=True,
+                        count_include_pad=False,
+                    )
+                )
+            downsample.extend(
+                [
+                    torch.nn.Conv2d(
+                        inplanes,
+                        planes * block.expansion,
+                        kernel_size=1,
+                        stride=conv_stride,
+                        bias=False,
+                    ),
+                    torch.nn.BatchNorm2d(
+                        planes * block.expansion,
+                        eps=1e-05,
+                        momentum=0.1,
+                        affine=True,
+                        track_running_stats=True,
+                    ),
+                ]
+            )
+            downsample = nn.Sequential(*downsample)
+
+        layers = []
+        if downsample_first:
+            layers.append(
+                block(
+                    inplanes=inplanes,
+                    planes=planes,
+                    stride=stride,
+                    downsample=downsample,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    **kwargs,
+                )
+            )
+            inplanes = planes * block.expansion
+            for _ in range(1, num_blocks):
+                layers.append(
+                    block(
+                        inplanes=inplanes,
+                        planes=planes,
+                        stride=1,
+                        conv_cfg=conv_cfg,
+                        norm_cfg=norm_cfg,
+                        **kwargs,
+                    )
+                )
+
+        super(ResLayer, self).__init__(*layers)
+
+
+class Bottleneck(nn.Module):
+    expansion = 4
+
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        stride=1,
+        dilation=1,
+        downsample=None,
+        style="pytorch",
+        with_cp=False,
+        conv_cfg=None,
+        norm_cfg=dict(type="BN"),
+        dcn=None,
+        plugins=None,
+    ):
+        """Bottleneck block for ResNet.
+
+        If style is "pytorch", the stride-two layer is the 3x3 conv layer, if
+        it is "caffe", the stride-two layer is the first 1x1 conv layer.
+        """
+        super(Bottleneck, self).__init__()
+        assert style in ["pytorch", "caffe"]
+        assert dcn is None or isinstance(dcn, dict)
+        assert plugins is None or isinstance(plugins, list)
+        if plugins is not None:
+            allowed_position = ["after_conv1", "after_conv2", "after_conv3"]
+            assert all(p["position"] in allowed_position for p in plugins)
+
+        self.inplanes = inplanes
+        self.planes = planes
+        self.stride = stride
+        self.dilation = dilation
+        self.style = style
+        self.with_cp = with_cp
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.dcn = dcn
+        self.with_dcn = dcn is not None
+        self.plugins = plugins
+        self.with_plugins = plugins is not None
+        self.conv1_stride = stride
+        self.conv2_stride = 1
+
+        self.norm1_name, norm1 = "bn1", torch.nn.BatchNorm2d(
+            planes, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True
+        )
+        self.norm2_name, norm2 = "bn2", torch.nn.BatchNorm2d(
+            planes, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True
+        )
+        self.norm3_name, norm3 = "bn3", torch.nn.BatchNorm2d(
+            planes * self.expansion,
+            eps=1e-05,
+            momentum=0.1,
+            affine=True,
+            track_running_stats=True,
+        )
+        self.conv1 = torch.nn.Conv2d(
+            inplanes, planes, kernel_size=1, stride=self.conv1_stride, bias=False
+        )
+        self.add_module(self.norm1_name, norm1)
+        fallback_on_stride = False
+        if self.with_dcn:
+            fallback_on_stride = dcn.pop("fallback_on_stride", False)
+        if not self.with_dcn or fallback_on_stride:
+            self.conv2 = torch.nn.Conv2d(
+                planes,
+                planes,
+                kernel_size=3,
+                stride=self.conv2_stride,
+                padding=dilation,
+                dilation=dilation,
+                bias=False,
+            )
+        else:
+            assert self.conv_cfg is None, "conv_cfg must be None for DCN"
+            self.conv2 = ModulatedDeformConv2dPack(
+                planes,
+                planes,
+                kernel_size=3,
+                stride=self.conv2_stride,
+                padding=dilation,
+                dilation=dilation,
+                bias=False,
+            )
+
+        self.add_module(self.norm2_name, norm2)
+        self.conv3 = torch.nn.Conv2d(
+            planes,
+            planes * self.expansion,
+            kernel_size=(1, 1),
+            stride=(1, 1),
+            bias=False,
+        )
+        self.add_module(self.norm3_name, norm3)
+
+        self.relu = torch.nn.ReLU(inplace=True)
+        self.downsample = downsample
+
+    @property
+    def norm1(self):
+        """nn.Module: normalization layer after the first convolution layer"""
+        return getattr(self, self.norm1_name)
+
+    @property
+    def norm2(self):
+        """nn.Module: normalization layer after the second convolution layer"""
+        return getattr(self, self.norm2_name)
+
+    @property
+    def norm3(self):
+        """nn.Module: normalization layer after the third convolution layer"""
+        return getattr(self, self.norm3_name)
+
+    def forward(self, x):
+        """Forward function."""
+
+        def _inner_forward(x):
+            identity = x
+            out = self.conv1(x)
+            out = self.norm1(out)
+            out = self.relu(out)
+            out = self.conv2(out)
+            out = self.norm2(out)
+            out = self.relu(out)
+            out = self.conv3(out)
+            out = self.norm3(out)
+            if self.downsample is not None:
+                identity = self.downsample(x)
+            out += identity
+            return out
+
+        out = _inner_forward(x)
+        out = self.relu(out)
+        return out
+
+
+class ResNet(nn.Module):
+    """ResNet backbone.
+
+    Args:
+        depth (int): Depth of resnet, from {18, 34, 50, 101, 152}.
+        stem_channels (int | None): Number of stem channels. If not specified,
+            it will be the same as `base_channels`. Default: None.
+        base_channels (int): Number of base channels of res layer. Default: 64.
+        in_channels (int): Number of input image channels. Default: 3.
+        num_stages (int): Resnet stages. Default: 4.
+        strides (Sequence[int]): Strides of the first block of each stage.
+        dilations (Sequence[int]): Dilation of each stage.
+        out_indices (Sequence[int]): Output from which stages.
+        style (str): `pytorch` or `caffe`. If set to "pytorch", the stride-two
+            layer is the 3x3 conv layer, otherwise the stride-two layer is
+            the first 1x1 conv layer.
+        deep_stem (bool): Replace 7x7 conv in input stem with 3 3x3 conv
+        avg_down (bool): Use AvgPool instead of stride conv when
+            downsampling in the bottleneck.
+        frozen_stages (int): Stages to be frozen (stop grad and set eval mode).
+            -1 means not freezing any parameters.
+        norm_cfg (dict): Dictionary to construct and config norm layer.
+        norm_eval (bool): Whether to set norm layers to eval mode, namely,
+            freeze running stats (mean and var). Note: Effect on Batch Norm
+            and its variants only.
+        plugins (list[dict]): List of plugins for stages, each dict contains:
+
+            - cfg (dict, required): Cfg dict to build plugin.
+            - position (str, required): Position inside block to insert
+              plugin, options are 'after_conv1', 'after_conv2', 'after_conv3'.
+            - stages (tuple[bool], optional): Stages to apply plugin, length
+              should be same as 'num_stages'.
+        with_cp (bool): Use checkpoint or not. Using checkpoint will save some
+            memory while slowing down the training speed.
+        zero_init_residual (bool): Whether to use zero init for last norm layer
+            in resblocks to let them behave as identity.
+        pretrained (str, optional): model pretrained path. Default: None
+    """
+
+    arch_settings = {
+        101: (Bottleneck, (3, 4, 23, 3)),
+    }
+
+    def __init__(
+        self,
+        depth=101,
+        in_channels=3,
+        stem_channels=None,
+        base_channels=64,
+        num_stages=4,
+        strides=(1, 2, 2, 2),
+        dilations=(1, 1, 1, 1),
+        out_indices=(1, 2, 3),
+        style="caffe",
+        deep_stem=False,
+        avg_down=False,
+        frozen_stages=4,
+        conv_cfg=None,
+        norm_cfg=dict(type="BN2d", requires_grad=False),
+        norm_eval=True,
+        dcn=dict(type="DCNv2", deform_groups=1, fallback_on_stride=False),
+        stage_with_dcn=(False, False, True, True),
+        plugins=None,
+        with_cp=False,
+        zero_init_residual=True,
+        pretrained=None,
+    ):
+        super(ResNet, self).__init__()
+        self.zero_init_residual = zero_init_residual
+        if depth not in self.arch_settings:
+            raise KeyError(f"invalid depth {depth} for resnet")
+
+        block_init_cfg = None
+        if isinstance(pretrained, str):
+            warnings.warn(
+                "DeprecationWarning: pretrained is deprecated, "
+                'please use "init_cfg" instead'
+            )
+
+        self.depth = depth
+        if stem_channels is None:
+            stem_channels = base_channels
+        self.stem_channels = stem_channels
+        self.base_channels = base_channels
+        self.num_stages = num_stages
+        assert num_stages >= 1 and num_stages <= 4
+        self.strides = strides
+        self.dilations = dilations
+        assert len(strides) == len(dilations) == num_stages
+        self.out_indices = out_indices
+        assert max(out_indices) < num_stages
+        self.style = style
+        self.deep_stem = deep_stem
+        self.avg_down = avg_down
+        self.frozen_stages = frozen_stages
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.with_cp = with_cp
+        self.norm_eval = norm_eval
+        self.dcn = dcn
+        self.stage_with_dcn = stage_with_dcn
+        if dcn is not None:
+            assert len(stage_with_dcn) == num_stages
+        self.plugins = plugins
+        self.block, stage_blocks = self.arch_settings[depth]
+        self.stage_blocks = stage_blocks[:num_stages]
+        self.inplanes = stem_channels
+
+        self._make_stem_layer(in_channels, stem_channels)
+
+        self.res_layers = []
+        for i, num_blocks in enumerate(self.stage_blocks):
+            stride = strides[i]
+            dilation = dilations[i]
+            dcn = self.dcn if self.stage_with_dcn[i] else None
+            stage_plugins = None
+            planes = base_channels * 2**i
+            res_layer = self.make_res_layer(
+                block=self.block,
+                inplanes=self.inplanes,
+                planes=planes,
+                num_blocks=num_blocks,
+                stride=stride,
+                dilation=dilation,
+                style=self.style,
+                avg_down=self.avg_down,
+                with_cp=with_cp,
+                conv_cfg=conv_cfg,
+                norm_cfg=norm_cfg,
+                dcn=dcn,
+                plugins=stage_plugins,
+            )
+            self.inplanes = planes * self.block.expansion
+            layer_name = f"layer{i + 1}"
+            self.add_module(layer_name, res_layer)
+            self.res_layers.append(layer_name)
+
+        self._freeze_stages()
+
+        self.feat_dim = (
+            self.block.expansion * base_channels * 2 ** (len(self.stage_blocks) - 1)
+        )
+
+    def make_res_layer(self, **kwargs):
+        """Pack all blocks in a stage into a ``ResLayer``."""
+        return ResLayer(**kwargs)
+
+    @property
+    def norm1(self):
+        """nn.Module: the normalization layer named "norm1" """
+        return getattr(self, self.norm1_name)
+
+    def _make_stem_layer(self, in_channels, stem_channels):
+        self.conv1 = torch.nn.Conv2d(
+            in_channels, stem_channels, kernel_size=7, stride=2, padding=3, bias=False
+        )
+        self.norm1_name, norm1 = "bn1", torch.nn.BatchNorm2d(
+            stem_channels,
+            eps=1e-05,
+            momentum=0.1,
+            affine=True,
+            track_running_stats=True,
+        )
+        self.add_module(self.norm1_name, norm1)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+    def _freeze_stages(self):
+        if self.frozen_stages >= 0:
+            self.norm1.eval()
+            for m in [self.conv1, self.norm1]:
+                for param in m.parameters():
+                    param.requires_grad = False
+
+        for i in range(1, self.frozen_stages + 1):
+            m = getattr(self, f"layer{i}")
+            m.eval()
+            for param in m.parameters():
+                param.requires_grad = False
+
+    def forward(self, x):
+        """Forward function."""
+        x = self.conv1(x)
+        x = self.norm1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+        outs = []
+        for i, layer_name in enumerate(self.res_layers):
+            res_layer = getattr(self, layer_name)
+            x = res_layer(x)
+            if i in self.out_indices:
+                outs.append(x)
+        return tuple(outs)
+
+
+class MultiheadAttention(nn.Module):
+    """A wrapper for ``torch.nn.MultiheadAttention``.
+
+    This module implements MultiheadAttention with identity connection,
+    and positional encoding  is also passed as input.
+
+    Args:
+        embed_dims (int): The embedding dimension.
+        num_heads (int): Parallel attention heads.
+        attn_drop (float): A Dropout layer on attn_output_weights.
+            Default: 0.0.
+        proj_drop (float): A Dropout layer after `nn.MultiheadAttention`.
+            Default: 0.0.
+        dropout_layer (obj:`ConfigDict`): The dropout_layer used
+            when adding the shortcut.
+        batch_first (bool): When it is True,  Key, Query and Value are shape of
+            (batch, n, embed_dim), otherwise (n, batch, embed_dim).
+             Default to False.
+    """
+
+    def __init__(
+        self,
+        embed_dims=256,
+        num_heads=8,
+        attn_drop=0.0,
+        proj_drop=0.0,
+        dropout_layer=dict(type="Dropout", drop_prob=0.1),
+        batch_first=False,
+        **kwargs,
+    ):
+        super().__init__()
+        if "dropout" in kwargs:
+            warnings.warn(
+                "The arguments `dropout` in MultiheadAttention "
+                "has been deprecated, now you can separately "
+                "set `attn_drop`(float), proj_drop(float), "
+                "and `dropout_layer`(dict) ",
+                DeprecationWarning,
+            )
+            attn_drop = kwargs["dropout"]
+            dropout_layer["drop_prob"] = kwargs.pop("dropout")
+
+        self.embed_dims = embed_dims
+        self.num_heads = num_heads
+        self.batch_first = batch_first
+
+        self.attn = nn.MultiheadAttention(embed_dims, num_heads, attn_drop, **kwargs)
+
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.dropout_layer = (
+            nn.Dropout(p=dropout_layer.get("p", 0.1))
+            if dropout_layer
+            else nn.Identity()
+        )
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_pos=None,
+        attn_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        """Forward function for `MultiheadAttention`.
+
+        **kwargs allow passing a more general data flow when combining
+        with other operations in `transformerlayer`.
+
+        Args:
+            query (Tensor): The input query with shape [num_queries, bs,
+                embed_dims] if self.batch_first is False, else
+                [bs, num_queries embed_dims].
+            key (Tensor): The key tensor with shape [num_keys, bs,
+                embed_dims] if self.batch_first is False, else
+                [bs, num_keys, embed_dims] .
+                If None, the ``query`` will be used. Defaults to None.
+            value (Tensor): The value tensor with same shape as `key`.
+                Same in `nn.MultiheadAttention.forward`. Defaults to None.
+                If None, the `key` will be used.
+            identity (Tensor): This tensor, with the same shape as x,
+                will be used for the identity link.
+                If None, `x` will be used. Defaults to None.
+            query_pos (Tensor): The positional encoding for query, with
+                the same shape as `x`. If not None, it will
+                be added to `x` before forward function. Defaults to None.
+            key_pos (Tensor): The positional encoding for `key`, with the
+                same shape as `key`. Defaults to None. If not None, it will
+                be added to `key` before forward function. If None, and
+                `query_pos` has the same shape as `key`, then `query_pos`
+                will be used for `key_pos`. Defaults to None.
+            attn_mask (Tensor): ByteTensor mask with shape [num_queries,
+                num_keys]. Same in `nn.MultiheadAttention.forward`.
+                Defaults to None.
+            key_padding_mask (Tensor): ByteTensor with shape [bs, num_keys].
+                Defaults to None.
+
+        Returns:
+            Tensor: forwarded results with shape
+            [num_queries, bs, embed_dims]
+            if self.batch_first is False, else
+            [bs, num_queries embed_dims].
+        """
+
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+        if identity is None:
+            identity = query
+        if key_pos is None:
+            if query_pos is not None:
+                if query_pos.shape == key.shape:
+                    key_pos = query_pos
+                else:
+                    warnings.warn(
+                        f"position encoding of key is"
+                        f"missing in {self.__class__.__name__}."
+                    )
+        if query_pos is not None:
+            query = query + query_pos
+        if key_pos is not None:
+            key = key + key_pos
+
+        if self.batch_first:
+            query = query.transpose(0, 1)
+            key = key.transpose(0, 1)
+            value = value.transpose(0, 1)
+        out = self.attn(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+            key_padding_mask=key_padding_mask,
+        )[0]
+
+        if self.batch_first:
+            out = out.transpose(0, 1)
+        return identity + self.dropout_layer(self.proj_drop(out))
+
+
+class TransformerLayerSequence(nn.Module):
+    """Base class for TransformerEncoder and TransformerDecoder in vision
+    transformer.
+
+    As base-class of Encoder and Decoder in vision transformer.
+    Support customization such as specifying different kind
+    of `transformer_layer` in `transformer_coder`.
+
+    Args:
+        transformerlayer (list[obj:`mmcv.ConfigDict`] |
+            obj:`mmcv.ConfigDict`): Config of transformerlayer
+            in TransformerCoder. If it is obj:`mmcv.ConfigDict`,
+             it would be repeated `num_layer` times to a
+             list[`mmcv.ConfigDict`]. Default: None.
+        num_layers (int): The number of `TransformerLayer`. Default: None.
+    """
+
+    def __init__(self, transformerlayers=None, num_layers=5, **kwargs):
+        super().__init__()
+        self.num_layers = num_layers
+        self.layers = nn.ModuleList(
+            [transformerlayers(**kwargs) for _ in range(num_layers)]
+        )
+        self.embed_dims = 256
+        self.pre_norm = self.layers[0].pre_norm
+
+    def forward(
+        self,
+        query,
+        key,
+        value,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        """Forward function for `TransformerCoder`.
+
+        Args:
+            query (Tensor): Input query with shape
+                `(num_queries, bs, embed_dims)`.
+            key (Tensor): The key tensor with shape
+                `(num_keys, bs, embed_dims)`.
+            value (Tensor): The value tensor with shape
+                `(num_keys, bs, embed_dims)`.
+            query_pos (Tensor): The positional encoding for `query`.
+                Default: None.
+            key_pos (Tensor): The positional encoding for `key`.
+                Default: None.
+            attn_masks (List[Tensor], optional): Each element is 2D Tensor
+                which is used in calculation of corresponding attention in
+                operation_order. Default: None.
+            query_key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_queries]. Only used in self-attention
+                Default: None.
+            key_padding_mask (Tensor): ByteTensor for `query`, with
+                shape [bs, num_keys]. Default: None.
+
+        Returns:
+            Tensor:  results with shape [num_queries, bs, embed_dims].
+        """
+        for layer in self.layers:
+            query = layer(
+                query,
+                key,
+                value,
+                query_pos=query_pos,
+                key_pos=key_pos,
+                attn_masks=attn_masks,
+                query_key_padding_mask=query_key_padding_mask,
+                key_padding_mask=key_padding_mask,
+                **kwargs,
+            )
+        return query


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1151

### Problem description

- Added the PyTorch implementation of the UNIAD model.
- The original implementation relied on external libraries such as mmcv, mmdet, and mmdet3d.
- Removed these dependencies by refactoring key functions, including config, DictAction, build_model, load_checkpoint, and set_random_seed.
- Replaced the use of build_dataset by directly passing randomly generated input tensors based on the shape and distribution of the NuScenes dataset.
- Substituted mmcv.load_checkpoint with model.load_state_dict() for loading model weights.

### What's changed
ModelLoader class for UNIAD has been added to the respective directories.

### Checklist
- [ ] New/Existing tests provide coverage for changes
