### PR TITLE
Add helper cast_input_to_type() use in several affected models for dtype_override on inputs

### DIFF
--- a/gemma/pytorch/loader.py
+++ b/gemma/pytorch/loader.py
@@ -19,6 +19,7 @@ from ...config import (
 )
 from ...base import ForgeModel
 from .src.model_utils import pad_inputs
+from ...tools.utils import cast_input_to_type
 
 
 class ModelVariant(StrEnum):
@@ -163,12 +164,8 @@ class ModelLoader(ForgeModel):
         for key in inputs:
             inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
         if dtype_override is not None:
-            override_is_float = dtype_override.is_floating_point
             for key in inputs:
-                if override_is_float and inputs[key].is_floating_point():
-                    inputs[key] = inputs[key].to(dtype_override)
-                elif (not override_is_float) and (not inputs[key].is_floating_point()):
-                    inputs[key] = inputs[key].to(dtype_override)
+                inputs[key] = cast_input_to_type(inputs[key], dtype_override)
         padded_input_ids, seq_len = pad_inputs(inputs["input_ids"], max_new_tokens)
         padded_attention_mask, _ = pad_inputs(inputs["attention_mask"], max_new_tokens)
         self.seq_len = seq_len

--- a/gpt_neo/sequence_classification/pytorch/loader.py
+++ b/gpt_neo/sequence_classification/pytorch/loader.py
@@ -18,6 +18,7 @@ from ....config import (
     Framework,
     StrEnum,
 )
+from ....tools.utils import cast_input_to_type
 
 
 class ModelVariant(StrEnum):
@@ -156,7 +157,7 @@ class ModelLoader(ForgeModel):
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             for key in inputs:
-                inputs[key] = inputs[key].to(dtype_override)
+                inputs[key] = cast_input_to_type(inputs[key], dtype_override)
 
         return inputs
 

--- a/llama/causal_lm/pytorch/loader.py
+++ b/llama/causal_lm/pytorch/loader.py
@@ -19,7 +19,7 @@ from ....config import (
     StrEnum,
 )
 from ....base import ForgeModel
-from ....tools.utils import pad_inputs
+from ....tools.utils import pad_inputs, cast_input_to_type
 
 
 class ModelVariant(StrEnum):
@@ -245,13 +245,8 @@ class ModelLoader(ForgeModel):
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
-            # Only cast when the override dtype category matches the tensor's category
-            override_is_float = dtype_override.is_floating_point
             for key in inputs:
-                if override_is_float and inputs[key].is_floating_point():
-                    inputs[key] = inputs[key].to(dtype_override)
-                elif (not override_is_float) and (not inputs[key].is_floating_point()):
-                    inputs[key] = inputs[key].to(dtype_override)
+                inputs[key] = cast_input_to_type(inputs[key], dtype_override)
 
         # Pad input_ids and attention_mask
         target_len = self._variant_config.max_length

--- a/phi3/causal_lm/pytorch/loader.py
+++ b/phi3/causal_lm/pytorch/loader.py
@@ -18,6 +18,7 @@ from ....config import (
     StrEnum,
 )
 from ....base import ForgeModel
+from ....tools.utils import cast_input_to_type
 
 
 class ModelVariant(StrEnum):
@@ -86,12 +87,7 @@ class ModelLoader(ForgeModel):
         input_ids = inputs["input_ids"]
         attn_mask = inputs["attention_mask"]
         if dtype_override is not None:
-
-            override_is_float = dtype_override.is_floating_point
-
-            if override_is_float == input_ids.is_floating_point():
-                input_ids = input_ids.to(dtype_override)
-            if override_is_float == attn_mask.is_floating_point():
-                attn_mask = attn_mask.to(dtype_override)
+            input_ids = cast_input_to_type(input_ids, dtype_override)
+            attn_mask = cast_input_to_type(attn_mask, dtype_override)
 
         return [input_ids, attn_mask]

--- a/phi3/seq_cls/pytorch/loader.py
+++ b/phi3/seq_cls/pytorch/loader.py
@@ -18,6 +18,7 @@ from ....config import (
     StrEnum,
 )
 from ....base import ForgeModel
+from ....tools.utils import cast_input_to_type
 
 
 class ModelVariant(StrEnum):
@@ -83,5 +84,5 @@ class ModelLoader(ForgeModel):
         inputs = self.tokenizer(input_prompt, return_tensors="pt")
         input_ids = inputs["input_ids"]
         if dtype_override is not None:
-            input_ids = input_ids.to(dtype_override)
+            input_ids = cast_input_to_type(input_ids, dtype_override)
         return [input_ids]

--- a/phi3/token_cls/pytorch/loader.py
+++ b/phi3/token_cls/pytorch/loader.py
@@ -18,6 +18,7 @@ from ....config import (
     StrEnum,
 )
 from ....base import ForgeModel
+from ....tools.utils import cast_input_to_type
 
 
 class ModelVariant(StrEnum):
@@ -77,5 +78,5 @@ class ModelLoader(ForgeModel):
         inputs = self.tokenizer(input_prompt, return_tensors="pt")
         input_ids = inputs["input_ids"]
         if dtype_override is not None:
-            input_ids = input_ids.to(dtype_override)
+            input_ids = cast_input_to_type(input_ids, dtype_override)
         return [input_ids]


### PR DESCRIPTION
### Ticket
None

### Problem description
- A few more models fail with int inputs being cast to float leading to "assert "int" in str(indices.get_dtype())"

### What's changed
 - Add new helper cast_input_to_type() to replaces repeated code in few models
 - Solves assert "int" in str(indices.get_dtype()) in few more models (gpt_neo, phi3), some of which are passing in tt-xla

### Checklist
- [x] Tested locally on affected/updated tt-xla models
