### PR TITLE
Bringup CLIP-ViT pytorch model

### DIFF
--- a/clip/pytorch/__init__.py
+++ b/clip/pytorch/__init__.py
@@ -4,4 +4,4 @@
 """
 CLIP PyTorch model implementation for Tenstorrent projects.
 """
-from .loader import ModelLoader
+from .loader import ModelLoader, ModelVariant

--- a/config.py
+++ b/config.py
@@ -68,6 +68,7 @@ class ModelTask(StrEnum):
     MM_ACTION_PREDICTION = "mm_action_prediction"
     MM_CONDITIONAL_GENERATION = "mm_conditional_generation"
     MM_DOC_OCR = "mm_doc_ocr"
+    MM_IMAGE_TEXT_SIM = "mm_image_text_similarity"
     CONDITIONAL_GENERATION = "conditional_generation"
     ATOMIC_ML = "atomic_ml"
 


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1897

### Problem description

- The [clip-vit-base-patch32](https://huggingface.co/openai/clip-vit-base-patch32) variant is already available in the repo.
- Bringup below pytorch variants 
  - [clip-vit-base-patch16](https://huggingface.co/openai/clip-vit-base-patch16)
  - [clip-vit-large-patch14](https://huggingface.co/openai/clip-vit-large-patch14)
  - [clip-vit-large-patch14-336](https://huggingface.co/openai/clip-vit-large-patch14-336)

### What's changed

- Added support for the above CLIP-ViT variants.
- Implemented proper post-processing steps.

### Checklist
- [x] Verified the changes on local testing

### Logs

- [oct31_clip_vit_cpu_run.log](https://github.com/user-attachments/files/23263685/oct31_clip_vit_cpu_run_final.log)
- [oct31_clip_vit_xla_run.zip](https://github.com/user-attachments/files/23263752/xla_run.zip)


