### PR TITLE
Remove detectron2 dependency from BEVFormer model

### DIFF
--- a/bevformer/pytorch/__init__.py
+++ b/bevformer/pytorch/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+BEVFormer model implementation for Tenstorrent projects.
+"""
+
+from .loader import ModelLoader, ModelVariant


### PR DESCRIPTION
### Ticket
Fixes #223 

### Problem description

- Remove dependency for detectron2 package instead of adding it in requirements.txt

### What's changed

- To eliminate the need for detectron2, the corresponding Conv2d, get_norm, and ShapeSpec implementations were moved into the codebase. Hence detectron2 is no longer required as a dependency