### PR TITLE
Initial tensor parallel changes get_mesh_config(), load_shard_spec() for falcon, gemma models

### DIFF
--- a/base.py
+++ b/base.py
@@ -174,3 +174,25 @@ class ForgeModel(ABC):
         """
         # Default implementation just returns outputs if present in kwargs
         return kwargs.get("outputs", None)
+
+    def get_mesh_shape(self, num_devices: int):
+        """Get the mesh shape for the model.
+
+        Args:
+            num_devices: Number of devices to distribute the model across
+
+        Returns:
+            tuple: Mesh shape tuple, or None if not applicable for this model
+        """
+        return None
+
+    def load_shard_spec(self, model):
+        """Load the shard spec of the model. Note: model needs to be on device first.
+
+        Args:
+            model: The model instance (should be on device)
+
+        Returns:
+            Dict[Tensor, Tuple(str, str)]: Shard specification object, or None if not applicable for this model
+        """
+        return None

--- a/base.py
+++ b/base.py
@@ -175,16 +175,16 @@ class ForgeModel(ABC):
         # Default implementation just returns outputs if present in kwargs
         return kwargs.get("outputs", None)
 
-    def get_mesh_shape(self, num_devices: int):
+    def get_mesh_config(self, num_devices: int):
         """Get the mesh shape for the model.
 
         Args:
             num_devices: Number of devices to distribute the model across
 
         Returns:
-            tuple: Mesh shape tuple, or None if not applicable for this model
+            tuple: Mesh shape tuple, mesh names tuple, or None if not applicable for this model
         """
-        return None
+        return None, ()
 
     def load_shard_spec(self, model):
         """Load the shard spec of the model. Note: model needs to be on device first.

--- a/gemma/pytorch/loader.py
+++ b/gemma/pytorch/loader.py
@@ -178,6 +178,9 @@ class ModelLoader(ForgeModel):
         return mesh_shape, ("batch", "model")
 
     def load_shard_spec(self, model):
+        if self._variant in [ModelVariant.GEMMA_1_1_2B_IT, ModelVariant.GEMMA_2B, ModelVariant.GEMMA_2_2B_IT]:
+            return None
+
         shard_specs = {}
         for layer in model.model.layers:
             shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")

--- a/gemma/pytorch/loader.py
+++ b/gemma/pytorch/loader.py
@@ -172,3 +172,20 @@ class ModelLoader(ForgeModel):
         inputs["input_ids"] = padded_input_ids
         inputs["attention_mask"] = padded_attention_mask
         return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        mesh_shape = (1, num_devices)
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+        for layer in model.model.layers:
+            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+
+            shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
+        return shard_specs


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/975

### Problem description
- Large models that will run on multichip topologies need shard specs and mesh configs defined in tt-forge-models to be used with shardy and spmd

### What's changed
- Create optional get_mesh_config() and load_shard_spec() APIs and populate them from gemma and falcon models to start for llmbox (t3k). 
- With these changes, 5 ModelGroup.RED tensor parallel model variants (3x falcon, 2x gemma) can pass.
- Will be improved and added to more models in the future, this is just initial changes to start.

### Checklist
- [x] Tested alongside upcoming changes in tt-xla
