### PR TITLE
UNIAD Fix for tt-xla TorchRuntimeError

### DIFF
--- a/uniad/pytorch/src/planning_head.py
+++ b/uniad/pytorch/src/planning_head.py
@@ -204,7 +204,7 @@ class PlanningHeadSingleMode(nn.Module):
                 )
                 < self.occ_filter_range**2
             )
-            pos_xy_t.append(pos_xy[keep_index].cpu().detach().numpy())
+            pos_xy_t.append(pos_xy[keep_index].detach().numpy())
             valid_occupancy_num += torch.sum(keep_index > 0)
         if valid_occupancy_num == 0:
             return sdc_traj_all
@@ -212,7 +212,7 @@ class PlanningHeadSingleMode(nn.Module):
         col_optimizer = CollisionNonlinearOptimizer(
             self.planning_steps, 0.5, self.sigma, self.alpha_collision, pos_xy_t
         )
-        col_optimizer.set_reference_trajectory(sdc_traj_all[0].cpu().detach().numpy())
+        col_optimizer.set_reference_trajectory(sdc_traj_all[0].detach().numpy())
         sol = col_optimizer.solve()
         sdc_traj_optim = np.stack(
             [sol.value(col_optimizer.position_x), sol.value(col_optimizer.position_y)],

--- a/uniad/pytorch/src/uniad_e2e.py
+++ b/uniad/pytorch/src/uniad_e2e.py
@@ -119,13 +119,6 @@ class UniAD(UniADTrack):
         list[list[dict]]), with the outer list indicating test time
         augmentations.
         """
-        for k, v in kwargs.items():
-            if isinstance(v, torch.Tensor):
-                kwargs[k] = v.to("cpu")
-            elif isinstance(v, list):
-                kwargs[k] = [
-                    x.to("cpu") if isinstance(x, torch.Tensor) else x for x in v
-                ]
         return self.forward_test(**kwargs)
 
     def loss_weighted_and_prefixed(self, loss_dict, prefix=""):
@@ -156,20 +149,6 @@ class UniAD(UniADTrack):
             if not isinstance(var, list):
                 raise TypeError("{} must be a list, but got {}".format(name, type(var)))
         img = [img] if img is None else img
-
-        if img_metas[0][0]["scene_token"] != self.prev_frame_info["scene_token"]:
-            self.prev_frame_info["prev_bev"] = None
-        self.prev_frame_info["scene_token"] = img_metas[0][0]["scene_token"]
-
-        self.prev_frame_info["prev_bev"] = None
-
-        tmp_pos = copy.deepcopy(img_metas[0][0]["can_bus"][:3])
-        tmp_angle = copy.deepcopy(img_metas[0][0]["can_bus"][-1])
-        img_metas[0][0]["can_bus"][:3] -= self.prev_frame_info["prev_pos"]
-        img_metas[0][0]["can_bus"][-1] -= self.prev_frame_info["prev_angle"]
-        self.prev_frame_info["prev_pos"] = tmp_pos
-        self.prev_frame_info["prev_angle"] = tmp_angle
-
         img = img[0]
         img_metas = img_metas[0]
         timestamp = timestamp[0] if timestamp is not None else None

--- a/uniad/pytorch/src/uniad_track.py
+++ b/uniad/pytorch/src/uniad_track.py
@@ -610,19 +610,19 @@ class UniADTrack(MVXTwoStageDetector):
         obj_idxes = bboxes_dict["obj_idxes"]
         result_dict = dict(
             boxes_3d=bboxes,
-            scores_3d=scores.cpu(),
-            labels_3d=labels.cpu(),
-            track_scores=track_scores.cpu(),
-            bbox_index=bbox_index.cpu(),
-            track_ids=obj_idxes.cpu(),
-            mask=bboxes_dict["mask"].cpu(),
+            scores_3d=scores,
+            labels_3d=labels,
+            track_scores=track_scores,
+            bbox_index=bbox_index,
+            track_ids=obj_idxes,
+            mask=bboxes_dict["mask"],
             track_bbox_results=[
                 [
                     bboxes,
-                    scores.cpu(),
-                    labels.cpu(),
-                    bbox_index.cpu(),
-                    bboxes_dict["mask"].cpu(),
+                    scores,
+                    labels,
+                    bbox_index,
+                    bboxes_dict["mask"],
                 ]
             ],
         )
@@ -663,8 +663,8 @@ class UniADTrack(MVXTwoStageDetector):
         result_dict = results[0]
         result_dict_det = dict(
             boxes_3d_det=bboxes,
-            scores_3d_det=scores.cpu(),
-            labels_3d_det=labels.cpu(),
+            scores_3d_det=scores,
+            labels_3d_det=labels,
         )
         result_dict.update(result_dict_det)
         return [result_dict]


### PR DESCRIPTION
### Ticket
[tt-xla PR](https://github.com/tenstorrent/tt-xla/pull/1432)

### Problem description
While testing in tt-xla with the [UNIAD PR](https://github.com/tenstorrent/tt-forge-models/pull/155) changes the model is failed with error - torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors

### What's changed
I have debugged and fixed the issue in this PR. After applying this fix, in the tt-xla I got "Out of Memory: Not enough space to allocate 285081600 B L1 buffer across 64 banks, where each bank needs to store 4454400 B, but bank size is only 1366560 B"

### Checklist
- [ ] New/Existing tests provide coverage for changes
