### PR TITLE
Fix PCC drop in YOLOv10 by disabling end2end mode

### DIFF
--- a/yolov10/pytorch/loader.py
+++ b/yolov10/pytorch/loader.py
@@ -102,6 +102,11 @@ class ModelLoader(ForgeModel):
         )
         model = DetectionModel(cfg=weights["model"].yaml)
         model.load_state_dict(weights["model"].float().state_dict())
+
+        # https://github.com/tenstorrent/tt-xla/issues/1692
+        model.end2end = False
+        model.model[-1].end2end = False
+
         model.eval()
 
         # Only convert dtype if explicitly requested


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1195
- https://github.com/tenstorrent/tt-xla/issues/1692

### Problem description

- PCC drop observed in yolov10n & yolov10x due to topk operation [oct14_yolov10n.log](https://github.com/user-attachments/files/22921595/oct14_yolov10n.log) , [oct14_yolov10x.log](https://github.com/user-attachments/files/22921596/oct14_yolov10x.log)

### What's changed

- [Topk](https://github.com/ultralytics/ultralytics/blob/42d15b69de1de90a66c91edc0bb0fc7f1a3c0bf8/ultralytics/nn/modules/head.py#L226C36-L226C67) is invoked within the postprocess function, which runs only when the end2end attribute is True. 
- In YOLOv10, the detect head explicitly sets end2end = True ([reference](https://github.com/ultralytics/ultralytics/blob/42d15b69de1de90a66c91edc0bb0fc7f1a3c0bf8/ultralytics/nn/modules/head.py#L1211))  whereas in other YOLO models such as YOLOv9, YOLOv8, and YOLO-World, it is set to [False](https://github.com/ultralytics/ultralytics/blob/42d15b69de1de90a66c91edc0bb0fc7f1a3c0bf8/ultralytics/nn/modules/head.py#L72). 
- That's why PCC drop is Higher in YOLOv10 compared to other YOLO models. For more context , checkout https://github.com/tenstorrent/tt-xla/issues/1692
- This PR disables the endtoend, preventing the TopK operation from execution.[Post-processing](https://github.com/ultralytics/ultralytics/blob/42d15b69de1de90a66c91edc0bb0fc7f1a3c0bf8/ultralytics/nn/modules/head.py#L210) can be applied to raw predictions obtained from compilation.
- After disabling end2end, PCC exceeds 0.99 for both YOLOv10n and YOLOv10x.[oct15_yolov10_n_x_after_fix.log](https://github.com/user-attachments/files/22922876/oct15_yolov10_n_x_after_fix.log)


### Checklist
- [x] verified the functionality through local testing
