### PR TITLE
Fix Runtime Error in Surya OCR Model

### DIFF
--- a/suryaocr/pytorch/loader.py
+++ b/suryaocr/pytorch/loader.py
@@ -80,6 +80,7 @@ class ModelLoader(ForgeModel):
         """Initialize ModelLoader with specified variant."""
         super().__init__(variant)
         self._transform = transforms.Compose([transforms.ToTensor()])
+        self.image_tensor = None
 
     def load_model(self, dtype_override=None) -> nn.Module:
         """Load Surya OCR wrapper model.
@@ -92,6 +93,8 @@ class ModelLoader(ForgeModel):
             raise ImportError(
                 "Surya package is not available. Please install `surya` to use SuryaOCR loader."
             )
+        if self.image_tensor is None:
+            self.load_inputs()
         if self._variant == ModelVariant.OCR_TEXT:
             model = SuryaOCRWrapper(image_tensor=self.image_tensor)
         elif self._variant == ModelVariant.OCR_DETECTION:
@@ -105,7 +108,7 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None):
+    def load_inputs(self, dtype_override: Optional[torch.dtype] = torch.float32):
         """Generate sample inputs for Surya OCR.
 
         Returns:

--- a/suryaocr/pytorch/src/utils.py
+++ b/suryaocr/pytorch/src/utils.py
@@ -19,10 +19,10 @@ from surya.recognition import RecognitionPredictor
 
 
 class SuryaOCRWrapper(nn.Module):
-    def __init__(self, image_tensor=None):
+    def __init__(self, image_tensor=None, device: str = "cpu"):
         super().__init__()
-        self.detection_predictor = DetectionPredictor()
-        self.foundation_predictor = FoundationPredictor()
+        self.detection_predictor = DetectionPredictor(device=device)
+        self.foundation_predictor = FoundationPredictor(device=device)
         self.rec_predictor = RecognitionPredictor(self.foundation_predictor)
         self._to_pil = transforms.ToPILImage()
 
@@ -77,9 +77,9 @@ class SuryaOCRWrapper(nn.Module):
 
 
 class SuryaOCRDetectionWrapper(nn.Module):
-    def __init__(self):
+    def __init__(self, device: str = "cpu"):
         super().__init__()
-        self.detection_predictor = DetectionPredictor()
+        self.detection_predictor = DetectionPredictor(device=device)
         self._to_pil = transforms.ToPILImage()
 
         # Set eval mode on wrapper and underlying models


### PR DESCRIPTION
### Ticket
#243 

### Problem description

-  Surya OCR Model faces `RuntimeError: Can't change device type after XLA runtime is initialized`.

### What's changed
The above runtime error is fixed by [this](https://github.com/tenstorrent/tt-xla/pull/1970) PR, post which model fails with below error
```
E       TypeError: to() received an invalid combination of arguments - got (method), but expected one of:
E        * (torch.device device = None, torch.dtype dtype = None, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)
E        * (torch.dtype dtype, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)
E        * (Tensor tensor, bool non_blocking = False, bool copy = False, *, torch.memory_format memory_format = None)
```
Passing device=device into the predictors ensures they store a concrete device , so all internal .to(device) calls receive a valid argument instead of a method. 

### Logs
[surya_ocr_text1.log](https://github.com/user-attachments/files/23618444/surya_ocr_text1.log)