### PR TITLE
Restructure Whisper model loader

### DIFF
--- a/whisper/pytorch/__init__.py
+++ b/whisper/pytorch/__init__.py
@@ -4,4 +4,4 @@
 """
 Whisper PyTorch model implementation for Tenstorrent projects.
 """
-from .loader import ModelLoader
+from .loader import ModelLoader, ModelVariant


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-xla/issues/1707

### Problem description

- On testing whisper large v3 model in tt-xla, it was facing runtime error mentioned in [this](https://github.com/tenstorrent/tt-xla/issues/1707) issue. 

### What's changed

- This issue occurred because of missing inputs — the tt-forge-fe tests use a wrapper that adds additional inputs, whereas tt-forge-models/loader.py returns only one. Since the tt-xla tests load models directly without using the custom test scripts, this input mismatch leads to test failures. To address this, wrappers has been added to custom test , corresponding changes can be found in this [PR](https://github.com/tenstorrent/tt-xla/pull/1843/files).  In the current PR, according to each variant, inputs has been modified.

- Below changes have been made to align with the original tests from tt-forge-fe:
  a. For ModelVariant.WHISPER_LARGE_V3: uses encoder-only WhisperModel with AutoFeatureExtractor.
      For other variants: uses WhisperForConditionalGeneration with WhisperProcessor.
  b. Constructs decoder_input_ids from the tokenizer’s decoder start token for generation models and for WHISPER_LARGE_V3_TURBO, produces encoder outputs early and returns them alongside decoder inputs.
  c. Return format adjustments: For turbo, it returns a pair [decoder_input_ids, encoder_outputs] while for other variants it returns {"input_features": input_features, "decoder_input_ids": decoder_input_ids}.

### Logs after testing in tt-xla
[whisper_restructured_all_variants_oct29.zip](https://github.com/user-attachments/files/23205717/whisper_restructured_all_variants_oct29.zip)