### PR TITLE
Update Model Group UltraFastLaneDet

### DIFF
--- a/ultra_fast_lane_detection/pytorch/loader.py
+++ b/ultra_fast_lane_detection/pytorch/loader.py
@@ -143,7 +143,9 @@ class ModelLoader(ForgeModel):
         return ModelInfo(
             model="ultra-fast-lane-detection",
             variant=variant,
-            group=ModelGroup.RED,
+            group=ModelGroup.RED
+            if variant == ModelVariant.TUSIMPLE_RESNET18
+            else ModelGroup.GENERALITY,
             source=ModelSource.GITHUB,
             task=ModelTask.CV_IMAGE_SEG,
             framework=Framework.TORCH,


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-forge-models/issues/253)

### Problem description
 Modification od the ultrafast-lane-detection model group to mark only one variant as RED, instead of marking multiple variants as RED.

### What's changed
loader.py has been changed for the group recording

