### PR TITLE
Add support for BEVFormer-Small, BEVFormer-Base, and BEVFormerV2 variants

### DIFF
--- a/bevformer/pytorch/loader.py
+++ b/bevformer/pytorch/loader.py
@@ -5,18 +5,26 @@
 BEVFormer model loader implementation
 """
 import torch
-import numpy as np
 from typing import Optional
 from ...base import ForgeModel
-from ...config import ModelGroup, ModelTask, ModelSource, Framework, StrEnum, ModelInfo
+from ...config import (
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    ModelInfo,
+    ModelConfig,
+)
+
 from .src.model import (
     BEVFormer,
-    img_backbone,
-    pts_bbox_head,
-    img_neck,
+    BEVFormerV2,
+    get_bevformer_model,
+    get_bevformer_v2_model,
     load_checkpoint_bev,
 )
-from .src.model_utils import generate_random_lidar2img, generate_random_can_bus
+from .src.model_utils import build_inputs
 from ...tools.utils import get_file
 
 
@@ -24,11 +32,40 @@ class ModelVariant(StrEnum):
     """Available BEVFormer model variants."""
 
     BEVFORMER_TINY = "BEVFormer-tiny"
+    BEVFORMER_SMALL = "BEVFormer-small"
+    BEVFORMER_BASE = "BEVFormer-base"
+    BEVFORMER_V2_R50_T1_BASE = "bevformerv2-r50-t1-base"
+    BEVFORMER_V2_R50_T1 = "bevformerv2-r50-t1"
+    BEVFORMER_V2_R50_T2 = "bevformerv2-r50-t2"
+    BEVFORMER_V2_R50_T8 = "bevformerv2-r50-t8"
 
 
 class ModelLoader(ForgeModel):
     """BEVFormer model loader implementation for autonomous driving tasks."""
 
+    _VARIANTS = {
+        ModelVariant.BEVFORMER_TINY: ModelConfig(
+            pretrained_model_name="BEVFormer-tiny"
+        ),
+        ModelVariant.BEVFORMER_SMALL: ModelConfig(
+            pretrained_model_name="BEVFormer-small"
+        ),
+        ModelVariant.BEVFORMER_BASE: ModelConfig(
+            pretrained_model_name="BEVFormer-base"
+        ),
+        ModelVariant.BEVFORMER_V2_R50_T1_BASE: ModelConfig(
+            pretrained_model_name="bevformerv2-r50-t1-base"
+        ),
+        ModelVariant.BEVFORMER_V2_R50_T1: ModelConfig(
+            pretrained_model_name="bevformerv2-r50-t1"
+        ),
+        ModelVariant.BEVFORMER_V2_R50_T2: ModelConfig(
+            pretrained_model_name="bevformerv2-r50-t2"
+        ),
+        ModelVariant.BEVFORMER_V2_R50_T8: ModelConfig(
+            pretrained_model_name="bevformerv2-r50-t8"
+        ),
+    }
     # Default variant to use
     DEFAULT_VARIANT = ModelVariant.BEVFORMER_TINY
 
@@ -61,22 +98,75 @@ class ModelLoader(ForgeModel):
             framework=Framework.TORCH,
         )
 
-    def load_model(self, **kwargs):
+    def load_model(self, variant: Optional["ModelVariant"] = None, **kwargs):
         """Load and return the BEVFormer model instance with default settings.
         Returns:
             Torch model: The BEVFormer model instance.
         """
-        # Load model with defaults
-        model = BEVFormer(
-            img_backbone=img_backbone,
-            pts_bbox_head=pts_bbox_head,
-            img_neck=img_neck,
-            use_grid_mask=True,
-            video_test_mode=True,
-        )
-        checkpoint_path = str(
-            get_file("test_files/pytorch/bevformer/bevformer_tiny_epoch_24.pth")
-        )
+        variant_str = str(self._variant) if self._variant else str(self.DEFAULT_VARIANT)
+        if (
+            variant_str == ModelVariant.BEVFORMER_V2_R50_T1_BASE.value
+            or variant_str == ModelVariant.BEVFORMER_V2_R50_T1.value
+            or variant_str == ModelVariant.BEVFORMER_V2_R50_T2.value
+            or variant_str == ModelVariant.BEVFORMER_V2_R50_T8.value
+        ):
+            (
+                img_backbone,
+                pts_bbox_head,
+                img_neck,
+                fcos3d_bbox_head,
+                frames,
+            ) = get_bevformer_v2_model(variant_str)
+            model = BEVFormerV2(
+                img_backbone=img_backbone,
+                pts_bbox_head=pts_bbox_head,
+                img_neck=img_neck,
+                fcos3d_bbox_head=fcos3d_bbox_head,
+                frames=frames,
+                use_grid_mask=True,
+                video_test_mode=False,
+                num_levels=4,
+                num_mono_levels=5,
+            )
+        else:
+            img_backbone, pts_bbox_head, img_neck = get_bevformer_model(variant_str)
+            model = BEVFormer(
+                img_backbone=img_backbone,
+                pts_bbox_head=pts_bbox_head,
+                img_neck=img_neck,
+                use_grid_mask=True,
+                video_test_mode=True,
+            )
+        if variant_str == ModelVariant.BEVFORMER_SMALL.value:
+            checkpoint_path = str(
+                get_file("test_files/pytorch/bevformer/bevformer_small_epoch_24.pth")
+            )
+        elif variant_str == ModelVariant.BEVFORMER_BASE.value:
+            checkpoint_path = str(
+                get_file("test_files/pytorch/bevformer/bevformer_r101_dcn_24ep.pth")
+            )
+        elif variant_str == ModelVariant.BEVFORMER_V2_R50_T1_BASE.value:
+            checkpoint_path = str(
+                get_file(
+                    "test_files/pytorch/bevformer/bevformerv2_t1_base_epoch_24.pth"
+                )
+            )
+        elif variant_str == ModelVariant.BEVFORMER_V2_R50_T1.value:
+            checkpoint_path = str(
+                get_file("test_files/pytorch/bevformer/bevformerv2_r50_t1_epoch_24.pth")
+            )
+        elif variant_str == ModelVariant.BEVFORMER_V2_R50_T2.value:
+            checkpoint_path = str(
+                get_file("test_files/pytorch/bevformer/bevformerv2_r50_t2_epoch_24.pth")
+            )
+        elif variant_str == ModelVariant.BEVFORMER_V2_R50_T8.value:
+            checkpoint_path = str(
+                get_file("test_files/pytorch/bevformer/bevformerv2_r50_t8_epoch_24.pth")
+            )
+        else:
+            checkpoint_path = str(
+                get_file("test_files/pytorch/bevformer/bevformer_tiny_epoch_24.pth")
+            )
         checkpoint = load_checkpoint_bev(
             model,
             checkpoint_path,
@@ -85,37 +175,62 @@ class ModelLoader(ForgeModel):
         model.eval()
         return model
 
-    def load_inputs(self, **kwargs):
+    def load_inputs(self, variant: Optional["ModelVariant"] = None, **kwargs):
         """Return sample inputs for the BEVFormer model with default settings.
         Returns:
             dict: A dictionary of input tensors and metadata suitable for the model.
         """
 
-        img_shapes = [
-            (480, 800, 3),
-            (480, 800, 3),
-            (480, 800, 3),
-            (480, 800, 3),
-            (480, 800, 3),
-            (480, 800, 3),
-        ]
-        lidar2img = generate_random_lidar2img()
+        inputs_dict = build_inputs()
+        variant_str = str(self._variant) if self._variant else str(self.DEFAULT_VARIANT)
+        if (
+            variant_str == ModelVariant.BEVFORMER_V2_R50_T1_BASE.value
+            or variant_str == ModelVariant.BEVFORMER_V2_R50_T1.value
+            or variant_str == ModelVariant.BEVFORMER_V2_R50_T2.value
+            or variant_str == ModelVariant.BEVFORMER_V2_R50_T8.value
+        ):
+            img = torch.randn(1, 6, 3, 640, 1600)
+            img_metas = {
+                "img_shape": inputs_dict["img_shapes"],
+                "lidar2img": inputs_dict["lidar2img"],
+                "lidar2cam": inputs_dict["lidar2cam"],
+                "pad_shape": inputs_dict["pad_shape"],
+                "scale_factor": 1.0,
+                "flip": False,
+                "pcd_horizontal_flip": False,
+                "pcd_vertical_flip": False,
+                "img_norm_cfg": inputs_dict["img_norm_cfg"],
+                "sample_idx": "3e8750f331d7499e9b5123e9eb70f2e2",
+                "prev_idx": "",
+                "next_idx": "3950bd41f74548429c0f7700ff3d8269",
+                "pcd_scale_factor": 1.0,
+                "scene_token": "fcbccedd61424f1b85dcbf8f897f9754",
+            }
+            input_dict = {
+                "rescale": True,
+                "img_metas": [[{0: img_metas}]],
+                "img": [img],
+                "ego2global_translation": inputs_dict["ego2global_translation"],
+                "ego2global_rotation": inputs_dict["ego2global_rotation"],
+                "lidar2ego_translation": inputs_dict["lidar2ego_translation"],
+                "lidar2ego_rotation": inputs_dict["lidar2ego_rotation"],
+            }
+        else:
+            img = torch.randn(1, 6, 3, 480, 800)
+            img_metas = {
+                "img_shape": inputs_dict["img_shapes"],
+                "lidar2img": inputs_dict["lidar2img"],
+                "scale_factor": 1.0,
+                "flip": False,
+                "pcd_horizontal_flip": False,
+                "pcd_vertical_flip": False,
+                "sample_idx": "3e8750f331d7499e9b5123e9eb70f2e2",
+                "prev_idx": "",
+                "next_idx": "3950bd41f74548429c0f7700ff3d8269",
+                "pcd_scale_factor": 1.0,
+                "scene_token": "fcbccedd61424f1b85dcbf8f897f9754",
+                "can_bus": inputs_dict["can_bus"],
+            }
+            input_dict = {"rescale": True, "img_metas": [[img_metas]], "img": [img]}
 
-        can_bus = generate_random_can_bus()
-        img = torch.randn(1, 6, 3, 480, 800)
-        img_metas = {
-            "img_shape": img_shapes,
-            "lidar2img": lidar2img,
-            "scale_factor": 1.0,
-            "flip": False,
-            "pcd_horizontal_flip": False,
-            "pcd_vertical_flip": False,
-            "sample_idx": "3e8750f331d7499e9b5123e9eb70f2e2",
-            "prev_idx": "",
-            "next_idx": "3950bd41f74548429c0f7700ff3d8269",
-            "pcd_scale_factor": 1.0,
-            "scene_token": "fcbccedd61424f1b85dcbf8f897f9754",
-            "can_bus": can_bus,
-        }
-        input_dict = {"rescale": True, "img_metas": [[img_metas]], "img": [img]}
         return input_dict

--- a/bevformer/pytorch/src/model_utils.py
+++ b/bevformer/pytorch/src/model_utils.py
@@ -18,6 +18,20 @@ def generate_random_lidar2img(n=6):
     return lidar2img
 
 
+def generate_random_lidar2cam(n=6):
+    lidar2cam = []
+    for _ in range(n):
+        rot = np.random.uniform(-1.0, 1.0, size=(3, 3))
+        rot, _ = np.linalg.qr(rot)
+        trans = np.random.uniform(-1.0, 1.0, size=(3, 1))
+        top = np.hstack((rot, trans))
+        bottom = np.array([[0, 0, 0, 1]], dtype=np.float32)
+        lidar2cam_matrix = np.vstack((top, bottom)).astype(np.float32)
+        lidar2cam.append(lidar2cam_matrix)
+
+    return lidar2cam
+
+
 def generate_random_can_bus():
     can_bus = np.array(
         [
@@ -39,7 +53,7 @@ def generate_random_can_bus():
     return can_bus
 
 
-def build_random_inputs():
+def build_inputs():
 
     img_shapes = [
         (480, 800, 3),
@@ -50,13 +64,73 @@ def build_random_inputs():
         (480, 800, 3),
     ]
     lidar2img = generate_random_lidar2img()
-
     can_bus = generate_random_can_bus()
+    lidar2cam = generate_random_lidar2cam()
     img = torch.randn(1, 6, 3, 480, 800)
+    img_shapes = [
+        (480, 800, 3),
+        (480, 800, 3),
+        (480, 800, 3),
+        (480, 800, 3),
+        (480, 800, 3),
+        (480, 800, 3),
+    ]
+    pad_shape = [
+        (640, 1600, 3),
+        (640, 1600, 3),
+        (640, 1600, 3),
+        (640, 1600, 3),
+        (640, 1600, 3),
+        (640, 1600, 3),
+    ]
+    img_norm_cfg = {
+        "mean": np.array([103.53, 116.28, 123.675], dtype=np.float32),
+        "std": np.array([1.0, 1.0, 1.0], dtype=np.float32),
+        "to_rgb": False,
+    }
+    ego2global_translation = [
+        [
+            torch.tensor([600.1202], dtype=torch.float64),
+            torch.tensor([1647.4908], dtype=torch.float64),
+            torch.tensor([0.0], dtype=torch.float64),
+        ]
+    ]
+    ego2global_rotation = [
+        [
+            torch.tensor([-0.9687], dtype=torch.float64),
+            torch.tensor([-0.0040], dtype=torch.float64),
+            torch.tensor([-0.0077], dtype=torch.float64),
+            torch.tensor([0.2482], dtype=torch.float64),
+        ]
+    ]
+    lidar2ego_translation = [
+        [
+            torch.tensor([0.9858], dtype=torch.float64),
+            torch.tensor([0.0], dtype=torch.float64),
+            torch.tensor([1.8402], dtype=torch.float64),
+        ]
+    ]
+    lidar2ego_rotation = [
+        [
+            torch.tensor([0.7067], dtype=torch.float64),
+            torch.tensor([-0.0153], dtype=torch.float64),
+            torch.tensor([0.0174], dtype=torch.float64),
+            torch.tensor([-0.7071], dtype=torch.float64),
+        ]
+    ]
+    timestamp = [torch.tensor([1.5332e09], dtype=torch.float64)]
 
     return {
         "can_bus": can_bus,
         "lidar2img": lidar2img,
+        "lidar2cam": lidar2cam,
         "img_shapes": img_shapes,
         "img": img,
+        "pad_shape": pad_shape,
+        "img_norm_cfg": img_norm_cfg,
+        "ego2global_translation": ego2global_translation,
+        "ego2global_rotation": ego2global_rotation,
+        "lidar2ego_translation": lidar2ego_translation,
+        "lidar2ego_rotation": lidar2ego_rotation,
+        "timestamp": timestamp,
     }


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-xla/issues/1139

### Problem description

- Add support for **BEVFormer** model remaining variants. 

### What's changed

- This PR adds support for below bevformer variants
   a. BEVFormer-small
   b. BEVFormer-base
   c. BEVFormer2-r50-t1-base
   d.BEVFormerv2-r50-t1
   e.BEVFormerv2-r50-t2
   f.BEVFormerv2-r50-t8

- Required additional classes like BEVFormerV2, PerceptionTransformerV2, PerceptionTransformerBEVEncoder, ResNetFusion, BEVFormerHead_GroupDETR for supporting BEVFormerV2 variants were added. 

- Helper functions like get_bevformer_v2_model and BEVFormerBaseConfig class was created to build and return config dicts specific to each variant.

Logs:
[bevformer_xla_all_variants.log](https://github.com/user-attachments/files/22919010/bevformer_xla_all_variants.log)

