### PR TITLE
Bringup Qwen2.5-VL-3B-Instruct pytorch model

### DIFF
--- a/config.py
+++ b/config.py
@@ -66,6 +66,7 @@ class ModelTask(StrEnum):
     MM_MASKED_LM = "mm_masked_lm"
     MM_CAUSAL_LM = "mm_causal_lm"
     MM_ACTION_PREDICTION = "mm_action_prediction"
+    MM_CONDITIONAL_GENERATION = "mm_conditional_generation"
     CONDITIONAL_GENERATION = "conditional_generation"
     ATOMIC_ML = "atomic_ml"
 

--- a/qwen_2_5_vl/pytorch/__init__.py
+++ b/qwen_2_5_vl/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Qwen 2.5 VL PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/qwen_2_5_vl/pytorch/loader.py
+++ b/qwen_2_5_vl/pytorch/loader.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 2.5 VL model loader implementation for vision-language tasks.
+"""
+from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor
+from typing import Optional
+from qwen_vl_utils import process_vision_info
+
+from ...base import ForgeModel
+from ...config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from .src.model import Wrapper
+
+
+class ModelVariant(StrEnum):
+    """Available Qwen 2.5 VL model variants for vision-language tasks."""
+
+    QWEN_2_5_VL_3B_INSTRUCT = "3b_instruct"
+
+
+class ModelLoader(ForgeModel):
+    """Qwen 2.5 VL model loader implementation for vision-language tasks."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.QWEN_2_5_VL_3B_INSTRUCT: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen2.5-VL-3B-Instruct",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.QWEN_2_5_VL_3B_INSTRUCT
+
+    # Shared configuration parameters
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+                },
+                {"type": "text", "text": "Describe this image."},
+            ],
+        }
+    ]
+
+    # Vision processing parameters
+    min_pixels = 56 * 56
+    max_pixels = 13 * 28 * 1280
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.processor = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        return ModelInfo(
+            model="qwen_2_5_vl",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.MM_CONDITIONAL_GENERATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_processor(self):
+        """Load processor for the current variant.
+
+        Returns:
+            The loaded processor instance
+        """
+        # Initialize processor with vision parameters
+        processor_kwargs = {
+            "min_pixels": self.min_pixels,
+            "max_pixels": self.max_pixels,
+        }
+
+        # Load the processor
+        self.processor = AutoProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name, **processor_kwargs
+        )
+
+        return self.processor
+
+    def load_model(self, dtype_override=None):
+        """Load and return the Qwen 2.5 VL model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Wrapped Qwen 2.5 VL model instance for vision-language tasks.
+        """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        model_kwargs = {"low_cpu_mem_usage": True, "use_cache": False}
+
+        # Load the model with dtype override if specified
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+        model.eval()
+        model = Wrapper(model)
+
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Load and return sample inputs for the Qwen 2.5 VL model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+                           If specified, converts pixel_values to the specified dtype.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        # Ensure processor is initialized
+        if self.processor is None:
+            self._load_processor()
+
+        # Apply chat template to get text prompt
+        text = self.processor.apply_chat_template(
+            self.messages, tokenize=False, add_generation_prompt=True
+        )
+
+        # Process vision inputs
+        image_inputs, video_inputs = process_vision_info(self.messages)
+
+        # Process all inputs together
+        inputs = self.processor(
+            text=[text],
+            images=image_inputs,
+            videos=video_inputs,
+            padding=True,
+            return_tensors="pt",
+        )
+
+        # Convert pixel_values to specified dtype if provided
+        if dtype_override is not None:
+            inputs["pixel_values"] = inputs["pixel_values"].to(dtype_override)
+
+        return inputs

--- a/qwen_2_5_vl/pytorch/src/model.py
+++ b/qwen_2_5_vl/pytorch/src/model.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Qwen 2.5 VL model wrapper for extracting logits from model outputs.
+"""
+
+import torch
+
+# https://github.com/tenstorrent/tt-xla/issues/1661
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, attention_mask, pixel_values, image_grid_thw):
+        inputs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+        }
+        outputs = self.model(**inputs)
+        return outputs.logits


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1529

### Problem description
- Bringup Qwen2.5-VL-3B-Instruct pytorch model

### What's changed

- This PR adds support for Qwen2.5-VL-3B-Instruct pytorch model
- Fixes [#Issue-1661](https://github.com/tenstorrent/tt-xla/issues/1661) by wrapping a model with wrapper to return logits alone.
- Note : max_pixels set to 13x28x1280 due to [#Issue-1659](https://github.com/tenstorrent/tt-xla/issues/1659)

### Checklist
- [x] verified the functionality through local testing

### Logs

- [oct12_qwen_2_5_vl_3b_xla.log](https://github.com/user-attachments/files/22870269/oct12_qwen_2_5_3b_xla.log)

