### PR TITLE
add jax model for alexnet and mnist mlp multimodel

### DIFF
--- a/alexnet/image_classification/jax/__init__.py
+++ b/alexnet/image_classification/jax/__init__.py
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .loader import ModelLoader, ModelVariant
-from .src import AlexNetModel, LocalResponseNormalization
+from .src import AlexNetModel, AlexNetMultichipModel, LocalResponseNormalization

--- a/alexnet/image_classification/jax/src/__init__.py
+++ b/alexnet/image_classification/jax/src/__init__.py
@@ -2,4 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from .model_implementation import AlexNetModel, LocalResponseNormalization
+from .model_implementation import (
+    AlexNetModel,
+    AlexNetMultichipModel,
+    LocalResponseNormalization,
+)

--- a/alexnet/image_classification/jax/src/model_implementation.py
+++ b/alexnet/image_classification/jax/src/model_implementation.py
@@ -100,6 +100,151 @@ class AlexNetModel(nn.Module):
         return x
 
 
+class AlexNetMultichipModel(nn.Module):
+    """
+    JAX multichip implementation of the AlexNet model originally introduced by
+    Alex Krizhevsky in papers:
+      - "ImageNet Classification with Deep Convolutional Neural Networks"
+        (https://papers.nips.cc/paper_files/paper/2012/file/c399862d3b9d6b76c8436e924a68c45b-Paper.pdf)
+      - "One weird trick for parallelizing convolutional neural networks"
+        (https://arxiv.org/abs/1404.5997)
+    """
+
+    axis_name: str
+    num_devices: int
+    train_mode: bool
+    param_dtype: Optional[
+        Union[str, type[Any], jnp.dtype, jax._src.typing.SupportsDType, Any]
+    ] = jnp.bfloat16
+
+    @nn.compact
+    def __call__(self, x: jax.Array) -> jax.Array:
+        # Utilizing data parallelism for the Convolutional layers since their
+        # parameters tensors are too small so the overhead of inter-device
+        # communication outweighs the benefit of tensor parallelism. We don't
+        # need to explicitely state the parameters partitioning because
+        # replication is assumed by default.
+
+        scaled_kernel_init = nn.initializers.variance_scaling(
+            scale=0.5, mode="fan_in", distribution="truncated_normal"
+        )
+
+        # First feature extraction layer
+        x = nn.Conv(
+            features=64,
+            kernel_size=(11, 11),
+            strides=(4, 4),
+            padding=0,
+            param_dtype=self.param_dtype,
+            kernel_init=scaled_kernel_init,
+        )(x)
+        x = nn.relu(x)
+        x = nn.max_pool(x, window_shape=(3, 3), strides=(2, 2))
+
+        # Second feature extraction layer
+        x = nn.Conv(
+            features=192,
+            kernel_size=(5, 5),
+            strides=(1, 1),
+            padding=2,
+            param_dtype=self.param_dtype,
+            kernel_init=scaled_kernel_init,
+        )(x)
+        x = nn.relu(x)
+        x = nn.max_pool(x, window_shape=(3, 3), strides=(2, 2))
+
+        # Third feature extraction layer
+        x = nn.Conv(
+            features=384,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding=1,
+            param_dtype=self.param_dtype,
+            kernel_init=scaled_kernel_init,
+        )(x)
+        x = nn.relu(x)
+
+        # Fourth feature extraction layer
+        x = nn.Conv(
+            features=256,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding=1,
+            param_dtype=self.param_dtype,
+            kernel_init=scaled_kernel_init,
+        )(x)
+        x = nn.relu(x)
+
+        # Fifth feature extraction layer
+        x = nn.Conv(
+            features=256,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding=1,
+            param_dtype=self.param_dtype,
+            kernel_init=scaled_kernel_init,
+        )(x)
+        x = nn.relu(x)
+        x = nn.max_pool(x, window_shape=(3, 3), strides=(2, 2))
+
+        # Flatten
+        x = x.reshape((x.shape[0], -1))
+
+        # Gather features from all devices (sub-batches)
+        x = jax.lax.all_gather(x, self.axis_name, tiled=True)
+
+        # Utilizing tensor parallelism for Dense layers.
+        dense_kernel_init = nn.with_partitioning(
+            scaled_kernel_init,
+            (None, self.axis_name),
+        )
+        dense_bias_init = nn.with_partitioning(
+            nn.linear.initializers.ones_init(), (self.axis_name)
+        )
+
+        # First classifier layer
+        x = nn.Dense(
+            features=4096 // self.num_devices,
+            param_dtype=self.param_dtype,
+            kernel_init=dense_kernel_init,
+            bias_init=dense_bias_init,
+        )(x)
+        x = nn.relu(x)
+        x = nn.Dropout(rate=0.5)(x, deterministic=not self.train_mode)
+
+        # Gather results from all devices
+        x = jax.lax.all_gather(x, self.axis_name, axis=1, tiled=True)
+
+        # Second classifier layer
+        x = nn.Dense(
+            features=4096 // self.num_devices,
+            param_dtype=self.param_dtype,
+            kernel_init=dense_kernel_init,
+            bias_init=dense_bias_init,
+        )(x)
+        x = nn.relu(x)
+        x = nn.Dropout(rate=0.5)(x, deterministic=not self.train_mode)
+
+        # Gather results from all devices
+        x = jax.lax.all_gather(x, self.axis_name, axis=1, tiled=True)
+
+        # Third classifier layer
+        x = nn.Dense(
+            features=1000 // self.num_devices,
+            param_dtype=self.param_dtype,
+            kernel_init=dense_kernel_init,
+            bias_init=dense_bias_init,
+        )(x)
+
+        # Gather results from all devices
+        x = jax.lax.all_gather(x, self.axis_name, axis=1, tiled=True)
+
+        # Calculate probabilities
+        x = nn.softmax(x)
+
+        return x
+
+
 class LocalResponseNormalization(nn.Module):
     """Local response normalization layer per original paper implementation."""
 

--- a/mnist/image_classification/jax/__init__.py
+++ b/mnist/image_classification/jax/__init__.py
@@ -3,3 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .loader import ModelLoader, ModelVariant
+from .mlp.model_implementation import MNISTMLPModel, MNISTMLPMultichipModel
+from .cnn_batchnorm.model_implementation import MNISTCNNBatchNormModel
+from .cnn_dropout.model_implementation import MNISTCNNDropoutModel

--- a/mnist/image_classification/jax/loader.py
+++ b/mnist/image_classification/jax/loader.py
@@ -20,7 +20,7 @@ from ....config import (
     Framework,
     StrEnum,
 )
-from .mlp.model_implementation import MNISTMLPModel
+from .mlp.model_implementation import MNISTMLPModel, MNISTMLPMultichipModel
 from .cnn_batchnorm.model_implementation import MNISTCNNBatchNormModel
 from .cnn_dropout.model_implementation import MNISTCNNDropoutModel
 

--- a/mnist/image_classification/jax/mlp/model_implementation.py
+++ b/mnist/image_classification/jax/mlp/model_implementation.py
@@ -2,7 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any, Optional, Union
+
 import jax
+import jax.numpy as jnp
 from flax import linen as nn
 
 
@@ -19,6 +22,48 @@ class MNISTMLPModel(nn.Module):
             x = nn.Dense(features=h)(x)
             x = nn.relu(x)
 
+        x = nn.Dense(features=10)(x)
+        x = nn.softmax(x)
+
+        return x
+
+
+class MNISTMLPMultichipModel(nn.Module):
+    """MNIST MLP multichip model implementation with tensor parallelism."""
+
+    hidden_sizes: tuple[int]
+    axis_name: str
+    num_devices: int
+    train_mode: bool
+    param_dtype: Optional[
+        Union[str, type[Any], jnp.dtype, jax._src.typing.SupportsDType, Any]
+    ] = jnp.bfloat16
+
+    @nn.compact
+    def __call__(self, x):
+        x = x.reshape((x.shape[0], -1))
+
+        # Utilizing tensor parallelism for large Dense layers.
+        dense_kernel_init = nn.with_partitioning(
+            nn.linear.default_kernel_init,
+            (None, self.axis_name),
+        )
+        dense_bias_init = nn.with_partitioning(
+            nn.linear.initializers.ones_init(), (self.axis_name)
+        )
+
+        for hidden_size in self.hidden_sizes:
+            x = nn.Dense(
+                features=hidden_size // self.num_devices,
+                param_dtype=self.param_dtype,
+                kernel_init=dense_kernel_init,
+                bias_init=dense_bias_init,
+            )(x)
+            x = nn.relu(x)
+            # Gather results from all devices
+            x = jax.lax.all_gather(x, self.axis_name, axis=1, tiled=True)
+
+        # Final layer is pretty small so no point in parallelizing it.
         x = nn.Dense(features=10)(x)
         x = nn.softmax(x)
 


### PR DESCRIPTION
### Problem description
The implementation and tester files for the AlexNet and MNIST_MLP models need to be moved to the tt_forge/models directory.

### What's changed
The AlexNet and MNIST_MLP model implementation and tester files have been moved to the tt_forge/models directory.

### Checklist
- [x] New/Existing tests provide coverage for changes
