### PR TITLE
Fix Pretrained weights loading in the DLA model

### DIFF
--- a/dla/pytorch/loader.py
+++ b/dla/pytorch/loader.py
@@ -164,7 +164,7 @@ class ModelLoader(ForgeModel):
         else:
             # Load model using the dla_model module (torchvision style)
             func = getattr(dla_model, model_name)
-            model = func(pretrained=None)
+            model = func(pretrained="imagenet")
 
         model.eval()
 


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-forge-models/issues/241)

### Problem description
In the DLA model, the pre-trained weights were not loaded. Because of this, during the ONNX compilation in forge-fe for the variants dla169 and dla102, a PCC issue occurs (dla169: 0.6508514243129618, dla102 : 0.6586661919880112 ).

## Model Log 
[model_fixed_dla169_and_dla102.log](https://github.com/user-attachments/files/23301080/model_fixed.log)
