### PR TITLE
Bringup MapTR's fusion & tiny_r50_av2_24e variant in pytorch

### DIFF
--- a/maptr/pytorch/loader.py
+++ b/maptr/pytorch/loader.py
@@ -19,7 +19,14 @@ from ...config import (
 )
 from ...base import ForgeModel
 from ...tools.utils import get_file
-from .src.maptr import build_model, model_cfg, gkt_cfg, lss_cfg
+from .src.maptr import (
+    build_model,
+    model_cfg,
+    gkt_cfg,
+    lss_cfg,
+    lidar_encoder_cfg,
+    fuser_cfg,
+)
 from mmcv import ConfigDict
 import numpy as np
 import copy
@@ -35,6 +42,8 @@ class ModelVariant(StrEnum):
     TINY_R50_24E_T4 = "tiny_r50_24e_t4"
     NANO_R18_110E = "nano_r18_110e"
     TINY_R50_24E_BEVPOOL = "tiny_r50_24e_bevpool"
+    TINY_FUSION_24E = "tiny_fusion_24e"
+    TINY_R50_24E_AV2 = "tiny_r50_24e_av2"
 
 
 class ModelLoader(ForgeModel):
@@ -62,6 +71,12 @@ class ModelLoader(ForgeModel):
         ),
         ModelVariant.TINY_R50_24E_BEVPOOL: ModelConfig(
             pretrained_model_name="tiny_r50_24e_bevpool",
+        ),
+        ModelVariant.TINY_FUSION_24E: ModelConfig(
+            pretrained_model_name="tiny_fusion_24e",
+        ),
+        ModelVariant.TINY_R50_24E_AV2: ModelConfig(
+            pretrained_model_name="tiny_r50_24e_av2",
         ),
     }
 
@@ -108,8 +123,11 @@ class ModelLoader(ForgeModel):
         # Get the variant name from the instance's variant config
         variant_name = self._variant_config.pretrained_model_name
 
-        # Get pretrained weights
-        model_path = str(get_file(f"test_files/pytorch/maptr/maptr_{variant_name}.pth"))
+        # Get pretrained weights (skip for AV2 variant as no weights are available)
+        if variant_name != "tiny_r50_24e_av2":
+            model_path = str(
+                get_file(f"test_files/pytorch/maptr/maptr_{variant_name}.pth")
+            )
 
         # Create deep copy to prevent global state contamination
         local_model_cfg = copy.deepcopy(model_cfg)
@@ -123,6 +141,8 @@ class ModelLoader(ForgeModel):
             "tiny_r50_110e",
             "tiny_r50_24e_t4",
             "nano_r18_110e",
+            "tiny_fusion_24e",
+            "tiny_r50_24e_av2",
         ]:
             local_model_cfg["pts_bbox_head"]["transformer"]["encoder"][
                 "transformerlayers"
@@ -177,29 +197,92 @@ class ModelLoader(ForgeModel):
                 "voxel_size"
             ] = bevpool_voxel_size
 
+        if variant_name == "tiny_fusion_24e":
+            # Fusion specific parameters
+            fusion_voxel_size = [0.1, 0.1, 0.2]
+
+            # Add fusion-specific configurations
+            local_model_cfg["modality"] = "fusion"
+            local_model_cfg["lidar_encoder"] = lidar_encoder_cfg
+            local_model_cfg["pts_bbox_head"]["transformer"]["modality"] = "fusion"
+            local_model_cfg["pts_bbox_head"]["transformer"]["fuser"] = fuser_cfg
+
+            # Override voxel size in lidar_encoder
+            local_model_cfg["lidar_encoder"]["voxelize"][
+                "voxel_size"
+            ] = fusion_voxel_size
+
+            # Override parameters in bbox_coder
+            local_model_cfg["pts_bbox_head"]["bbox_coder"][
+                "voxel_size"
+            ] = fusion_voxel_size
+
+        if variant_name == "tiny_r50_24e_av2":
+            # AV2 specific configurations
+            av2_point_cloud_range = [-30.0, -15.0, -2.0, 30.0, 15.0, 2.0]
+            av2_bev_h = 100
+            av2_bev_w = 200
+            av2_post_center_range = [-35, -20, -35, -20, 35, 20, 35, 20]
+
+            # Update point cloud range
+            local_model_cfg["pts_bbox_head"]["transformer"]["encoder"][
+                "pc_range"
+            ] = av2_point_cloud_range
+            local_model_cfg["pts_bbox_head"]["transformer"]["encoder"][
+                "transformerlayers"
+            ]["attn_cfgs"][1]["pc_range"] = av2_point_cloud_range
+            local_model_cfg["pts_bbox_head"]["bbox_coder"][
+                "pc_range"
+            ] = av2_point_cloud_range
+
+            # Update BEV dimensions
+            local_model_cfg["pts_bbox_head"]["bev_h"] = av2_bev_h
+            local_model_cfg["pts_bbox_head"]["bev_w"] = av2_bev_w
+            local_model_cfg["pts_bbox_head"]["positional_encoding"][
+                "row_num_embed"
+            ] = av2_bev_h
+            local_model_cfg["pts_bbox_head"]["positional_encoding"][
+                "col_num_embed"
+            ] = av2_bev_w
+
+            # Update post center range
+            local_model_cfg["pts_bbox_head"]["bbox_coder"][
+                "post_center_range"
+            ] = av2_post_center_range
+
+            # Set number of cameras to 7 for AV2
+            local_model_cfg["pts_bbox_head"]["transformer"]["num_cams"] = 7
+            local_model_cfg["pts_bbox_head"]["transformer"]["encoder"][
+                "transformerlayers"
+            ]["attn_cfgs"][1]["num_cams"] = 7
+            local_model_cfg["pts_bbox_head"]["transformer"]["encoder"][
+                "transformerlayers"
+            ]["attn_cfgs"][1]["pc_range"] = av2_point_cloud_range
+
         # wrap the model config
         self.cfg = ConfigDict(local_model_cfg)
 
         # Build model
         model = build_model(self.cfg)
 
-        # Load pretrained weights
-        load_checkpoint(model, model_path, map_location="cpu")
+        # Load pretrained weights (skip for AV2 variant as no weights are available)
+        if variant_name != "tiny_r50_24e_av2":
+            load_checkpoint(model, model_path, map_location="cpu")
         model.eval()
 
         return model
 
     def load_inputs(self):
-        """Prepare dummy sample inputs for the MAPTR model (NuScenes format).
+        """Prepare dummy sample inputs for the MAPTR model.
 
         This function creates synthetic test data mimicking the structure expected by
-        MAPTR when using the NuScenes dataset. It does not load real data, but instead
+        MAPTR for different datasets. It does not load real data, but instead
         generates placeholder inputs for testing purposes:
 
         - img_shape: List of image shapes, one per camera view.
         - lidar2img: List of 4x4 projection matrices (identity matrices here as placeholders).
         - can_bus: Vehicle state vector (zeros used as dummy values).
-        - img: Random image tensor simulating 6 camera views.
+        - img: Random image tensor simulating camera views (6 for NuScenes, 7 for AV2).
         - (bevpool variant only) camera2ego, camera_intrinsics, img_aug_matrix, lidar2ego:
           Identity matrices used as placeholders.
 
@@ -208,13 +291,19 @@ class ModelLoader(ForgeModel):
                 - ``img_metas`` (list): Metadata with image shapes, projection matrices,
                 CAN bus vector, and a dummy scene token (plus bevpool-specific fields when
                 using the tiny_r50_24e_bevpool variant).
-                - ``img`` (list): Randomized image tensor of shape (1, 6, 3, 480, 800).
+                - ``img`` (list): Randomized image tensor of shape (1, num_cams, 3, 480, 800)
+                  where num_cams is 6 for NuScenes variants and 7 for AV2 variants.
         """
 
-        img_shape = [(480, 800, 3)] * 6
-        lidar2img = [np.eye(4) for _ in range(6)]
+        # Determine number of cameras based on variant
+        num_cams = (
+            7 if self._variant_config.pretrained_model_name == "tiny_r50_24e_av2" else 6
+        )
+
+        img_shape = [(480, 800, 3)] * num_cams
+        lidar2img = [np.eye(4) for _ in range(num_cams)]
         can_bus = np.zeros(18, dtype=np.float64)
-        img = torch.randn(1, 6, 3, 480, 800)
+        img = torch.randn(1, num_cams, 3, 480, 800)
 
         data = {
             "img_metas": [
@@ -239,5 +328,8 @@ class ModelLoader(ForgeModel):
                     lidar2ego=np.eye(4, dtype=np.float32),
                 )
             )
+
+        if self._variant_config.pretrained_model_name == "tiny_fusion_24e":
+            data["points"] = [[torch.randn(196628, 5)]]
 
         return data


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-xla/issues/1144

### Problem description

Add support for below target variants 

- [maptr_tiny_fusion_24e](https://github.com/hustvl/MapTR/blob/main/projects/configs/maptr/maptr_tiny_fusion_24e.py)
- [maptr_tiny_r50_av2_24e](https://github.com/hustvl/MapTR/blob/main/projects/configs/maptr/maptr_tiny_r50_av2_24e.py)

### What's changed

Added support for above variants

#### maptr_tiny_fusion_24e
- Implemented [get_indice_pairs_3d](https://github.com/hustvl/MapTR/blob/a6872d8d9670bde17b4b01560f1221f88b443d55/mmdetection3d/mmdet3d/ops/spconv/ops.py#L87C53-L87C72), [indice_conv_fp32](https://github.com/hustvl/MapTR/blob/a6872d8d9670bde17b4b01560f1221f88b443d55/mmdetection3d/mmdet3d/ops/spconv/ops.py#L132C32-L132C48) in python (ported from C++).
- Validated results against the original CPU implementation using real inputs.
  - [sep24_fusion_org_cpu.log](https://github.com/user-attachments/files/22561760/sep24_fusion_org_cpu.log)
  - [sep26_maptr_fusion_our_impl.log](https://github.com/user-attachments/files/22562121/sep26_maptr_fusion_org_ip_with_filter.log)
   - [sep26_maptr_fusion_comp_org_vs_our_impl.log](https://github.com/user-attachments/files/22561720/sep26_maptr_fusion_comp_org_vs_my_cpu_with_filter.log)
  
#### maptr_tiny_r50_av2_24e

- No pretrained weights available for this variant in repo.
- core model architecture of [maptr_tiny_r50_24e](https://github.com/hustvl/MapTR/blob/main/projects/configs/maptr/maptr_tiny_r50_24e.py) & [maptr_tiny_r50_av2_24e](https://github.com/hustvl/MapTR/blob/main/projects/configs/maptr/maptr_tiny_r50_av2_24e.py) is same. 
- [Differences](https://www.diffchecker.com/78GGIfQ1/): Point Cloud Range, BEV Dimensions, Number of Cameras, Post Center Range, input dataset, and data preparation.
- Passing random inputs for now like other variants. model functionality verified. 
- Will prepare actual AV2 dataset inputs and compare results accordingly while passing actual inputs in future.

### Checklist
- [x] verified the changes on local testing

### Logs

- [sep26_maptr_fusion_rand_ip.log](https://github.com/user-attachments/files/22561911/sep26_maptr_fusion_rand_ip_f.log)
- [sep26_tiny_av2_rand_ip.log](https://github.com/user-attachments/files/22561917/sep26_tiny_av2_rand_ip.log)

