### PR TITLE
Add llama sequence classification padding token

### DIFF
--- a/llama/sequence_classification/pytorch/loader.py
+++ b/llama/sequence_classification/pytorch/loader.py
@@ -199,10 +199,6 @@ class ModelLoader(ForgeModel):
         )
         model.eval()
 
-        # Resize token embeddings if we added a new pad token
-        if len(self.tokenizer) > model.config.vocab_size:
-            model.resize_token_embeddings(len(self.tokenizer))
-
         # Set pad token id in model config
         model.config.pad_token_id = self.tokenizer.pad_token_id
         self.model = model


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When trying to run this model with a batch size > 1 it fails with the following error:
```
E           ValueError: Cannot handle batch sizes > 1 if no padding token is defined.
```
[(see CI failure here)](https://github.com/tenstorrent/tt-xla/actions/runs/18408437182/job/52454701139#step:16:4206)

### What's changed
Added a padding token to the tokenizer and model config (following[ Huggingface notes](https://huggingface.co/docs/transformers/model_doc/llama2#notes)).

### Checklist
- [ ] New/Existing tests provide coverage for changes
