### PR TITLE
Bringup PETR pytorch Model

### DIFF
--- a/config.py
+++ b/config.py
@@ -71,6 +71,7 @@ class ModelTask(StrEnum):
     MM_IMAGE_TEXT_SIM = "mm_image_text_similarity"
     CONDITIONAL_GENERATION = "conditional_generation"
     ATOMIC_ML = "atomic_ml"
+    MULTIVIEW_3D_OBJECT_DET = "Multiview_3D_object_detection"
 
 
 class ModelSource(StrEnum):

--- a/petr/pytorch/__init__.py
+++ b/petr/pytorch/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PETR model implementation for Tenstorrent projects.
+"""
+
+from .loader import ModelLoader, ModelVariant

--- a/petr/pytorch/loader.py
+++ b/petr/pytorch/loader.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+PETR model loader implementation
+"""
+import torch
+from typing import Optional
+import copy
+import numpy as np
+
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ...base import ForgeModel
+from ...tools.utils import get_file
+from .src.petr import (
+    build_model,
+    load_checkpoint,
+    ConfigDict,
+    model_cfg,
+    resnet50_dcn_backbone_cfg,
+    LiDARInstance3DBoxes,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available PETR model variants."""
+
+    VOVNET_GRIDMASK_P4_800X320 = "vovnet_gridmask_p4_800x320"
+    VOVNET_GRIDMASK_P4_1600X640 = "vovnet_gridmask_p4_1600x640"
+    R50DCN_GRIDMASK_C5 = "r50dcn_gridmask_c5"
+    R50DCN_GRIDMASK_P4 = "r50dcn_gridmask_p4"
+
+
+class ModelLoader(ForgeModel):
+    """PETR model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.VOVNET_GRIDMASK_P4_800X320: ModelConfig(
+            pretrained_model_name="vovnet_gridmask_p4_800x320",
+        ),
+        ModelVariant.VOVNET_GRIDMASK_P4_1600X640: ModelConfig(
+            pretrained_model_name="vovnet_gridmask_p4_1600x640",
+        ),
+        ModelVariant.R50DCN_GRIDMASK_C5: ModelConfig(
+            pretrained_model_name="r50dcn_gridmask_c5",
+        ),
+        ModelVariant.R50DCN_GRIDMASK_P4: ModelConfig(
+            pretrained_model_name="r50dcn_gridmask_p4",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.VOVNET_GRIDMASK_P4_800X320
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant.
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        if variant == ModelVariant.VOVNET_GRIDMASK_P4_800X320:
+            group = ModelGroup.RED
+        else:
+            group = ModelGroup.GENERALITY
+
+        return ModelInfo(
+            model="petr",
+            variant=variant,
+            group=group,
+            task=ModelTask.MULTIVIEW_3D_OBJECT_DET,
+            source=ModelSource.GITHUB,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self):
+        """Load pretrained PETR model for this instance's variant.
+
+        Returns:
+            torch.nn.Module: The PETR model instance.
+        """
+        # Get the variant name from the instance's variant config
+        variant_name = self._variant_config.pretrained_model_name
+
+        # Get pretrained weights
+        model_path = str(get_file(f"test_files/pytorch/petr/{variant_name}.pth"))
+
+        # Create deep copy to prevent global state contamination
+        local_model_cfg = copy.deepcopy(model_cfg)
+
+        # Modify backbone and neck based on variant
+        if variant_name == "r50dcn_gridmask_c5":
+            # ResNet50 DCN with C5 (no neck)
+            local_model_cfg["img_backbone"] = copy.deepcopy(resnet50_dcn_backbone_cfg)
+            local_model_cfg["img_backbone"]["out_indices"] = (3,)
+            del local_model_cfg["img_neck"]
+            local_model_cfg["pts_bbox_head"]["in_channels"] = 2048
+
+        elif variant_name == "r50dcn_gridmask_p4":
+            # ResNet50 DCN with P4 (with neck)
+            local_model_cfg["img_backbone"] = copy.deepcopy(resnet50_dcn_backbone_cfg)
+            local_model_cfg["img_neck"]["in_channels"] = [1024, 2048]
+
+        # Add checkpoint flag for all variants except base 800x320
+        if variant_name != "vovnet_gridmask_p4_800x320":
+            local_model_cfg["pts_bbox_head"]["transformer"]["decoder"][
+                "transformerlayers"
+            ]["with_cp"] = True
+
+        # Wrap the model config
+        self.cfg = ConfigDict(local_model_cfg)
+
+        # Build model
+        model = build_model(self.cfg)
+
+        # Load pretrained weights
+        load_checkpoint(model, model_path, map_location="cpu")
+        model.eval()
+
+        return model
+
+    def load_inputs(self):
+        """Prepare dummy sample inputs for the PETR model.
+
+        This function creates synthetic test data mimicking the structure expected by
+        PETR for NuScenes dataset. It does not load real data, but instead
+        generates placeholder inputs for testing purposes.
+
+        The input dimensions are automatically selected based on the model variant:
+        - vovnet_gridmask_p4_800x320: 320x800 images
+        - vovnet_gridmask_p4_1600x640: 640x1600 images
+        - r50dcn_gridmask_c5 & r50dcn_gridmask_p4: 512x1408 images
+
+        Returns:
+            dict: Dictionary containing:
+                - ``img_metas`` (list): Nested list containing a dictionary with metadata:
+                    - ``img_shape`` (list): Original image dimensions [(H, W, 3)] * 6 cameras
+                    - ``pad_shape`` (list): Padded image dimensions [(H, W, 3)] * 6 cameras
+                    - ``lidar2img`` (list): 4x4 projection matrices (identity matrices) for 6 cameras
+                    - ``box_type_3d`` (class): LiDARInstance3DBoxes class for wrapping 3D bounding boxes
+                - ``img`` (list): Random image tensor of shape [1, 6, 3, H, W] where 6 is the number of cameras
+        """
+        variant_name = self._variant_config.pretrained_model_name
+
+        # Determine image dimensions based on variant
+        if variant_name == "vovnet_gridmask_p4_800x320":
+            img_h, img_w = 320, 800
+        elif variant_name == "vovnet_gridmask_p4_1600x640":
+            img_h, img_w = 640, 1600
+        elif variant_name in ["r50dcn_gridmask_c5", "r50dcn_gridmask_p4"]:
+            img_h, img_w = 512, 1408
+        else:
+            raise ValueError(f"Unknown variant: {variant_name}")
+
+        # Number of cameras (6 for NuScenes)
+        num_cams = 6
+
+        # Create dummy inputs
+        img_shape = [(img_h, img_w, 3)] * num_cams
+        pad_shape = [(img_h, img_w, 3)] * num_cams
+        lidar2img = [np.eye(4) for _ in range(num_cams)]
+        img = torch.randn(1, num_cams, 3, img_h, img_w)
+
+        data = {
+            "img_metas": [
+                [
+                    {
+                        "img_shape": img_shape,
+                        "pad_shape": pad_shape,
+                        "lidar2img": lidar2img,
+                        "box_type_3d": LiDARInstance3DBoxes,
+                    }
+                ]
+            ],
+            "img": [img],
+        }
+
+        return data

--- a/petr/pytorch/src/petr.py
+++ b/petr/pytorch/src/petr.py
@@ -1,0 +1,4993 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+"""
+PETR model implementation
+
+Apdapted from: https://github.com/megvii-research/PETR
+License : https://github.com/megvii-research/PETR/blob/main/LICENSE
+"""
+
+# ============================================================================
+# IMPORTS
+# ============================================================================
+
+import ast
+import copy
+import inspect
+import math
+import os
+import os.path as osp
+import platform
+import re
+import shutil
+import sys
+import tempfile
+import uuid
+import warnings
+from abc import ABCMeta, abstractmethod
+from argparse import ArgumentParser
+from collections import OrderedDict
+from functools import partial
+from importlib import import_module
+from itertools import chain
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.utils.checkpoint as cp
+import torchvision.ops as ops
+from addict import Dict
+from torch import distributed as dist
+from torch.nn.modules.utils import _pair, _single
+from torch.nn.parallel import DataParallel
+from torch.nn.parallel._functions import _get_stream
+
+
+# ============================================================================
+# MMCV UTILS
+# ============================================================================
+
+BASE_KEY = "_base_"
+DELETE_KEY = "_delete_"
+DEPRECATION_KEY = "_deprecation_"
+RESERVED_KEYS = ["filename", "text", "pretty_text"]
+
+if torch.__version__ == "parrots":
+    TORCH_VERSION = torch.__version__
+else:
+    TORCH_VERSION = tuple(int(x) for x in torch.__version__.split(".")[:2])
+
+
+def check_file_exist(filename, msg_tmpl='file "{}" does not exist'):
+    if not osp.isfile(filename):
+        raise FileNotFoundError(msg_tmpl.format(filename))
+
+
+class ConfigDict(Dict):
+    def __missing__(self, name):
+        raise KeyError(name)
+
+    def __getattr__(self, name):
+        try:
+            value = super(ConfigDict, self).__getattr__(name)
+        except KeyError:
+            ex = AttributeError(
+                f"'{self.__class__.__name__}' object has no " f"attribute '{name}'"
+            )
+        except Exception as e:
+            ex = e
+        else:
+            return value
+        raise ex
+
+
+class Config:
+    @staticmethod
+    def _validate_py_syntax(filename):
+        with open(filename, "r", encoding="utf-8") as f:
+            content = f.read()
+        try:
+            ast.parse(content)
+        except SyntaxError as e:
+            raise SyntaxError(
+                "There are syntax errors in config " f"file {filename}: {e}"
+            )
+
+    @staticmethod
+    def _substitute_predefined_vars(filename, temp_config_name):
+        file_dirname = osp.dirname(filename)
+        file_basename = osp.basename(filename)
+        file_basename_no_extension = osp.splitext(file_basename)[0]
+        file_extname = osp.splitext(filename)[1]
+        support_templates = dict(
+            fileDirname=file_dirname,
+            fileBasename=file_basename,
+            fileBasenameNoExtension=file_basename_no_extension,
+            fileExtname=file_extname,
+        )
+        with open(filename, "r", encoding="utf-8") as f:
+            config_file = f.read()
+        for key, value in support_templates.items():
+            regexp = r"\{\{\s*" + str(key) + r"\s*\}\}"
+            value = value.replace("\\", "/")
+            config_file = re.sub(regexp, value, config_file)
+        with open(temp_config_name, "w", encoding="utf-8") as tmp_config_file:
+            tmp_config_file.write(config_file)
+
+    @staticmethod
+    def _pre_substitute_base_vars(filename, temp_config_name):
+        with open(filename, "r", encoding="utf-8") as f:
+            config_file = f.read()
+        base_var_dict = {}
+        regexp = r"\{\{\s*" + BASE_KEY + r"\.([\w\.]+)\s*\}\}"
+        base_vars = set(re.findall(regexp, config_file))
+        for base_var in base_vars:
+            randstr = f"_{base_var}_{uuid.uuid4().hex.lower()[:6]}"
+            base_var_dict[randstr] = base_var
+            regexp = r"\{\{\s*" + BASE_KEY + r"\." + base_var + r"\s*\}\}"
+            config_file = re.sub(regexp, f'"{randstr}"', config_file)
+        with open(temp_config_name, "w", encoding="utf-8") as tmp_config_file:
+            tmp_config_file.write(config_file)
+        return base_var_dict
+
+    @staticmethod
+    def _substitute_base_vars(cfg, base_var_dict, base_cfg):
+        cfg = copy.deepcopy(cfg)
+
+        if isinstance(cfg, dict):
+            for k, v in cfg.items():
+                if isinstance(v, str) and v in base_var_dict:
+                    new_v = base_cfg
+                    for new_k in base_var_dict[v].split("."):
+                        new_v = new_v[new_k]
+                    cfg[k] = new_v
+                elif isinstance(v, (list, tuple, dict)):
+                    cfg[k] = Config._substitute_base_vars(v, base_var_dict, base_cfg)
+        elif isinstance(cfg, tuple):
+            cfg = tuple(
+                Config._substitute_base_vars(c, base_var_dict, base_cfg) for c in cfg
+            )
+        elif isinstance(cfg, list):
+            cfg = [
+                Config._substitute_base_vars(c, base_var_dict, base_cfg) for c in cfg
+            ]
+        elif isinstance(cfg, str) and cfg in base_var_dict:
+            new_v = base_cfg
+            for new_k in base_var_dict[cfg].split("."):
+                new_v = new_v[new_k]
+            cfg = new_v
+
+        return cfg
+
+    @staticmethod
+    def _file2dict(filename, use_predefined_variables=True):
+        filename = osp.abspath(osp.expanduser(filename))
+        check_file_exist(filename)
+        fileExtname = osp.splitext(filename)[1]
+        if fileExtname not in [".py", ".json", ".yaml", ".yml"]:
+            raise IOError("Only py/yml/yaml/json type are supported now!")
+
+        with tempfile.TemporaryDirectory() as temp_config_dir:
+            temp_config_file = tempfile.NamedTemporaryFile(
+                dir=temp_config_dir, suffix=fileExtname
+            )
+            if platform.system() == "Windows":
+                temp_config_file.close()
+            temp_config_name = osp.basename(temp_config_file.name)
+            if use_predefined_variables:
+                Config._substitute_predefined_vars(filename, temp_config_file.name)
+            else:
+                shutil.copyfile(filename, temp_config_file.name)
+            base_var_dict = Config._pre_substitute_base_vars(
+                temp_config_file.name, temp_config_file.name
+            )
+
+            if filename.endswith(".py"):
+                temp_module_name = osp.splitext(temp_config_name)[0]
+                sys.path.insert(0, temp_config_dir)
+                Config._validate_py_syntax(filename)
+                mod = import_module(temp_module_name)
+                sys.path.pop(0)
+                cfg_dict = {
+                    name: value
+                    for name, value in mod.__dict__.items()
+                    if not name.startswith("__")
+                }
+                del sys.modules[temp_module_name]
+            elif filename.endswith((".yml", ".yaml", ".json")):
+                import mmcv
+
+                cfg_dict = mmcv.load(temp_config_file.name)
+            temp_config_file.close()
+
+        if DEPRECATION_KEY in cfg_dict:
+            deprecation_info = cfg_dict.pop(DEPRECATION_KEY)
+            warning_msg = (
+                f"The config file {filename} will be deprecated " "in the future."
+            )
+            if "expected" in deprecation_info:
+                warning_msg += f' Please use {deprecation_info["expected"]} ' "instead."
+            if "reference" in deprecation_info:
+                warning_msg += (
+                    " More information can be found at "
+                    f'{deprecation_info["reference"]}'
+                )
+            warnings.warn(warning_msg)
+
+        cfg_text = filename + "\n"
+        with open(filename, "r", encoding="utf-8") as f:
+            cfg_text += f.read()
+
+        if BASE_KEY in cfg_dict:
+            cfg_dir = osp.dirname(filename)
+            base_filename = cfg_dict.pop(BASE_KEY)
+            base_filename = (
+                base_filename if isinstance(base_filename, list) else [base_filename]
+            )
+
+            cfg_dict_list = list()
+            cfg_text_list = list()
+            for f in base_filename:
+                _cfg_dict, _cfg_text = Config._file2dict(osp.join(cfg_dir, f))
+                cfg_dict_list.append(_cfg_dict)
+                cfg_text_list.append(_cfg_text)
+
+            base_cfg_dict = dict()
+            for c in cfg_dict_list:
+                duplicate_keys = base_cfg_dict.keys() & c.keys()
+                if len(duplicate_keys) > 0:
+                    raise KeyError(
+                        "Duplicate key is not allowed among bases. "
+                        f"Duplicate keys: {duplicate_keys}"
+                    )
+                base_cfg_dict.update(c)
+            cfg_dict = Config._substitute_base_vars(
+                cfg_dict, base_var_dict, base_cfg_dict
+            )
+
+            base_cfg_dict = Config._merge_a_into_b(cfg_dict, base_cfg_dict)
+            cfg_dict = base_cfg_dict
+            cfg_text_list.append(cfg_text)
+            cfg_text = "\n".join(cfg_text_list)
+
+        return cfg_dict, cfg_text
+
+    @staticmethod
+    def _merge_a_into_b(a, b, allow_list_keys=False):
+        b = b.copy()
+        for k, v in a.items():
+            if allow_list_keys and k.isdigit() and isinstance(b, list):
+                k = int(k)
+                if len(b) <= k:
+                    raise KeyError(f"Index {k} exceeds the length of list {b}")
+                b[k] = Config._merge_a_into_b(v, b[k], allow_list_keys)
+            elif isinstance(v, dict) and k in b and not v.pop(DELETE_KEY, False):
+                allowed_types = (dict, list) if allow_list_keys else dict
+                if not isinstance(b[k], allowed_types):
+                    raise TypeError(
+                        f"{k}={v} in child config cannot inherit from base "
+                        f"because {k} is a dict in the child config but is of "
+                        f"type {type(b[k])} in base config. You may set "
+                        f"`{DELETE_KEY}=True` to ignore the base config"
+                    )
+                b[k] = Config._merge_a_into_b(v, b[k], allow_list_keys)
+            else:
+                b[k] = v
+        return b
+
+    @staticmethod
+    def fromfile(filename, use_predefined_variables=True, import_custom_modules=True):
+        cfg_dict, cfg_text = Config._file2dict(filename, use_predefined_variables)
+        if import_custom_modules and cfg_dict.get("custom_imports", None):
+            import_modules_from_strings(**cfg_dict["custom_imports"])
+        return Config(cfg_dict, cfg_text=cfg_text, filename=filename)
+
+    @staticmethod
+    def fromstring(cfg_str, file_format):
+        if file_format not in [".py", ".json", ".yaml", ".yml"]:
+            raise IOError("Only py/yml/yaml/json type are supported now!")
+        if file_format != ".py" and "dict(" in cfg_str:
+            warnings.warn('Please check "file_format", the file format may be .py')
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", suffix=file_format, delete=False
+        ) as temp_file:
+            temp_file.write(cfg_str)
+        cfg = Config.fromfile(temp_file.name)
+        os.remove(temp_file.name)
+        return cfg
+
+    @staticmethod
+    def auto_argparser(description=None):
+        partial_parser = ArgumentParser(description=description)
+        partial_parser.add_argument("config", help="config file path")
+        cfg_file = partial_parser.parse_known_args()[0].config
+        cfg = Config.fromfile(cfg_file)
+        parser = ArgumentParser(description=description)
+        parser.add_argument("config", help="config file path")
+        add_args(parser, cfg)
+        return parser, cfg
+
+    def __init__(self, cfg_dict=None, cfg_text=None, filename=None):
+        if cfg_dict is None:
+            cfg_dict = dict()
+        elif not isinstance(cfg_dict, dict):
+            raise TypeError("cfg_dict must be a dict, but " f"got {type(cfg_dict)}")
+        for key in cfg_dict:
+            if key in RESERVED_KEYS:
+                raise KeyError(f"{key} is reserved for config file")
+
+        super(Config, self).__setattr__("_cfg_dict", ConfigDict(cfg_dict))
+        super(Config, self).__setattr__("_filename", filename)
+        if cfg_text:
+            text = cfg_text
+        elif filename:
+            with open(filename, "r") as f:
+                text = f.read()
+        else:
+            text = ""
+        super(Config, self).__setattr__("_text", text)
+
+    @property
+    def filename(self):
+        return self._filename
+
+    @property
+    def text(self):
+        return self._text
+
+    @property
+    def pretty_text(self):
+
+        indent = 4
+
+        def _indent(s_, num_spaces):
+            s = s_.split("\n")
+            if len(s) == 1:
+                return s_
+            first = s.pop(0)
+            s = [(num_spaces * " ") + line for line in s]
+            s = "\n".join(s)
+            s = first + "\n" + s
+            return s
+
+        def _format_basic_types(k, v, use_mapping=False):
+            if isinstance(v, str):
+                v_str = f"'{v}'"
+            else:
+                v_str = str(v)
+
+            if use_mapping:
+                k_str = f"'{k}'" if isinstance(k, str) else str(k)
+                attr_str = f"{k_str}: {v_str}"
+            else:
+                attr_str = f"{str(k)}={v_str}"
+            attr_str = _indent(attr_str, indent)
+
+            return attr_str
+
+        def _format_list(k, v, use_mapping=False):
+            if all(isinstance(_, dict) for _ in v):
+                v_str = "[\n"
+                v_str += "\n".join(
+                    f"dict({_indent(_format_dict(v_), indent)})," for v_ in v
+                ).rstrip(",")
+                if use_mapping:
+                    k_str = f"'{k}'" if isinstance(k, str) else str(k)
+                    attr_str = f"{k_str}: {v_str}"
+                else:
+                    attr_str = f"{str(k)}={v_str}"
+                attr_str = _indent(attr_str, indent) + "]"
+            else:
+                attr_str = _format_basic_types(k, v, use_mapping)
+            return attr_str
+
+        def _contain_invalid_identifier(dict_str):
+            contain_invalid_identifier = False
+            for key_name in dict_str:
+                contain_invalid_identifier |= not str(key_name).isidentifier()
+            return contain_invalid_identifier
+
+        def _format_dict(input_dict, outest_level=False):
+            r = ""
+            s = []
+
+            use_mapping = _contain_invalid_identifier(input_dict)
+            if use_mapping:
+                r += "{"
+            for idx, (k, v) in enumerate(input_dict.items()):
+                is_last = idx >= len(input_dict) - 1
+                end = "" if outest_level or is_last else ","
+                if isinstance(v, dict):
+                    v_str = "\n" + _format_dict(v)
+                    if use_mapping:
+                        k_str = f"'{k}'" if isinstance(k, str) else str(k)
+                        attr_str = f"{k_str}: dict({v_str}"
+                    else:
+                        attr_str = f"{str(k)}=dict({v_str}"
+                    attr_str = _indent(attr_str, indent) + ")" + end
+                elif isinstance(v, list):
+                    attr_str = _format_list(k, v, use_mapping) + end
+                else:
+                    attr_str = _format_basic_types(k, v, use_mapping) + end
+
+                s.append(attr_str)
+            r += "\n".join(s)
+            if use_mapping:
+                r += "}"
+            return r
+
+        cfg_dict = self._cfg_dict.to_dict()
+        text = _format_dict(cfg_dict, outest_level=True)
+        yapf_style = dict(
+            based_on_style="pep8",
+            blank_line_before_nested_class_or_def=True,
+            split_before_expression_after_opening_paren=True,
+        )
+        text, _ = FormatCode(text, style_config=yapf_style, verify=True)
+
+        return text
+
+    def __len__(self):
+        return len(self._cfg_dict)
+
+    def __getattr__(self, name):
+        return getattr(self._cfg_dict, name)
+
+    def __getitem__(self, name):
+        return self._cfg_dict.__getitem__(name)
+
+    def __setattr__(self, name, value):
+        if isinstance(value, dict):
+            value = ConfigDict(value)
+        self._cfg_dict.__setattr__(name, value)
+
+    def __setitem__(self, name, value):
+        if isinstance(value, dict):
+            value = ConfigDict(value)
+        self._cfg_dict.__setitem__(name, value)
+
+    def __iter__(self):
+        return iter(self._cfg_dict)
+
+    def __getstate__(self):
+        return (self._cfg_dict, self._filename, self._text)
+
+    def __setstate__(self, state):
+        _cfg_dict, _filename, _text = state
+        super(Config, self).__setattr__("_cfg_dict", _cfg_dict)
+        super(Config, self).__setattr__("_filename", _filename)
+        super(Config, self).__setattr__("_text", _text)
+
+    def dump(self, file=None):
+        cfg_dict = super(Config, self).__getattribute__("_cfg_dict").to_dict()
+        if self.filename.endswith(".py"):
+            if file is None:
+                return self.pretty_text
+            else:
+                with open(file, "w", encoding="utf-8") as f:
+                    f.write(self.pretty_text)
+        else:
+            import mmcv
+
+            if file is None:
+                file_format = self.filename.split(".")[-1]
+                return mmcv.dump(cfg_dict, file_format=file_format)
+            else:
+                mmcv.dump(cfg_dict, file)
+
+    def merge_from_dict(self, options, allow_list_keys=True):
+
+        option_cfg_dict = {}
+        for full_key, v in options.items():
+            d = option_cfg_dict
+            key_list = full_key.split(".")
+            for subkey in key_list[:-1]:
+                d.setdefault(subkey, ConfigDict())
+                d = d[subkey]
+            subkey = key_list[-1]
+            d[subkey] = v
+
+        cfg_dict = super(Config, self).__getattribute__("_cfg_dict")
+        super(Config, self).__setattr__(
+            "_cfg_dict",
+            Config._merge_a_into_b(
+                option_cfg_dict, cfg_dict, allow_list_keys=allow_list_keys
+            ),
+        )
+
+
+def build_from_cfg(cfg, registry, default_args=None):
+    if not isinstance(cfg, dict):
+        raise TypeError(f"cfg must be a dict, but got {type(cfg)}")
+    if "type" not in cfg:
+        if default_args is None or "type" not in default_args:
+            raise KeyError(
+                '`cfg` or `default_args` must contain the key "type", '
+                f"but got {cfg}\n{default_args}"
+            )
+    if not isinstance(registry, Registry):
+        raise TypeError(
+            "registry must be an mmcv.Registry object, " f"but got {type(registry)}"
+        )
+    if not (isinstance(default_args, dict) or default_args is None):
+        raise TypeError(
+            "default_args must be a dict or None, " f"but got {type(default_args)}"
+        )
+
+    args = cfg.copy()
+
+    if default_args is not None:
+        for name, value in default_args.items():
+            args.setdefault(name, value)
+
+    obj_type = args.pop("type")
+    if isinstance(obj_type, str):
+        obj_cls = registry.get(obj_type)
+        if obj_cls is None:
+            raise KeyError(f"{obj_type} is not in the {registry.name} registry")
+    elif inspect.isclass(obj_type):
+        obj_cls = obj_type
+    else:
+        raise TypeError(f"type must be a str or valid type, but got {type(obj_type)}")
+    try:
+        return obj_cls(**args)
+    except Exception as e:
+        raise type(e)(f"{obj_cls.__name__}: {e}")
+
+
+class Registry:
+    def __init__(self, name, build_func=None, parent=None, scope=None):
+        self._name = name
+        self._module_dict = dict()
+        self._children = dict()
+        self._scope = self.infer_scope() if scope is None else scope
+        if build_func is None:
+            if parent is not None:
+                self.build_func = parent.build_func
+            else:
+                self.build_func = build_from_cfg
+        else:
+            self.build_func = build_func
+        if parent is not None:
+            assert isinstance(parent, Registry)
+            parent._add_children(self)
+            self.parent = parent
+        else:
+            self.parent = None
+
+    def __len__(self):
+        return len(self._module_dict)
+
+    def __contains__(self, key):
+        return self.get(key) is not None
+
+    @staticmethod
+    def infer_scope():
+        filename = inspect.getmodule(inspect.stack()[2][0]).__name__
+        split_filename = filename.split(".")
+        return split_filename[0]
+
+    @staticmethod
+    def split_scope_key(key):
+        split_index = key.find(".")
+        if split_index != -1:
+            return key[:split_index], key[split_index + 1 :]
+        else:
+            return None, key
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def scope(self):
+        return self._scope
+
+    @property
+    def module_dict(self):
+        return self._module_dict
+
+    @property
+    def children(self):
+        return self._children
+
+    def get(self, key):
+        scope, real_key = self.split_scope_key(key)
+        if scope is None or scope == self._scope:
+            if real_key in self._module_dict:
+                return self._module_dict[real_key]
+        else:
+            if scope in self._children:
+                return self._children[scope].get(real_key)
+            else:
+                parent = self.parent
+                while parent.parent is not None:
+                    parent = parent.parent
+                return parent.get(key)
+
+    def build(self, *args, **kwargs):
+        return self.build_func(*args, **kwargs, registry=self)
+
+    def _add_children(self, registry):
+        assert isinstance(registry, Registry)
+        assert registry.scope is not None
+        assert (
+            registry.scope not in self.children
+        ), f"scope {registry.scope} exists in {self.name} registry"
+        self.children[registry.scope] = registry
+
+    def _register_module(self, module_class, module_name=None, force=False):
+        if not inspect.isclass(module_class):
+            raise TypeError("module must be a class, " f"but got {type(module_class)}")
+
+        if module_name is None:
+            module_name = module_class.__name__
+        if isinstance(module_name, str):
+            module_name = [module_name]
+        for name in module_name:
+            if not force and name in self._module_dict:
+                raise KeyError(f"{name} is already registered " f"in {self.name}")
+            self._module_dict[name] = module_class
+
+    def deprecated_register_module(self, cls=None, force=False):
+        warnings.warn(
+            "The old API of register_module(module, force=False) "
+            "is deprecated and will be removed, please use the new API "
+            "register_module(name=None, force=False, module=None) instead."
+        )
+        if cls is None:
+            return partial(self.deprecated_register_module, force=force)
+        self._register_module(cls, force=force)
+        return cls
+
+    def register_module(self, name=None, force=False, module=None):
+        if not isinstance(force, bool):
+            raise TypeError(f"force must be a boolean, but got {type(force)}")
+        if isinstance(name, type):
+            return self.deprecated_register_module(name, force=force)
+
+        if not (name is None or isinstance(name, str) or is_seq_of(name, str)):
+            raise TypeError(
+                "name must be either of None, an instance of str or a sequence"
+                f"  of str, but got {type(name)}"
+            )
+
+        if module is not None:
+            self._register_module(module_class=module, module_name=name, force=force)
+            return module
+
+        def _register(cls):
+            self._register_module(module_class=cls, module_name=name, force=force)
+            return cls
+
+        return _register
+
+
+def build_model_from_cfg(cfg, registry, default_args=None):
+    if isinstance(cfg, list):
+        modules = [build_from_cfg(cfg_, registry, default_args) for cfg_ in cfg]
+        return Sequential(*modules)
+    else:
+        return build_from_cfg(cfg, registry, default_args)
+
+
+class BaseModule(nn.Module, metaclass=ABCMeta):
+    def __init__(self, init_cfg=None):
+        super(BaseModule, self).__init__()
+        self._is_init = False
+
+        self.init_cfg = copy.deepcopy(init_cfg)
+
+    @property
+    def is_init(self):
+        return self._is_init
+
+    def init_weights(self):
+        is_top_level_module = False
+        if not hasattr(self, "_params_init_info"):
+            self._params_init_info = defaultdict(dict)
+            is_top_level_module = True
+            for name, param in self.named_parameters():
+                self._params_init_info[param]["init_info"] = (
+                    f"The value is the same before and "
+                    f"after calling `init_weights` "
+                    f"of {self.__class__.__name__} "
+                )
+                self._params_init_info[param]["tmp_mean_value"] = param.data.mean()
+            for sub_module in self.modules():
+                sub_module._params_init_info = self._params_init_info
+
+        logger_names = list(logger_initialized.keys())
+        logger_name = logger_names[0] if logger_names else "mmcv"
+
+        from ..cnn import initialize
+        from ..cnn.utils.weight_init import update_init_info
+
+        module_name = self.__class__.__name__
+        if not self._is_init:
+            if self.init_cfg:
+                print_log(
+                    f"initialize {module_name} with init_cfg {self.init_cfg}",
+                    logger=logger_name,
+                )
+                initialize(self, self.init_cfg)
+                if isinstance(self.init_cfg, dict):
+                    if self.init_cfg["type"] == "Pretrained":
+                        return
+
+            for m in self.children():
+                if hasattr(m, "init_weights"):
+                    m.init_weights()
+                    update_init_info(
+                        m,
+                        init_info=f"Initialized by "
+                        f"user-defined `init_weights`"
+                        f" in {m.__class__.__name__} ",
+                    )
+
+            self._is_init = True
+        else:
+            warnings.warn(
+                f"init_weights of {self.__class__.__name__} has "
+                f"been called more than once."
+            )
+
+        if is_top_level_module:
+            self._dump_init_info(logger_name)
+
+            for sub_module in self.modules():
+                del sub_module._params_init_info
+
+    def _dump_init_info(self, logger_name):
+        logger = get_logger(logger_name)
+
+        with_file_handler = False
+        for handler in logger.handlers:
+            if isinstance(handler, FileHandler):
+                handler.stream.write("Name of parameter - Initialization information\n")
+                for name, param in self.named_parameters():
+                    handler.stream.write(
+                        f"\n{name} - {param.shape}: "
+                        f"\n{self._params_init_info[param]['init_info']} \n"
+                    )
+                handler.stream.flush()
+                with_file_handler = True
+        if not with_file_handler:
+            for name, param in self.named_parameters():
+                print_log(
+                    f"\n{name} - {param.shape}: "
+                    f"\n{self._params_init_info[param]['init_info']} \n ",
+                    logger=logger_name,
+                )
+
+
+class Sequential(BaseModule, nn.Sequential):
+    def __init__(self, *args, init_cfg=None):
+        BaseModule.__init__(self, init_cfg)
+        nn.Sequential.__init__(self, *args)
+
+
+MODELS = Registry("model", build_func=build_model_from_cfg)
+MATCH_COST = Registry("Match Cost")
+
+CONV_LAYERS = Registry("conv layer")
+NORM_LAYERS = Registry("norm layer")
+ACTIVATION_LAYERS = Registry("activation layer")
+PADDING_LAYERS = Registry("padding layer")
+UPSAMPLE_LAYERS = Registry("upsample layer")
+PLUGIN_LAYERS = Registry("plugin layer")
+
+DROPOUT_LAYERS = Registry("drop out layers")
+POSITIONAL_ENCODING = Registry("position encoding")
+ATTENTION = Registry("attention")
+FEEDFORWARD_NETWORK = Registry("feed-forward Network")
+TRANSFORMER_LAYER = Registry("transformerLayer")
+TRANSFORMER_LAYER_SEQUENCE = Registry("transformer-layers sequence")
+MODULE_WRAPPERS = Registry("module wrapper")
+
+for module in [
+    nn.ReLU,
+    nn.LeakyReLU,
+    nn.PReLU,
+    nn.RReLU,
+    nn.ReLU6,
+    nn.ELU,
+    nn.Sigmoid,
+    nn.Tanh,
+]:
+    ACTIVATION_LAYERS.register_module(module=module)
+
+NORM_LAYERS.register_module("BN", module=nn.BatchNorm2d)
+NORM_LAYERS.register_module("BN1d", module=nn.BatchNorm1d)
+NORM_LAYERS.register_module("BN2d", module=nn.BatchNorm2d)
+NORM_LAYERS.register_module("BN3d", module=nn.BatchNorm3d)
+NORM_LAYERS.register_module("GN", module=nn.GroupNorm)
+NORM_LAYERS.register_module("LN", module=nn.LayerNorm)
+NORM_LAYERS.register_module("IN", module=nn.InstanceNorm2d)
+NORM_LAYERS.register_module("IN1d", module=nn.InstanceNorm1d)
+NORM_LAYERS.register_module("IN2d", module=nn.InstanceNorm2d)
+NORM_LAYERS.register_module("IN3d", module=nn.InstanceNorm3d)
+
+CONV_LAYERS.register_module("Conv1d", module=nn.Conv1d)
+CONV_LAYERS.register_module("Conv2d", module=nn.Conv2d)
+CONV_LAYERS.register_module("Conv3d", module=nn.Conv3d)
+CONV_LAYERS.register_module("Conv", module=nn.Conv2d)
+
+
+def build_match_cost(cfg, default_args=None):
+    return build_from_cfg(cfg, MATCH_COST, default_args)
+
+
+def _get_norm():
+    if TORCH_VERSION == "parrots":
+        from parrots.nn.modules.batchnorm import _BatchNorm, _InstanceNorm
+
+        SyncBatchNorm_ = torch.nn.SyncBatchNorm2d
+    else:
+        from torch.nn.modules.instancenorm import _InstanceNorm
+        from torch.nn.modules.batchnorm import _BatchNorm
+
+        SyncBatchNorm_ = torch.nn.SyncBatchNorm
+    return _BatchNorm, _InstanceNorm, SyncBatchNorm_
+
+
+def kaiming_init(
+    module, a=0, mode="fan_out", nonlinearity="relu", bias=0, distribution="normal"
+):
+    assert distribution in ["uniform", "normal"]
+    if hasattr(module, "weight") and module.weight is not None:
+        if distribution == "uniform":
+            nn.init.kaiming_uniform_(
+                module.weight, a=a, mode=mode, nonlinearity=nonlinearity
+            )
+        else:
+            nn.init.kaiming_normal_(
+                module.weight, a=a, mode=mode, nonlinearity=nonlinearity
+            )
+    if hasattr(module, "bias") and module.bias is not None:
+        nn.init.constant_(module.bias, bias)
+
+
+def build_conv_layer(cfg, *args, **kwargs):
+    if cfg is None:
+        cfg_ = dict(type="Conv2d")
+    else:
+        if not isinstance(cfg, dict):
+            raise TypeError("cfg must be a dict")
+        if "type" not in cfg:
+            raise KeyError('the cfg dict must contain the key "type"')
+        cfg_ = cfg.copy()
+
+    layer_type = cfg_.pop("type")
+    if layer_type not in CONV_LAYERS:
+        raise KeyError(f"Unrecognized norm type {layer_type}")
+    else:
+        conv_layer = CONV_LAYERS.get(layer_type)
+
+    layer = conv_layer(*args, **kwargs, **cfg_)
+
+    return layer
+
+
+@PLUGIN_LAYERS.register_module()
+class ConvModule(nn.Module):
+    _abbr_ = "conv_block"
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+        bias="auto",
+        conv_cfg=None,
+        norm_cfg=None,
+        act_cfg=dict(type="ReLU"),
+        inplace=True,
+        with_spectral_norm=False,
+        padding_mode="zeros",
+        order=("conv", "norm", "act"),
+    ):
+        super(ConvModule, self).__init__()
+        assert conv_cfg is None or isinstance(conv_cfg, dict)
+        assert norm_cfg is None or isinstance(norm_cfg, dict)
+        assert act_cfg is None or isinstance(act_cfg, dict)
+        official_padding_mode = ["zeros", "circular"]
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.act_cfg = act_cfg
+        self.inplace = inplace
+        self.with_spectral_norm = with_spectral_norm
+        self.with_explicit_padding = padding_mode not in official_padding_mode
+        self.order = order
+        assert isinstance(self.order, tuple) and len(self.order) == 3
+        assert set(order) == set(["conv", "norm", "act"])
+
+        self.with_norm = norm_cfg is not None
+        self.with_activation = act_cfg is not None
+        if bias == "auto":
+            bias = not self.with_norm
+        self.with_bias = bias
+
+        if self.with_explicit_padding:
+            pad_cfg = dict(type=padding_mode)
+            self.padding_layer = build_padding_layer(pad_cfg, padding)
+
+        conv_padding = 0 if self.with_explicit_padding else padding
+        self.conv = build_conv_layer(
+            conv_cfg,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=conv_padding,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+        )
+        self.in_channels = self.conv.in_channels
+        self.out_channels = self.conv.out_channels
+        self.kernel_size = self.conv.kernel_size
+        self.stride = self.conv.stride
+        self.padding = padding
+        self.dilation = self.conv.dilation
+        self.transposed = self.conv.transposed
+        self.output_padding = self.conv.output_padding
+        self.groups = self.conv.groups
+
+        if self.with_spectral_norm:
+            self.conv = nn.utils.spectral_norm(self.conv)
+
+        if self.with_norm:
+            if order.index("norm") > order.index("conv"):
+                norm_channels = out_channels
+            else:
+                norm_channels = in_channels
+            self.norm_name, norm = build_norm_layer(norm_cfg, norm_channels)
+            self.add_module(self.norm_name, norm)
+            if self.with_bias:
+                if isinstance(norm, (_BatchNorm, _InstanceNorm)):
+                    warnings.warn("Unnecessary conv bias before batch/instance norm")
+        else:
+            self.norm_name = None
+
+        if self.with_activation:
+            act_cfg_ = act_cfg.copy()
+            if act_cfg_["type"] not in [
+                "Tanh",
+                "PReLU",
+                "Sigmoid",
+                "HSigmoid",
+                "Swish",
+            ]:
+                act_cfg_.setdefault("inplace", inplace)
+            self.activate = build_activation_layer(act_cfg_)
+
+        self.init_weights()
+
+    @property
+    def norm(self):
+        if self.norm_name:
+            return getattr(self, self.norm_name)
+        else:
+            return None
+
+    def init_weights(self):
+        if not hasattr(self.conv, "init_weights"):
+            if self.with_activation and self.act_cfg["type"] == "LeakyReLU":
+                nonlinearity = "leaky_relu"
+                a = self.act_cfg.get("negative_slope", 0.01)
+            else:
+                nonlinearity = "relu"
+                a = 0
+            kaiming_init(self.conv, a=a, nonlinearity=nonlinearity)
+        if self.with_norm:
+            constant_init(self.norm, 1, bias=0)
+
+    def forward(self, x, activate=True, norm=True):
+        for layer in self.order:
+            if layer == "conv":
+                if self.with_explicit_padding:
+                    x = self.padding_layer(x)
+                x = self.conv(x)
+            elif layer == "norm" and norm and self.with_norm:
+                x = self.norm(x)
+            elif layer == "act" and activate and self.with_activation:
+                x = self.activate(x)
+        return x
+
+
+_BatchNorm, _InstanceNorm, SyncBatchNorm_ = _get_norm()
+
+
+def infer_abbr(class_type):
+    if not inspect.isclass(class_type):
+        raise TypeError(f"class_type must be a type, but got {type(class_type)}")
+    if hasattr(class_type, "_abbr_"):
+        return class_type._abbr_
+    if issubclass(class_type, _InstanceNorm):
+        return "in"
+    elif issubclass(class_type, _BatchNorm):
+        return "bn"
+    elif issubclass(class_type, nn.GroupNorm):
+        return "gn"
+    elif issubclass(class_type, nn.LayerNorm):
+        return "ln"
+    else:
+        class_name = class_type.__name__.lower()
+        if "batch" in class_name:
+            return "bn"
+        elif "group" in class_name:
+            return "gn"
+        elif "layer" in class_name:
+            return "ln"
+        elif "instance" in class_name:
+            return "in"
+        else:
+            return "norm_layer"
+
+
+def build_norm_layer(cfg, num_features, postfix=""):
+    if not isinstance(cfg, dict):
+        raise TypeError("cfg must be a dict")
+    if "type" not in cfg:
+        raise KeyError('the cfg dict must contain the key "type"')
+    cfg_ = cfg.copy()
+
+    layer_type = cfg_.pop("type")
+    if layer_type not in NORM_LAYERS:
+        raise KeyError(f"Unrecognized norm type {layer_type}")
+
+    norm_layer = NORM_LAYERS.get(layer_type)
+    abbr = infer_abbr(norm_layer)
+
+    assert isinstance(postfix, (int, str))
+    name = abbr + str(postfix)
+
+    requires_grad = cfg_.pop("requires_grad", True)
+    cfg_.setdefault("eps", 1e-5)
+    if layer_type != "GN":
+        layer = norm_layer(num_features, **cfg_)
+        if layer_type == "SyncBN" and hasattr(layer, "_specify_ddp_gpu_num"):
+            layer._specify_ddp_gpu_num(1)
+    else:
+        assert "num_groups" in cfg_
+        layer = norm_layer(num_channels=num_features, **cfg_)
+
+    for param in layer.parameters():
+        param.requires_grad = requires_grad
+
+    return name, layer
+
+
+def obsolete_torch_version(torch_version, version_threshold):
+    return torch_version == "parrots" or torch_version <= version_threshold
+
+
+class NewEmptyTensorOp(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, new_shape):
+        ctx.shape = x.shape
+        return x.new_empty(new_shape)
+
+    @staticmethod
+    def backward(ctx, grad):
+        shape = ctx.shape
+        return NewEmptyTensorOp.apply(grad, shape), None
+
+
+@CONV_LAYERS.register_module("Conv", force=True)
+class Conv2d(nn.Conv2d):
+    def forward(self, x):
+        if x.numel() == 0 and obsolete_torch_version(TORCH_VERSION, (1, 4)):
+            out_shape = [x.shape[0], self.out_channels]
+            for i, k, p, s, d in zip(
+                x.shape[-2:], self.kernel_size, self.padding, self.stride, self.dilation
+            ):
+                o = (i + 2 * p - (d * (k - 1) + 1)) // s + 1
+                out_shape.append(o)
+            empty = NewEmptyTensorOp.apply(x, out_shape)
+            if self.training:
+                dummy = sum(x.view(-1)[0] for x in self.parameters()) * 0.0
+                return empty + dummy
+            else:
+                return empty
+
+        return super().forward(x)
+
+
+class Linear(torch.nn.Linear):
+    def forward(self, x):
+        if x.numel() == 0 and obsolete_torch_version(TORCH_VERSION, (1, 5)):
+            out_shape = [x.shape[0], self.out_features]
+            empty = NewEmptyTensorOp.apply(x, out_shape)
+            if self.training:
+                dummy = sum(x.view(-1)[0] for x in self.parameters()) * 0.0
+                return empty + dummy
+            else:
+                return empty
+
+        return super().forward(x)
+
+
+class ModuleList(BaseModule, nn.ModuleList):
+    def __init__(self, modules=None, init_cfg=None):
+        BaseModule.__init__(self, init_cfg)
+        nn.ModuleList.__init__(self, modules)
+
+
+def build_positional_encoding(cfg, default_args=None):
+    return build_from_cfg(cfg, POSITIONAL_ENCODING, default_args)
+
+
+def build_feedforward_network(cfg, default_args=None):
+    return build_from_cfg(cfg, FEEDFORWARD_NETWORK, default_args)
+
+
+def build_transformer_layer(cfg, default_args=None):
+    return build_from_cfg(cfg, TRANSFORMER_LAYER, default_args)
+
+
+@DROPOUT_LAYERS.register_module()
+class Dropout(nn.Dropout):
+    def __init__(self, drop_prob=0.5, inplace=False):
+        super().__init__(p=drop_prob, inplace=inplace)
+
+
+def build_dropout(cfg, default_args=None):
+    return build_from_cfg(cfg, DROPOUT_LAYERS, default_args)
+
+
+def build_activation_layer(cfg):
+    return build_from_cfg(cfg, ACTIVATION_LAYERS)
+
+
+@FEEDFORWARD_NETWORK.register_module()
+class FFN(BaseModule):
+    def __init__(
+        self,
+        embed_dims=256,
+        feedforward_channels=1024,
+        num_fcs=2,
+        act_cfg=dict(type="ReLU", inplace=True),
+        ffn_drop=0.0,
+        dropout_layer=None,
+        add_identity=True,
+        init_cfg=None,
+        **kwargs,
+    ):
+        super(FFN, self).__init__(init_cfg)
+        assert num_fcs >= 2, "num_fcs should be no less " f"than 2. got {num_fcs}."
+        self.embed_dims = embed_dims
+        self.feedforward_channels = feedforward_channels
+        self.num_fcs = num_fcs
+        self.act_cfg = act_cfg
+        self.activate = build_activation_layer(act_cfg)
+
+        layers = []
+        in_channels = embed_dims
+        for _ in range(num_fcs - 1):
+            layers.append(
+                Sequential(
+                    Linear(in_channels, feedforward_channels),
+                    self.activate,
+                    nn.Dropout(ffn_drop),
+                )
+            )
+            in_channels = feedforward_channels
+        layers.append(Linear(feedforward_channels, embed_dims))
+        layers.append(nn.Dropout(ffn_drop))
+        self.layers = Sequential(*layers)
+        self.dropout_layer = (
+            build_dropout(dropout_layer) if dropout_layer else torch.nn.Identity()
+        )
+        self.add_identity = add_identity
+
+    def forward(self, x, identity=None):
+        out = self.layers(x)
+        if not self.add_identity:
+            return self.dropout_layer(out)
+        if identity is None:
+            identity = x
+        return identity + self.dropout_layer(out)
+
+
+@ATTENTION.register_module()
+class MultiheadAttention(BaseModule):
+    def __init__(
+        self,
+        embed_dims,
+        num_heads,
+        attn_drop=0.0,
+        proj_drop=0.0,
+        dropout_layer=dict(type="Dropout", drop_prob=0.0),
+        init_cfg=None,
+        batch_first=False,
+        **kwargs,
+    ):
+        super(MultiheadAttention, self).__init__(init_cfg)
+        if "dropout" in kwargs:
+            warnings.warn(
+                "The arguments `dropout` in MultiheadAttention "
+                "has been deprecated, now you can separately "
+                "set `attn_drop`(float), proj_drop(float), "
+                "and `dropout_layer`(dict) "
+            )
+            attn_drop = kwargs["dropout"]
+            dropout_layer["drop_prob"] = kwargs.pop("dropout")
+
+        self.embed_dims = embed_dims
+        self.num_heads = num_heads
+        self.batch_first = batch_first
+
+        self.attn = nn.MultiheadAttention(embed_dims, num_heads, attn_drop, **kwargs)
+
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.dropout_layer = (
+            build_dropout(dropout_layer) if dropout_layer else nn.Identity()
+        )
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_pos=None,
+        attn_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+        if identity is None:
+            identity = query
+        if key_pos is None:
+            if query_pos is not None:
+                if query_pos.shape == key.shape:
+                    key_pos = query_pos
+                else:
+                    warnings.warn(
+                        f"position encoding of key is"
+                        f"missing in {self.__class__.__name__}."
+                    )
+        if query_pos is not None:
+            query = query + query_pos
+        if key_pos is not None:
+            key = key + key_pos
+
+        if self.batch_first:
+            query = query.transpose(0, 1)
+            key = key.transpose(0, 1)
+            value = value.transpose(0, 1)
+
+        out = self.attn(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+            key_padding_mask=key_padding_mask,
+        )[0]
+
+        if self.batch_first:
+            out = out.transpose(0, 1)
+
+        return identity + self.dropout_layer(self.proj_drop(out))
+
+
+def build_attention(cfg, default_args=None):
+    return build_from_cfg(cfg, ATTENTION, default_args)
+
+
+@TRANSFORMER_LAYER.register_module()
+class BaseTransformerLayer(BaseModule):
+    def __init__(
+        self,
+        attn_cfgs=None,
+        ffn_cfgs=dict(
+            type="FFN",
+            embed_dims=256,
+            feedforward_channels=1024,
+            num_fcs=2,
+            ffn_drop=0.0,
+            act_cfg=dict(type="ReLU", inplace=True),
+        ),
+        operation_order=None,
+        norm_cfg=dict(type="LN"),
+        init_cfg=None,
+        batch_first=False,
+        **kwargs,
+    ):
+
+        deprecated_args = dict(
+            feedforward_channels="feedforward_channels",
+            ffn_dropout="ffn_drop",
+            ffn_num_fcs="num_fcs",
+        )
+        for ori_name, new_name in deprecated_args.items():
+            if ori_name in kwargs:
+                warnings.warn(
+                    f"The arguments `{ori_name}` in BaseTransformerLayer "
+                    f"has been deprecated, now you should set `{new_name}` "
+                    f"and other FFN related arguments "
+                    f"to a dict named `ffn_cfgs`. "
+                )
+                ffn_cfgs[new_name] = kwargs[ori_name]
+
+        super(BaseTransformerLayer, self).__init__(init_cfg)
+
+        self.batch_first = batch_first
+
+        assert set(operation_order) & set(
+            ["self_attn", "norm", "ffn", "cross_attn"]
+        ) == set(operation_order), (
+            f"The operation_order of"
+            f" {self.__class__.__name__} should "
+            f"contains all four operation type "
+            f"{['self_attn', 'norm', 'ffn', 'cross_attn']}"
+        )
+
+        num_attn = operation_order.count("self_attn") + operation_order.count(
+            "cross_attn"
+        )
+        if isinstance(attn_cfgs, dict):
+            attn_cfgs = [copy.deepcopy(attn_cfgs) for _ in range(num_attn)]
+        else:
+            assert num_attn == len(attn_cfgs), (
+                f"The length "
+                f"of attn_cfg {num_attn} is "
+                f"not consistent with the number of attention"
+                f"in operation_order {operation_order}."
+            )
+
+        self.num_attn = num_attn
+        self.operation_order = operation_order
+        self.norm_cfg = norm_cfg
+        self.pre_norm = operation_order[0] == "norm"
+        self.attentions = ModuleList()
+
+        index = 0
+        for operation_name in operation_order:
+            if operation_name in ["self_attn", "cross_attn"]:
+                if "batch_first" in attn_cfgs[index]:
+                    assert self.batch_first == attn_cfgs[index]["batch_first"]
+                else:
+                    attn_cfgs[index]["batch_first"] = self.batch_first
+                attention = build_attention(attn_cfgs[index])
+                attention.operation_name = operation_name
+                self.attentions.append(attention)
+                index += 1
+
+        self.embed_dims = self.attentions[0].embed_dims
+
+        self.ffns = ModuleList()
+        num_ffns = operation_order.count("ffn")
+        if isinstance(ffn_cfgs, dict):
+            ffn_cfgs = ConfigDict(ffn_cfgs)
+        if isinstance(ffn_cfgs, dict):
+            ffn_cfgs = [copy.deepcopy(ffn_cfgs) for _ in range(num_ffns)]
+        assert len(ffn_cfgs) == num_ffns
+        for ffn_index in range(num_ffns):
+            if "embed_dims" not in ffn_cfgs[ffn_index]:
+                ffn_cfgs["embed_dims"] = self.embed_dims
+            else:
+                assert ffn_cfgs[ffn_index]["embed_dims"] == self.embed_dims
+            self.ffns.append(
+                build_feedforward_network(ffn_cfgs[ffn_index], dict(type="FFN"))
+            )
+
+        self.norms = ModuleList()
+        num_norms = operation_order.count("norm")
+        for _ in range(num_norms):
+            self.norms.append(build_norm_layer(norm_cfg, self.embed_dims)[1])
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+
+        norm_index = 0
+        attn_index = 0
+        ffn_index = 0
+        identity = query
+        if attn_masks is None:
+            attn_masks = [None for _ in range(self.num_attn)]
+        elif isinstance(attn_masks, torch.Tensor):
+            attn_masks = [copy.deepcopy(attn_masks) for _ in range(self.num_attn)]
+            warnings.warn(
+                f"Use same attn_mask in all attentions in "
+                f"{self.__class__.__name__} "
+            )
+        else:
+            assert len(attn_masks) == self.num_attn, (
+                f"The length of "
+                f"attn_masks {len(attn_masks)} must be equal "
+                f"to the number of attention in "
+                f"operation_order {self.num_attn}"
+            )
+
+        for layer in self.operation_order:
+            if layer == "self_attn":
+                temp_key = temp_value = query
+                query = self.attentions[attn_index](
+                    query,
+                    temp_key,
+                    temp_value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=query_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=query_key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "norm":
+                query = self.norms[norm_index](query)
+                norm_index += 1
+
+            elif layer == "cross_attn":
+                query = self.attentions[attn_index](
+                    query,
+                    key,
+                    value,
+                    identity if self.pre_norm else None,
+                    query_pos=query_pos,
+                    key_pos=key_pos,
+                    attn_mask=attn_masks[attn_index],
+                    key_padding_mask=key_padding_mask,
+                    **kwargs,
+                )
+                attn_index += 1
+                identity = query
+
+            elif layer == "ffn":
+                query = self.ffns[ffn_index](query, identity if self.pre_norm else None)
+                ffn_index += 1
+
+        return query
+
+
+@TRANSFORMER_LAYER_SEQUENCE.register_module()
+class TransformerLayerSequence(BaseModule):
+    def __init__(self, transformerlayers=None, num_layers=None, init_cfg=None):
+        super(TransformerLayerSequence, self).__init__(init_cfg)
+        if isinstance(transformerlayers, dict):
+            transformerlayers = [
+                copy.deepcopy(transformerlayers) for _ in range(num_layers)
+            ]
+        else:
+            assert (
+                isinstance(transformerlayers, list)
+                and len(transformerlayers) == num_layers
+            )
+        self.num_layers = num_layers
+        self.layers = ModuleList()
+        for i in range(num_layers):
+            self.layers.append(build_transformer_layer(transformerlayers[i]))
+        self.embed_dims = self.layers[0].embed_dims
+        self.pre_norm = self.layers[0].pre_norm
+
+    def forward(
+        self,
+        query,
+        key,
+        value,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+        for layer in self.layers:
+            query = layer(
+                query,
+                key,
+                value,
+                query_pos=query_pos,
+                key_pos=key_pos,
+                attn_masks=attn_masks,
+                query_key_padding_mask=query_key_padding_mask,
+                key_padding_mask=key_padding_mask,
+                **kwargs,
+            )
+        return query
+
+
+class DataContainer:
+    def __init__(self, data, stack=False, padding_value=0, cpu_only=False, pad_dims=2):
+        self._data = data
+        self._cpu_only = cpu_only
+        self._stack = stack
+        self._padding_value = padding_value
+        assert pad_dims in [None, 1, 2, 3]
+        self._pad_dims = pad_dims
+
+    def __len__(self):
+        return len(self._data)
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def datatype(self):
+        if isinstance(self.data, torch.Tensor):
+            return self.data.type()
+        else:
+            return type(self.data)
+
+    @property
+    def cpu_only(self):
+        return self._cpu_only
+
+    @property
+    def stack(self):
+        return self._stack
+
+    @property
+    def padding_value(self):
+        return self._padding_value
+
+    @property
+    def pad_dims(self):
+        return self._pad_dims
+
+    def size(self, *args, **kwargs):
+        return self.data.size(*args, **kwargs)
+
+    def dim(self):
+        return self.data.dim()
+
+
+class CheckpointLoader:
+
+    _schemes = {}
+
+    @classmethod
+    def _register_scheme(cls, prefixes, loader, force=False):
+        if isinstance(prefixes, str):
+            prefixes = [prefixes]
+        else:
+            assert isinstance(prefixes, (list, tuple))
+        for prefix in prefixes:
+            if (prefix not in cls._schemes) or force:
+                cls._schemes[prefix] = loader
+            else:
+                raise KeyError(
+                    f"{prefix} is already registered as a loader backend, "
+                    'add "force=True" if you want to override it'
+                )
+        cls._schemes = OrderedDict(
+            sorted(cls._schemes.items(), key=lambda t: t[0], reverse=True)
+        )
+
+    @classmethod
+    def register_scheme(cls, prefixes, loader=None, force=False):
+
+        if loader is not None:
+            cls._register_scheme(prefixes, loader, force=force)
+            return
+
+        def _register(loader_cls):
+            cls._register_scheme(prefixes, loader_cls, force=force)
+            return loader_cls
+
+        return _register
+
+    @classmethod
+    def _get_checkpoint_loader(cls, path):
+        for p in cls._schemes:
+            if path.startswith(p):
+                return cls._schemes[p]
+
+    @classmethod
+    def load_checkpoint(cls, filename, map_location=None, logger=None):
+        checkpoint_loader = cls._get_checkpoint_loader(filename)
+        class_name = checkpoint_loader.__name__
+        return checkpoint_loader(filename, map_location)
+
+
+def _load_checkpoint(filename, map_location=None, logger=None):
+    return CheckpointLoader.load_checkpoint(filename, map_location, logger)
+
+
+def load_checkpoint(
+    model,
+    filename,
+    map_location=None,
+    strict=False,
+    logger=None,
+    revise_keys=[(r"^module\.", "")],
+):
+    checkpoint = _load_checkpoint(filename, map_location, logger)
+    if not isinstance(checkpoint, dict):
+        raise RuntimeError(f"No state_dict found in checkpoint file {filename}")
+    if "state_dict" in checkpoint:
+        state_dict = checkpoint["state_dict"]
+    else:
+        state_dict = checkpoint
+
+    metadata = getattr(state_dict, "_metadata", OrderedDict())
+    for p, r in revise_keys:
+        state_dict = OrderedDict({re.sub(p, r, k): v for k, v in state_dict.items()})
+    state_dict._metadata = metadata
+    load_state_dict(model, state_dict, strict, logger)
+    return checkpoint
+
+
+@CheckpointLoader.register_scheme(prefixes="")
+def load_from_local(filename, map_location):
+    if not osp.isfile(filename):
+        raise IOError(f"{filename} is not a checkpoint file")
+    checkpoint = torch.load(filename, map_location=map_location)
+    return checkpoint
+
+
+def is_module_wrapper(module):
+
+    module_wrappers = tuple(MODULE_WRAPPERS.module_dict.values())
+    return isinstance(module, module_wrappers)
+
+
+def get_dist_info():
+    if dist.is_available() and dist.is_initialized():
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+    else:
+        rank = 0
+        world_size = 1
+    return rank, world_size
+
+
+def load_state_dict(module, state_dict, strict=False, logger=None):
+    unexpected_keys = []
+    all_missing_keys = []
+    err_msg = []
+
+    metadata = getattr(state_dict, "_metadata", None)
+    state_dict = state_dict.copy()
+    if metadata is not None:
+        state_dict._metadata = metadata
+
+    def load(module, prefix=""):
+        if is_module_wrapper(module):
+            module = module.module
+        local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
+        module._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            True,
+            all_missing_keys,
+            unexpected_keys,
+            err_msg,
+        )
+        for name, child in module._modules.items():
+            if child is not None:
+                load(child, prefix + name + ".")
+
+    load(module)
+    load = None
+    missing_keys = [key for key in all_missing_keys if "num_batches_tracked" not in key]
+
+    if unexpected_keys:
+        err_msg.append(
+            "unexpected key in source " f'state_dict: {", ".join(unexpected_keys)}\n'
+        )
+    if missing_keys:
+        err_msg.append(
+            f'missing keys in source state_dict: {", ".join(missing_keys)}\n'
+        )
+
+    rank, _ = get_dist_info()
+    if len(err_msg) > 0 and rank == 0:
+        err_msg.insert(0, "The model and loaded state dict do not match exactly\n")
+        err_msg = "\n".join(err_msg)
+        if strict:
+            raise RuntimeError(err_msg)
+        elif logger is not None:
+            logger.warning(err_msg)
+        else:
+            print(err_msg)
+
+
+class ModulatedDeformConv2d(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        groups=1,
+        deform_groups=1,
+        bias=True,
+    ):
+        super(ModulatedDeformConv2d, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_size = _pair(kernel_size)
+        self.stride = _pair(stride)
+        self.padding = _pair(padding)
+        self.dilation = _pair(dilation)
+        self.groups = groups
+        self.deform_groups = deform_groups
+        self.transposed = False
+        self.output_padding = _single(0)
+
+        self.weight = nn.Parameter(
+            torch.Tensor(out_channels, in_channels // groups, *self.kernel_size)
+        )
+        if bias:
+            self.bias = nn.Parameter(torch.Tensor(out_channels))
+        else:
+            self.register_parameter("bias", None)
+        self.init_weights()
+
+    def init_weights(self):
+        n = self.in_channels
+        for k in self.kernel_size:
+            n *= k
+        stdv = 1.0 / math.sqrt(n)
+        self.weight.data.uniform_(-stdv, stdv)
+        if self.bias is not None:
+            self.bias.data.zero_()
+
+    def forward(self, x, offset, mask):
+        pass
+
+
+@CONV_LAYERS.register_module("DCNv2")
+class ModulatedDeformConv2dPack(ModulatedDeformConv2d):
+    _version = 2
+
+    def __init__(self, *args, **kwargs):
+        super(ModulatedDeformConv2dPack, self).__init__(*args, **kwargs)
+        self.conv_offset = nn.Conv2d(
+            self.in_channels,
+            self.deform_groups * 3 * self.kernel_size[0] * self.kernel_size[1],
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            bias=True,
+        )
+        self.init_weights()
+
+    def init_weights(self):
+        super(ModulatedDeformConv2dPack, self).init_weights()
+        if hasattr(self, "conv_offset"):
+            self.conv_offset.weight.data.zero_()
+            self.conv_offset.bias.data.zero_()
+
+    def forward(self, x):
+        out = self.conv_offset(x)
+        o1, o2, mask = torch.chunk(out, 3, dim=1)
+        offset = torch.cat((o1, o2), dim=1)
+        mask = torch.sigmoid(mask)
+
+        # Replaced the custom ModulatedDeformConv2dFunction.apply call with torchvision.ops.deform_conv2d
+        # Reference:https://github.com/open-mmlab/mmcv/blob/7207397de3c2ffaef878628a55fa2ab37ac0bbc7/mmcv/ops/modulated_deform_conv.py#L153
+
+        return ops.deform_conv2d(
+            x,
+            offset,
+            self.weight,
+            self.bias,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            mask=mask,
+        )
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        version = local_metadata.get("version", None)
+
+        if version is None or version < 2:
+            if (
+                prefix + "conv_offset.weight" not in state_dict
+                and prefix[:-1] + "_offset.weight" in state_dict
+            ):
+                state_dict[prefix + "conv_offset.weight"] = state_dict.pop(
+                    prefix[:-1] + "_offset.weight"
+                )
+            if (
+                prefix + "conv_offset.bias" not in state_dict
+                and prefix[:-1] + "_offset.bias" in state_dict
+            ):
+                state_dict[prefix + "conv_offset.bias"] = state_dict.pop(
+                    prefix[:-1] + "_offset.bias"
+                )
+
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+
+# ============================================================================
+# MMDET UTILS
+# ============================================================================
+
+
+BACKBONES = MODELS
+NECKS = MODELS
+ROI_EXTRACTORS = MODELS
+SHARED_HEADS = MODELS
+HEADS = MODELS
+LOSSES = MODELS
+DETECTORS = MODELS
+
+PRIOR_GENERATORS = Registry("Generator for anchors and points")
+BBOX_ASSIGNERS = Registry("bbox_assigner")
+BBOX_SAMPLERS = Registry("bbox_sampler")
+BBOX_CODERS = Registry("bbox_coder")
+TRANSFORMER = Registry("Transformer")
+
+
+def build_backbone(cfg):
+    return BACKBONES.build(cfg)
+
+
+def build_neck(cfg):
+    return NECKS.build(cfg)
+
+
+def build_roi_extractor(cfg):
+    return ROI_EXTRACTORS.build(cfg)
+
+
+def build_shared_head(cfg):
+    return SHARED_HEADS.build(cfg)
+
+
+def build_head(cfg):
+    return HEADS.build(cfg)
+
+
+def build_loss(cfg):
+    return LOSSES.build(cfg)
+
+
+def build_detector(cfg, train_cfg=None, test_cfg=None):
+    return DETECTORS.build(
+        cfg, default_args=dict(train_cfg=train_cfg, test_cfg=test_cfg)
+    )
+
+
+def build_prior_generator(cfg, default_args=None):
+    return build_from_cfg(cfg, PRIOR_GENERATORS, default_args)
+
+
+def build_assigner(cfg, **default_args):
+    return build_from_cfg(cfg, BBOX_ASSIGNERS, default_args)
+
+
+def build_sampler(cfg, **default_args):
+    return build_from_cfg(cfg, BBOX_SAMPLERS, default_args)
+
+
+def build_bbox_coder(cfg, **default_args):
+    return build_from_cfg(cfg, BBOX_CODERS, default_args)
+
+
+def inverse_sigmoid(x, eps=1e-5):
+    x = x.clamp(min=0, max=1)
+    x1 = x.clamp(min=eps)
+    x2 = (1 - x).clamp(min=eps)
+    return torch.log(x1 / x2)
+
+
+@MATCH_COST.register_module()
+class IoUCost:
+    def __init__(self, iou_mode="giou", weight=1.0):
+        self.weight = weight
+        self.iou_mode = iou_mode
+
+
+@LOSSES.register_module()
+class FocalLoss(nn.Module):
+    def __init__(
+        self,
+        use_sigmoid=True,
+        gamma=2.0,
+        alpha=0.25,
+        reduction="mean",
+        loss_weight=1.0,
+        activated=False,
+    ):
+        super(FocalLoss, self).__init__()
+        assert use_sigmoid is True, "Only sigmoid focal loss supported now."
+        self.use_sigmoid = use_sigmoid
+        self.gamma = gamma
+        self.alpha = alpha
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+        self.activated = activated
+
+
+@LOSSES.register_module()
+class IoULoss(nn.Module):
+    def __init__(
+        self, linear=False, eps=1e-6, reduction="mean", loss_weight=1.0, mode="log"
+    ):
+        super(IoULoss, self).__init__()
+        assert mode in ["linear", "square", "log"]
+        if linear:
+            mode = "linear"
+            warnings.warn(
+                'DeprecationWarning: Setting "linear=True" in '
+                'IOULoss is deprecated, please use "mode=`linear`" '
+                "instead."
+            )
+        self.mode = mode
+        self.linear = linear
+        self.eps = eps
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+
+
+@MATCH_COST.register_module()
+class FocalLossCost:
+    def __init__(self, weight=1.0, alpha=0.25, gamma=2, eps=1e-12, binary_input=False):
+        self.weight = weight
+        self.alpha = alpha
+        self.gamma = gamma
+        self.eps = eps
+        self.binary_input = binary_input
+
+
+@LOSSES.register_module()
+class L1Loss(nn.Module):
+    def __init__(self, reduction="mean", loss_weight=1.0):
+        super(L1Loss, self).__init__()
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+
+
+class BaseSampler(metaclass=ABCMeta):
+    def __init__(
+        self, num, pos_fraction, neg_pos_ub=-1, add_gt_as_proposals=True, **kwargs
+    ):
+        self.num = num
+        self.pos_fraction = pos_fraction
+        self.neg_pos_ub = neg_pos_ub
+        self.add_gt_as_proposals = add_gt_as_proposals
+        self.pos_sampler = self
+        self.neg_sampler = self
+
+
+@BBOX_SAMPLERS.register_module()
+class PseudoSampler(BaseSampler):
+    def __init__(self, **kwargs):
+        pass
+
+
+@LOSSES.register_module()
+class GIoULoss(nn.Module):
+    def __init__(self, eps=1e-6, reduction="mean", loss_weight=1.0):
+        super(GIoULoss, self).__init__()
+        self.eps = eps
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+
+
+class BaseAssigner(metaclass=ABCMeta):
+    @abstractmethod
+    def assign(self, bboxes, gt_bboxes, gt_bboxes_ignore=None, gt_labels=None):
+        pass
+
+
+class BaseBBoxCoder(metaclass=ABCMeta):
+    pass
+
+
+@BBOX_CODERS.register_module()
+class DistancePointBBoxCoder(BaseBBoxCoder):
+    def __init__(self, clip_border=True):
+        super(BaseBBoxCoder, self).__init__()
+        self.clip_border = clip_border
+
+
+@PRIOR_GENERATORS.register_module()
+class MlvlPointGenerator:
+    def __init__(self, strides, offset=0.5):
+        self.strides = [_pair(stride) for stride in strides]
+        self.offset = offset
+
+    @property
+    def num_levels(self):
+        return len(self.strides)
+
+    @property
+    def num_base_priors(self):
+        return [1 for _ in range(len(self.strides))]
+
+    def _meshgrid(self, x, y, row_major=True):
+        yy, xx = torch.meshgrid(y, x)
+        if row_major:
+            return xx.reshape(-1), yy.reshape(-1)
+
+        else:
+            return yy.reshape(-1), xx.reshape(-1)
+
+    def grid_priors(
+        self, featmap_sizes, dtype=torch.float32, device="cuda", with_stride=False
+    ):
+
+        assert self.num_levels == len(featmap_sizes)
+        multi_level_priors = []
+        for i in range(self.num_levels):
+            priors = self.single_level_grid_priors(
+                featmap_sizes[i],
+                level_idx=i,
+                dtype=dtype,
+                device=device,
+                with_stride=with_stride,
+            )
+            multi_level_priors.append(priors)
+        return multi_level_priors
+
+    def single_level_grid_priors(
+        self,
+        featmap_size,
+        level_idx,
+        dtype=torch.float32,
+        device="cuda",
+        with_stride=False,
+    ):
+        feat_h, feat_w = featmap_size
+        stride_w, stride_h = self.strides[level_idx]
+        shift_x = (torch.arange(0, feat_w, device=device) + self.offset) * stride_w
+        shift_x = shift_x.to(dtype)
+
+        shift_y = (torch.arange(0, feat_h, device=device) + self.offset) * stride_h
+        shift_y = shift_y.to(dtype)
+        shift_xx, shift_yy = self._meshgrid(shift_x, shift_y)
+        if not with_stride:
+            shifts = torch.stack([shift_xx, shift_yy], dim=-1)
+        else:
+            stride_w = shift_xx.new_full((shift_xx.shape[0],), stride_w).to(dtype)
+            stride_h = shift_xx.new_full((shift_yy.shape[0],), stride_h).to(dtype)
+            shifts = torch.stack([shift_xx, shift_yy, stride_w, stride_h], dim=-1)
+        all_points = shifts.to(device)
+        return all_points
+
+    def valid_flags(self, featmap_sizes, pad_shape, device="cuda"):
+        assert self.num_levels == len(featmap_sizes)
+        multi_level_flags = []
+        for i in range(self.num_levels):
+            point_stride = self.strides[i]
+            feat_h, feat_w = featmap_sizes[i]
+            h, w = pad_shape[:2]
+            valid_feat_h = min(int(np.ceil(h / point_stride[1])), feat_h)
+            valid_feat_w = min(int(np.ceil(w / point_stride[0])), feat_w)
+            flags = self.single_level_valid_flags(
+                (feat_h, feat_w), (valid_feat_h, valid_feat_w), device=device
+            )
+            multi_level_flags.append(flags)
+        return multi_level_flags
+
+    def single_level_valid_flags(self, featmap_size, valid_size, device="cuda"):
+        feat_h, feat_w = featmap_size
+        valid_h, valid_w = valid_size
+        assert valid_h <= feat_h and valid_w <= feat_w
+        valid_x = torch.zeros(feat_w, dtype=torch.bool, device=device)
+        valid_y = torch.zeros(feat_h, dtype=torch.bool, device=device)
+        valid_x[:valid_w] = 1
+        valid_y[:valid_h] = 1
+        valid_xx, valid_yy = self._meshgrid(valid_x, valid_y)
+        valid = valid_xx & valid_yy
+        return valid
+
+    def sparse_priors(
+        self, prior_idxs, featmap_size, level_idx, dtype=torch.float32, device="cuda"
+    ):
+        height, width = featmap_size
+        x = (prior_idxs % width + self.offset) * self.strides[level_idx][0]
+        y = ((prior_idxs // width) % height + self.offset) * self.strides[level_idx][1]
+        prioris = torch.stack([x, y], 1).to(dtype)
+        prioris = prioris.to(device)
+        return prioris
+
+
+class BaseDenseHead(BaseModule, metaclass=ABCMeta):
+    def __init__(self, init_cfg=None):
+        super(BaseDenseHead, self).__init__(init_cfg)
+
+    def init_weights(self):
+        super(BaseDenseHead, self).init_weights()
+        for m in self.modules():
+            if hasattr(m, "conv_offset"):
+                constant_init(m.conv_offset, 0)
+
+
+class BBoxTestMixin(object):
+    def simple_test_bboxes(self, feats, img_metas, rescale=False):
+        outs = self.forward(feats)
+        results_list = self.get_bboxes(*outs, img_metas=img_metas, rescale=rescale)
+        return results_list
+
+
+@HEADS.register_module()
+class AnchorFreeHead(BaseDenseHead, BBoxTestMixin):
+
+    _version = 1
+
+    def __init__(
+        self,
+        num_classes,
+        in_channels,
+        feat_channels=256,
+        stacked_convs=4,
+        strides=(4, 8, 16, 32, 64),
+        dcn_on_last_conv=False,
+        conv_bias="auto",
+        loss_cls=dict(
+            type="FocalLoss", use_sigmoid=True, gamma=2.0, alpha=0.25, loss_weight=1.0
+        ),
+        loss_bbox=dict(type="IoULoss", loss_weight=1.0),
+        bbox_coder=dict(type="DistancePointBBoxCoder"),
+        conv_cfg=None,
+        norm_cfg=None,
+        train_cfg=None,
+        test_cfg=None,
+        init_cfg=dict(
+            type="Normal",
+            layer="Conv2d",
+            std=0.01,
+            override=dict(type="Normal", name="conv_cls", std=0.01, bias_prob=0.01),
+        ),
+    ):
+        super(AnchorFreeHead, self).__init__(init_cfg)
+        self.num_classes = num_classes
+        self.use_sigmoid_cls = loss_cls.get("use_sigmoid", False)
+        if self.use_sigmoid_cls:
+            self.cls_out_channels = num_classes
+        else:
+            self.cls_out_channels = num_classes + 1
+        self.in_channels = in_channels
+        self.feat_channels = feat_channels
+        self.stacked_convs = stacked_convs
+        self.strides = strides
+        self.dcn_on_last_conv = dcn_on_last_conv
+        assert conv_bias == "auto" or isinstance(conv_bias, bool)
+        self.conv_bias = conv_bias
+        self.loss_cls = build_loss(loss_cls)
+        self.loss_bbox = build_loss(loss_bbox)
+        self.bbox_coder = build_bbox_coder(bbox_coder)
+
+        self.prior_generator = MlvlPointGenerator(strides)
+        self.num_base_priors = self.prior_generator.num_base_priors[0]
+
+        self.train_cfg = train_cfg
+        self.test_cfg = test_cfg
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.fp16_enabled = False
+
+        self._init_layers()
+
+    def _init_layers(self):
+        self._init_cls_convs()
+        self._init_reg_convs()
+        self._init_predictor()
+
+    def _init_cls_convs(self):
+        self.cls_convs = nn.ModuleList()
+        for i in range(self.stacked_convs):
+            chn = self.in_channels if i == 0 else self.feat_channels
+            if self.dcn_on_last_conv and i == self.stacked_convs - 1:
+                conv_cfg = dict(type="DCNv2")
+            else:
+                conv_cfg = self.conv_cfg
+            self.cls_convs.append(
+                ConvModule(
+                    chn,
+                    self.feat_channels,
+                    3,
+                    stride=1,
+                    padding=1,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=self.norm_cfg,
+                    bias=self.conv_bias,
+                )
+            )
+
+    def _init_reg_convs(self):
+        self.reg_convs = nn.ModuleList()
+        for i in range(self.stacked_convs):
+            chn = self.in_channels if i == 0 else self.feat_channels
+            if self.dcn_on_last_conv and i == self.stacked_convs - 1:
+                conv_cfg = dict(type="DCNv2")
+            else:
+                conv_cfg = self.conv_cfg
+            self.reg_convs.append(
+                ConvModule(
+                    chn,
+                    self.feat_channels,
+                    3,
+                    stride=1,
+                    padding=1,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=self.norm_cfg,
+                    bias=self.conv_bias,
+                )
+            )
+
+    def _init_predictor(self):
+        self.conv_cls = nn.Conv2d(
+            self.feat_channels, self.cls_out_channels, 3, padding=1
+        )
+        self.conv_reg = nn.Conv2d(self.feat_channels, 4, 3, padding=1)
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+
+        version = local_metadata.get("version", None)
+        if version is None:
+            bbox_head_keys = [k for k in state_dict.keys() if k.startswith(prefix)]
+            ori_predictor_keys = []
+            new_predictor_keys = []
+            for key in bbox_head_keys:
+                ori_predictor_keys.append(key)
+                key = key.split(".")
+                conv_name = None
+                if key[1].endswith("cls"):
+                    conv_name = "conv_cls"
+                elif key[1].endswith("reg"):
+                    conv_name = "conv_reg"
+                elif key[1].endswith("centerness"):
+                    conv_name = "conv_centerness"
+                else:
+                    assert NotImplementedError
+                if conv_name is not None:
+                    key[1] = conv_name
+                    new_predictor_keys.append(".".join(key))
+                else:
+                    ori_predictor_keys.pop(-1)
+            for i in range(len(new_predictor_keys)):
+                state_dict[new_predictor_keys[i]] = state_dict.pop(
+                    ori_predictor_keys[i]
+                )
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+
+def build_transformer(cfg, default_args=None):
+    return build_from_cfg(cfg, TRANSFORMER, default_args)
+
+
+class ResLayer(Sequential):
+    def __init__(
+        self,
+        block,
+        inplanes,
+        planes,
+        num_blocks,
+        stride=1,
+        avg_down=False,
+        conv_cfg=None,
+        norm_cfg=dict(type="BN"),
+        downsample_first=True,
+        **kwargs,
+    ):
+        self.block = block
+
+        downsample = None
+        if stride != 1 or inplanes != planes * block.expansion:
+            downsample = []
+            conv_stride = stride
+            if avg_down:
+                conv_stride = 1
+                downsample.append(
+                    nn.AvgPool2d(
+                        kernel_size=stride,
+                        stride=stride,
+                        ceil_mode=True,
+                        count_include_pad=False,
+                    )
+                )
+            downsample.extend(
+                [
+                    build_conv_layer(
+                        conv_cfg,
+                        inplanes,
+                        planes * block.expansion,
+                        kernel_size=1,
+                        stride=conv_stride,
+                        bias=False,
+                    ),
+                    build_norm_layer(norm_cfg, planes * block.expansion)[1],
+                ]
+            )
+            downsample = nn.Sequential(*downsample)
+
+        layers = []
+        if downsample_first:
+            layers.append(
+                block(
+                    inplanes=inplanes,
+                    planes=planes,
+                    stride=stride,
+                    downsample=downsample,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    **kwargs,
+                )
+            )
+            inplanes = planes * block.expansion
+            for _ in range(1, num_blocks):
+                layers.append(
+                    block(
+                        inplanes=inplanes,
+                        planes=planes,
+                        stride=1,
+                        conv_cfg=conv_cfg,
+                        norm_cfg=norm_cfg,
+                        **kwargs,
+                    )
+                )
+
+        else:
+            for _ in range(num_blocks - 1):
+                layers.append(
+                    block(
+                        inplanes=inplanes,
+                        planes=inplanes,
+                        stride=1,
+                        conv_cfg=conv_cfg,
+                        norm_cfg=norm_cfg,
+                        **kwargs,
+                    )
+                )
+            layers.append(
+                block(
+                    inplanes=inplanes,
+                    planes=planes,
+                    stride=stride,
+                    downsample=downsample,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    **kwargs,
+                )
+            )
+        super(ResLayer, self).__init__(*layers)
+
+
+class BasicBlock(BaseModule):
+    expansion = 1
+
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        stride=1,
+        dilation=1,
+        downsample=None,
+        style="pytorch",
+        with_cp=False,
+        conv_cfg=None,
+        norm_cfg=dict(type="BN"),
+        dcn=None,
+        plugins=None,
+        init_cfg=None,
+    ):
+        super(BasicBlock, self).__init__(init_cfg)
+        assert dcn is None, "Not implemented yet."
+        assert plugins is None, "Not implemented yet."
+
+        self.norm1_name, norm1 = build_norm_layer(norm_cfg, planes, postfix=1)
+        self.norm2_name, norm2 = build_norm_layer(norm_cfg, planes, postfix=2)
+
+        self.conv1 = build_conv_layer(
+            conv_cfg,
+            inplanes,
+            planes,
+            3,
+            stride=stride,
+            padding=dilation,
+            dilation=dilation,
+            bias=False,
+        )
+        self.add_module(self.norm1_name, norm1)
+        self.conv2 = build_conv_layer(
+            conv_cfg, planes, planes, 3, padding=1, bias=False
+        )
+        self.add_module(self.norm2_name, norm2)
+
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+        self.stride = stride
+        self.dilation = dilation
+        self.with_cp = with_cp
+
+    @property
+    def norm1(self):
+        return getattr(self, self.norm1_name)
+
+    @property
+    def norm2(self):
+        return getattr(self, self.norm2_name)
+
+    def forward(self, x):
+        def _inner_forward(x):
+            identity = x
+
+            out = self.conv1(x)
+            out = self.norm1(out)
+            out = self.relu(out)
+
+            out = self.conv2(out)
+            out = self.norm2(out)
+
+            if self.downsample is not None:
+                identity = self.downsample(x)
+
+            out += identity
+
+            return out
+
+        if self.with_cp and x.requires_grad:
+            out = cp.checkpoint(_inner_forward, x)
+        else:
+            out = _inner_forward(x)
+
+        out = self.relu(out)
+
+        return out
+
+
+class Bottleneck(BaseModule):
+    expansion = 4
+
+    def __init__(
+        self,
+        inplanes,
+        planes,
+        stride=1,
+        dilation=1,
+        downsample=None,
+        style="pytorch",
+        with_cp=False,
+        conv_cfg=None,
+        norm_cfg=dict(type="BN"),
+        dcn=None,
+        plugins=None,
+        init_cfg=None,
+    ):
+        super(Bottleneck, self).__init__(init_cfg)
+        assert style in ["pytorch", "caffe"]
+        assert dcn is None or isinstance(dcn, dict)
+        assert plugins is None or isinstance(plugins, list)
+        if plugins is not None:
+            allowed_position = ["after_conv1", "after_conv2", "after_conv3"]
+            assert all(p["position"] in allowed_position for p in plugins)
+
+        self.inplanes = inplanes
+        self.planes = planes
+        self.stride = stride
+        self.dilation = dilation
+        self.style = style
+        self.with_cp = with_cp
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.dcn = dcn
+        self.with_dcn = dcn is not None
+        self.plugins = plugins
+        self.with_plugins = plugins is not None
+
+        if self.with_plugins:
+            self.after_conv1_plugins = [
+                plugin["cfg"]
+                for plugin in plugins
+                if plugin["position"] == "after_conv1"
+            ]
+            self.after_conv2_plugins = [
+                plugin["cfg"]
+                for plugin in plugins
+                if plugin["position"] == "after_conv2"
+            ]
+            self.after_conv3_plugins = [
+                plugin["cfg"]
+                for plugin in plugins
+                if plugin["position"] == "after_conv3"
+            ]
+
+        if self.style == "pytorch":
+            self.conv1_stride = 1
+            self.conv2_stride = stride
+        else:
+            self.conv1_stride = stride
+            self.conv2_stride = 1
+
+        self.norm1_name, norm1 = build_norm_layer(norm_cfg, planes, postfix=1)
+        self.norm2_name, norm2 = build_norm_layer(norm_cfg, planes, postfix=2)
+        self.norm3_name, norm3 = build_norm_layer(
+            norm_cfg, planes * self.expansion, postfix=3
+        )
+
+        self.conv1 = build_conv_layer(
+            conv_cfg,
+            inplanes,
+            planes,
+            kernel_size=1,
+            stride=self.conv1_stride,
+            bias=False,
+        )
+        self.add_module(self.norm1_name, norm1)
+        fallback_on_stride = False
+        if self.with_dcn:
+            fallback_on_stride = dcn.pop("fallback_on_stride", False)
+        if not self.with_dcn or fallback_on_stride:
+            self.conv2 = build_conv_layer(
+                conv_cfg,
+                planes,
+                planes,
+                kernel_size=3,
+                stride=self.conv2_stride,
+                padding=dilation,
+                dilation=dilation,
+                bias=False,
+            )
+        else:
+            assert self.conv_cfg is None, "conv_cfg must be None for DCN"
+            self.conv2 = build_conv_layer(
+                dcn,
+                planes,
+                planes,
+                kernel_size=3,
+                stride=self.conv2_stride,
+                padding=dilation,
+                dilation=dilation,
+                bias=False,
+            )
+
+        self.add_module(self.norm2_name, norm2)
+        self.conv3 = build_conv_layer(
+            conv_cfg, planes, planes * self.expansion, kernel_size=1, bias=False
+        )
+        self.add_module(self.norm3_name, norm3)
+
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+
+    def forward_plugin(self, x, plugin_names):
+        out = x
+        for name in plugin_names:
+            out = getattr(self, name)(out)
+        return out
+
+    @property
+    def norm1(self):
+        return getattr(self, self.norm1_name)
+
+    @property
+    def norm2(self):
+        return getattr(self, self.norm2_name)
+
+    @property
+    def norm3(self):
+        return getattr(self, self.norm3_name)
+
+    def forward(self, x):
+        def _inner_forward(x):
+            identity = x
+            out = self.conv1(x)
+            out = self.norm1(out)
+            out = self.relu(out)
+
+            if self.with_plugins:
+                out = self.forward_plugin(out, self.after_conv1_plugin_names)
+
+            out = self.conv2(out)
+            out = self.norm2(out)
+            out = self.relu(out)
+
+            if self.with_plugins:
+                out = self.forward_plugin(out, self.after_conv2_plugin_names)
+
+            out = self.conv3(out)
+            out = self.norm3(out)
+
+            if self.with_plugins:
+                out = self.forward_plugin(out, self.after_conv3_plugin_names)
+
+            if self.downsample is not None:
+                identity = self.downsample(x)
+
+            out += identity
+
+            return out
+
+        if self.with_cp and x.requires_grad:
+            out = cp.checkpoint(_inner_forward, x)
+        else:
+            out = _inner_forward(x)
+
+        out = self.relu(out)
+
+        return out
+
+
+@BACKBONES.register_module()
+class ResNet(BaseModule):
+
+    arch_settings = {
+        18: (BasicBlock, (2, 2, 2, 2)),
+        34: (BasicBlock, (3, 4, 6, 3)),
+        50: (Bottleneck, (3, 4, 6, 3)),
+        101: (Bottleneck, (3, 4, 23, 3)),
+        152: (Bottleneck, (3, 8, 36, 3)),
+    }
+
+    def __init__(
+        self,
+        depth,
+        in_channels=3,
+        stem_channels=None,
+        base_channels=64,
+        num_stages=4,
+        strides=(1, 2, 2, 2),
+        dilations=(1, 1, 1, 1),
+        out_indices=(0, 1, 2, 3),
+        style="pytorch",
+        deep_stem=False,
+        avg_down=False,
+        frozen_stages=-1,
+        conv_cfg=None,
+        norm_cfg=dict(type="BN", requires_grad=True),
+        norm_eval=True,
+        dcn=None,
+        stage_with_dcn=(False, False, False, False),
+        plugins=None,
+        with_cp=False,
+        zero_init_residual=True,
+        pretrained=None,
+        init_cfg=None,
+    ):
+        super(ResNet, self).__init__(init_cfg)
+        self.zero_init_residual = zero_init_residual
+        if depth not in self.arch_settings:
+            raise KeyError(f"invalid depth {depth} for resnet")
+
+        block_init_cfg = None
+        assert not (
+            init_cfg and pretrained
+        ), "init_cfg and pretrained cannot be specified at the same time"
+        if isinstance(pretrained, str):
+            warnings.warn(
+                "DeprecationWarning: pretrained is deprecated, "
+                'please use "init_cfg" instead'
+            )
+            self.init_cfg = dict(type="Pretrained", checkpoint=pretrained)
+        elif pretrained is None:
+            if init_cfg is None:
+                self.init_cfg = [
+                    dict(type="Kaiming", layer="Conv2d"),
+                    dict(type="Constant", val=1, layer=["_BatchNorm", "GroupNorm"]),
+                ]
+                block = self.arch_settings[depth][0]
+                if self.zero_init_residual:
+                    if block is BasicBlock:
+                        block_init_cfg = dict(
+                            type="Constant", val=0, override=dict(name="norm2")
+                        )
+                    elif block is Bottleneck:
+                        block_init_cfg = dict(
+                            type="Constant", val=0, override=dict(name="norm3")
+                        )
+        else:
+            raise TypeError("pretrained must be a str or None")
+
+        self.depth = depth
+        if stem_channels is None:
+            stem_channels = base_channels
+        self.stem_channels = stem_channels
+        self.base_channels = base_channels
+        self.num_stages = num_stages
+        assert num_stages >= 1 and num_stages <= 4
+        self.strides = strides
+        self.dilations = dilations
+        assert len(strides) == len(dilations) == num_stages
+        self.out_indices = out_indices
+        assert max(out_indices) < num_stages
+        self.style = style
+        self.deep_stem = deep_stem
+        self.avg_down = avg_down
+        self.frozen_stages = frozen_stages
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.with_cp = with_cp
+        self.norm_eval = norm_eval
+        self.dcn = dcn
+        self.stage_with_dcn = stage_with_dcn
+        if dcn is not None:
+            assert len(stage_with_dcn) == num_stages
+        self.plugins = plugins
+        self.block, stage_blocks = self.arch_settings[depth]
+        self.stage_blocks = stage_blocks[:num_stages]
+        self.inplanes = stem_channels
+
+        self._make_stem_layer(in_channels, stem_channels)
+
+        self.res_layers = []
+        for i, num_blocks in enumerate(self.stage_blocks):
+            stride = strides[i]
+            dilation = dilations[i]
+            dcn = self.dcn if self.stage_with_dcn[i] else None
+            if plugins is not None:
+                stage_plugins = self.make_stage_plugins(plugins, i)
+            else:
+                stage_plugins = None
+            planes = base_channels * 2**i
+            res_layer = self.make_res_layer(
+                block=self.block,
+                inplanes=self.inplanes,
+                planes=planes,
+                num_blocks=num_blocks,
+                stride=stride,
+                dilation=dilation,
+                style=self.style,
+                avg_down=self.avg_down,
+                with_cp=with_cp,
+                conv_cfg=conv_cfg,
+                norm_cfg=norm_cfg,
+                dcn=dcn,
+                plugins=stage_plugins,
+                init_cfg=block_init_cfg,
+            )
+            self.inplanes = planes * self.block.expansion
+            layer_name = f"layer{i + 1}"
+            self.add_module(layer_name, res_layer)
+            self.res_layers.append(layer_name)
+
+        self._freeze_stages()
+
+        self.feat_dim = (
+            self.block.expansion * base_channels * 2 ** (len(self.stage_blocks) - 1)
+        )
+
+    def make_stage_plugins(self, plugins, stage_idx):
+        stage_plugins = []
+        for plugin in plugins:
+            plugin = plugin.copy()
+            stages = plugin.pop("stages", None)
+            assert stages is None or len(stages) == self.num_stages
+            if stages is None or stages[stage_idx]:
+                stage_plugins.append(plugin)
+
+        return stage_plugins
+
+    def make_res_layer(self, **kwargs):
+        return ResLayer(**kwargs)
+
+    @property
+    def norm1(self):
+        return getattr(self, self.norm1_name)
+
+    def _make_stem_layer(self, in_channels, stem_channels):
+        if self.deep_stem:
+            self.stem = nn.Sequential(
+                build_conv_layer(
+                    self.conv_cfg,
+                    in_channels,
+                    stem_channels // 2,
+                    kernel_size=3,
+                    stride=2,
+                    padding=1,
+                    bias=False,
+                ),
+                build_norm_layer(self.norm_cfg, stem_channels // 2)[1],
+                nn.ReLU(inplace=True),
+                build_conv_layer(
+                    self.conv_cfg,
+                    stem_channels // 2,
+                    stem_channels // 2,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                    bias=False,
+                ),
+                build_norm_layer(self.norm_cfg, stem_channels // 2)[1],
+                nn.ReLU(inplace=True),
+                build_conv_layer(
+                    self.conv_cfg,
+                    stem_channels // 2,
+                    stem_channels,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                    bias=False,
+                ),
+                build_norm_layer(self.norm_cfg, stem_channels)[1],
+                nn.ReLU(inplace=True),
+            )
+        else:
+            self.conv1 = build_conv_layer(
+                self.conv_cfg,
+                in_channels,
+                stem_channels,
+                kernel_size=7,
+                stride=2,
+                padding=3,
+                bias=False,
+            )
+            self.norm1_name, norm1 = build_norm_layer(
+                self.norm_cfg, stem_channels, postfix=1
+            )
+            self.add_module(self.norm1_name, norm1)
+            self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+    def _freeze_stages(self):
+        if self.frozen_stages >= 0:
+            if self.deep_stem:
+                self.stem.eval()
+                for param in self.stem.parameters():
+                    param.requires_grad = False
+            else:
+                self.norm1.eval()
+                for m in [self.conv1, self.norm1]:
+                    for param in m.parameters():
+                        param.requires_grad = False
+
+        for i in range(1, self.frozen_stages + 1):
+            m = getattr(self, f"layer{i}")
+            m.eval()
+            for param in m.parameters():
+                param.requires_grad = False
+
+    def forward(self, x):
+        if self.deep_stem:
+            x = self.stem(x)
+        else:
+            x = self.conv1(x)
+            x = self.norm1(x)
+            x = self.relu(x)
+        x = self.maxpool(x)
+        outs = []
+        for i, layer_name in enumerate(self.res_layers):
+            res_layer = getattr(self, layer_name)
+            x = res_layer(x)
+            if i in self.out_indices:
+                outs.append(x)
+        return tuple(outs)
+
+
+# ============================================================================
+# MMDET3D UTILS
+# ============================================================================
+
+VOXEL_ENCODERS = MODELS
+MIDDLE_ENCODERS = MODELS
+FUSION_LAYERS = MODELS
+
+
+def build_backbone(cfg):
+    return BACKBONES.build(cfg)
+
+
+def build_neck(cfg):
+    return NECKS.build(cfg)
+
+
+def build_roi_extractor(cfg):
+    return ROI_EXTRACTORS.build(cfg)
+
+
+def build_shared_head(cfg):
+    return SHARED_HEADS.build(cfg)
+
+
+def build_head(cfg):
+    return HEADS.build(cfg)
+
+
+def build_loss(cfg):
+    return LOSSES.build(cfg)
+
+
+def build_detector(cfg, train_cfg=None, test_cfg=None):
+    return DETECTORS.build(
+        cfg, default_args=dict(train_cfg=train_cfg, test_cfg=test_cfg)
+    )
+
+
+def build_model(cfg, train_cfg=None, test_cfg=None):
+    return build_detector(cfg, train_cfg=train_cfg, test_cfg=test_cfg)
+
+
+def build_voxel_encoder(cfg):
+    return VOXEL_ENCODERS.build(cfg)
+
+
+def build_middle_encoder(cfg):
+    return MIDDLE_ENCODERS.build(cfg)
+
+
+def build_fusion_layer(cfg):
+    return FUSION_LAYERS.build(cfg)
+
+
+def bbox3d2result(bboxes, scores, labels, attrs=None):
+    result_dict = dict(
+        boxes_3d=bboxes.to("cpu"), scores_3d=scores.cpu(), labels_3d=labels.cpu()
+    )
+
+    if attrs is not None:
+        result_dict["attrs_3d"] = attrs.cpu()
+    return result_dict
+
+
+# ============================================================================
+# MODEL UTILS
+# ============================================================================
+
+
+def denormalize_bbox(normalized_bboxes, pc_range):
+    rot_sine = normalized_bboxes[..., 6:7]
+    rot_cosine = normalized_bboxes[..., 7:8]
+    rot = torch.atan2(rot_sine, rot_cosine)
+    cx = normalized_bboxes[..., 0:1]
+    cy = normalized_bboxes[..., 1:2]
+    cz = normalized_bboxes[..., 4:5]
+    w = normalized_bboxes[..., 2:3]
+    l = normalized_bboxes[..., 3:4]
+    h = normalized_bboxes[..., 5:6]
+
+    w = w.exp()
+    l = l.exp()
+    h = h.exp()
+    if normalized_bboxes.size(-1) > 8:
+        vx = normalized_bboxes[:, 8:9]
+        vy = normalized_bboxes[:, 9:10]
+        denormalized_bboxes = torch.cat([cx, cy, cz, w, l, h, rot, vx, vy], dim=-1)
+    else:
+        denormalized_bboxes = torch.cat([cx, cy, cz, w, l, h, rot], dim=-1)
+    return denormalized_bboxes
+
+
+def pos2posemb3d(pos, num_pos_feats=128, temperature=10000):
+    scale = 2 * math.pi
+    pos = pos * scale
+    dim_t = torch.arange(num_pos_feats, dtype=torch.float32, device=pos.device)
+    dim_t = temperature ** (2 * (dim_t // 2) / num_pos_feats)
+    pos_x = pos[..., 0, None] / dim_t
+    pos_y = pos[..., 1, None] / dim_t
+    pos_z = pos[..., 2, None] / dim_t
+    pos_x = torch.stack(
+        (pos_x[..., 0::2].sin(), pos_x[..., 1::2].cos()), dim=-1
+    ).flatten(-2)
+    pos_y = torch.stack(
+        (pos_y[..., 0::2].sin(), pos_y[..., 1::2].cos()), dim=-1
+    ).flatten(-2)
+    pos_z = torch.stack(
+        (pos_z[..., 0::2].sin(), pos_z[..., 1::2].cos()), dim=-1
+    ).flatten(-2)
+    posemb = torch.cat((pos_y, pos_x, pos_z), dim=-1)
+    return posemb
+
+
+def build_transformer_layer_sequence(cfg, default_args=None):
+    return build_from_cfg(cfg, TRANSFORMER_LAYER_SEQUENCE, default_args)
+
+
+@ATTENTION.register_module()
+class PETRMultiheadAttention(BaseModule):
+    def __init__(
+        self,
+        embed_dims,
+        num_heads,
+        attn_drop=0.0,
+        proj_drop=0.0,
+        dropout_layer=dict(type="Dropout", drop_prob=0.0),
+        init_cfg=None,
+        batch_first=False,
+        **kwargs,
+    ):
+        super(PETRMultiheadAttention, self).__init__(init_cfg)
+        if "dropout" in kwargs:
+            warnings.warn(
+                "The arguments `dropout` in MultiheadAttention "
+                "has been deprecated, now you can separately "
+                "set `attn_drop`(float), proj_drop(float), "
+                "and `dropout_layer`(dict) ",
+                DeprecationWarning,
+            )
+            attn_drop = kwargs["dropout"]
+            dropout_layer["drop_prob"] = kwargs.pop("dropout")
+
+        self.embed_dims = embed_dims
+        self.num_heads = num_heads
+        self.batch_first = batch_first
+
+        self.attn = nn.MultiheadAttention(embed_dims, num_heads, attn_drop, **kwargs)
+
+        self.proj_drop = nn.Dropout(proj_drop)
+        self.dropout_layer = (
+            build_dropout(dropout_layer) if dropout_layer else nn.Identity()
+        )
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        identity=None,
+        query_pos=None,
+        key_pos=None,
+        attn_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+        if identity is None:
+            identity = query
+        if key_pos is None:
+            if query_pos is not None:
+                if query_pos.shape == key.shape:
+                    key_pos = query_pos
+                else:
+                    warnings.warn(
+                        f"position encoding of key is"
+                        f"missing in {self.__class__.__name__}."
+                    )
+        if query_pos is not None:
+            query = query + query_pos
+        if key_pos is not None:
+            key = key + key_pos
+
+        if self.batch_first:
+            query = query.transpose(0, 1)
+            key = key.transpose(0, 1)
+            value = value.transpose(0, 1)
+
+        out = self.attn(
+            query=query,
+            key=key,
+            value=value,
+            attn_mask=attn_mask,
+            key_padding_mask=key_padding_mask,
+        )[0]
+
+        if self.batch_first:
+            out = out.transpose(0, 1)
+
+        return identity + self.dropout_layer(self.proj_drop(out))
+
+
+@TRANSFORMER_LAYER.register_module()
+class PETRTransformerDecoderLayer(BaseTransformerLayer):
+    def __init__(
+        self,
+        attn_cfgs,
+        feedforward_channels,
+        ffn_dropout=0.0,
+        operation_order=None,
+        act_cfg=dict(type="ReLU", inplace=True),
+        norm_cfg=dict(type="LN"),
+        ffn_num_fcs=2,
+        with_cp=True,
+        **kwargs,
+    ):
+        super(PETRTransformerDecoderLayer, self).__init__(
+            attn_cfgs=attn_cfgs,
+            feedforward_channels=feedforward_channels,
+            ffn_dropout=ffn_dropout,
+            operation_order=operation_order,
+            act_cfg=act_cfg,
+            norm_cfg=norm_cfg,
+            ffn_num_fcs=ffn_num_fcs,
+            **kwargs,
+        )
+        assert len(operation_order) == 6
+        assert set(operation_order) == set(["self_attn", "norm", "cross_attn", "ffn"])
+        self.use_checkpoint = with_cp
+
+    def _forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+    ):
+        x = super(PETRTransformerDecoderLayer, self).forward(
+            query,
+            key=key,
+            value=value,
+            query_pos=query_pos,
+            key_pos=key_pos,
+            attn_masks=attn_masks,
+            query_key_padding_mask=query_key_padding_mask,
+            key_padding_mask=key_padding_mask,
+        )
+
+        return x
+
+    def forward(
+        self,
+        query,
+        key=None,
+        value=None,
+        query_pos=None,
+        key_pos=None,
+        attn_masks=None,
+        query_key_padding_mask=None,
+        key_padding_mask=None,
+        **kwargs,
+    ):
+
+        if self.use_checkpoint and self.training:
+            x = cp.checkpoint(
+                self._forward,
+                query,
+                key,
+                value,
+                query_pos,
+                key_pos,
+                attn_masks,
+                query_key_padding_mask,
+                key_padding_mask,
+            )
+        else:
+            x = self._forward(
+                query,
+                key=key,
+                value=value,
+                query_pos=query_pos,
+                key_pos=key_pos,
+                attn_masks=attn_masks,
+                query_key_padding_mask=query_key_padding_mask,
+                key_padding_mask=key_padding_mask,
+            )
+        return x
+
+
+@TRANSFORMER.register_module()
+class PETRTransformer(BaseModule):
+    def __init__(self, encoder=None, decoder=None, init_cfg=None, cross=False):
+        super(PETRTransformer, self).__init__(init_cfg=init_cfg)
+        if encoder is not None:
+            self.encoder = build_transformer_layer_sequence(encoder)
+        else:
+            self.encoder = None
+        self.decoder = build_transformer_layer_sequence(decoder)
+        self.embed_dims = self.decoder.embed_dims
+        self.cross = cross
+
+    def init_weights(self):
+        for m in self.modules():
+            if hasattr(m, "weight") and m.weight.dim() > 1:
+                xavier_init(m, distribution="uniform")
+        self._is_init = True
+
+    def forward(self, x, mask, query_embed, pos_embed, reg_branch=None):
+        bs, n, c, h, w = x.shape
+        memory = x.permute(1, 3, 4, 0, 2).reshape(-1, bs, c)
+        pos_embed = pos_embed.permute(1, 3, 4, 0, 2).reshape(-1, bs, c)
+        query_embed = query_embed.unsqueeze(1).repeat(1, bs, 1)
+        mask = mask.view(bs, -1)
+        target = torch.zeros_like(query_embed)
+
+        out_dec = self.decoder(
+            query=target,
+            key=memory,
+            value=memory,
+            key_pos=pos_embed,
+            query_pos=query_embed,
+            key_padding_mask=mask,
+            reg_branch=reg_branch,
+        )
+        out_dec = out_dec.transpose(1, 2)
+        memory = memory.reshape(n, h, w, bs, c).permute(3, 0, 4, 1, 2)
+        return out_dec, memory
+
+
+@MATCH_COST.register_module()
+class BBox3DL1Cost(object):
+    def __init__(self, weight=1.0):
+        self.weight = weight
+
+    def __call__(self, bbox_pred, gt_bboxes):
+        bbox_cost = torch.cdist(bbox_pred, gt_bboxes, p=1)
+        return bbox_cost * self.weight
+
+
+@BBOX_ASSIGNERS.register_module()
+class HungarianAssigner3D(BaseAssigner):
+    def __init__(
+        self,
+        cls_cost=dict(type="ClassificationCost", weight=1.0),
+        reg_cost=dict(type="BBoxL1Cost", weight=1.0),
+        iou_cost=dict(type="IoUCost", weight=0.0),
+        pc_range=None,
+    ):
+        self.cls_cost = build_match_cost(cls_cost)
+        self.reg_cost = build_match_cost(reg_cost)
+        self.iou_cost = build_match_cost(iou_cost)
+        self.pc_range = pc_range
+
+    def assign(
+        self, bbox_pred, cls_pred, gt_bboxes, gt_labels, gt_bboxes_ignore=None, eps=1e-7
+    ):
+        pass
+
+
+class BaseDetector(BaseModule, metaclass=ABCMeta):
+    def __init__(self, init_cfg=None):
+        super(BaseDetector, self).__init__(init_cfg)
+        self.fp16_enabled = False
+
+
+class Base3DDetector(BaseDetector):
+    pass
+
+
+@DETECTORS.register_module()
+class MVXTwoStageDetector(Base3DDetector):
+    def __init__(
+        self,
+        pts_voxel_layer=None,
+        pts_voxel_encoder=None,
+        pts_middle_encoder=None,
+        pts_fusion_layer=None,
+        img_backbone=None,
+        pts_backbone=None,
+        img_neck=None,
+        pts_neck=None,
+        pts_bbox_head=None,
+        img_roi_head=None,
+        img_rpn_head=None,
+        train_cfg=None,
+        test_cfg=None,
+        pretrained=None,
+        init_cfg=None,
+    ):
+        super(MVXTwoStageDetector, self).__init__(init_cfg=init_cfg)
+
+        if pts_voxel_layer:
+            self.pts_voxel_layer = Voxelization(**pts_voxel_layer)
+        if pts_voxel_encoder:
+            self.pts_voxel_encoder = build_voxel_encoder(pts_voxel_encoder)
+        if pts_middle_encoder:
+            self.pts_middle_encoder = build_middle_encoder(pts_middle_encoder)
+        if pts_backbone:
+            self.pts_backbone = build_backbone(pts_backbone)
+        if pts_fusion_layer:
+            self.pts_fusion_layer = build_fusion_layer(pts_fusion_layer)
+        if pts_neck is not None:
+            self.pts_neck = build_neck(pts_neck)
+        if pts_bbox_head:
+            pts_train_cfg = train_cfg.pts if train_cfg else None
+            pts_bbox_head.update(train_cfg=pts_train_cfg)
+            pts_test_cfg = test_cfg.pts if test_cfg else None
+            pts_bbox_head.update(test_cfg=pts_test_cfg)
+            self.pts_bbox_head = build_head(pts_bbox_head)
+
+        if img_backbone:
+            self.img_backbone = build_backbone(img_backbone)
+        if img_neck is not None:
+            self.img_neck = build_neck(img_neck)
+        if img_rpn_head is not None:
+            self.img_rpn_head = build_head(img_rpn_head)
+        if img_roi_head is not None:
+            self.img_roi_head = build_head(img_roi_head)
+
+        self.train_cfg = train_cfg
+        self.test_cfg = test_cfg
+
+        if pretrained is None:
+            img_pretrained = None
+            pts_pretrained = None
+        elif isinstance(pretrained, dict):
+            img_pretrained = pretrained.get("img", None)
+            pts_pretrained = pretrained.get("pts", None)
+        else:
+            raise ValueError(f"pretrained should be a dict, got {type(pretrained)}")
+
+        if self.with_img_backbone:
+            if img_pretrained is not None:
+                warnings.warn(
+                    "DeprecationWarning: pretrained is a deprecated \
+                    key, please consider using init_cfg"
+                )
+                self.img_backbone.init_cfg = dict(
+                    type="Pretrained", checkpoint=img_pretrained
+                )
+        if self.with_img_roi_head:
+            if img_pretrained is not None:
+                warnings.warn(
+                    "DeprecationWarning: pretrained is a deprecated \
+                    key, please consider using init_cfg"
+                )
+                self.img_roi_head.init_cfg = dict(
+                    type="Pretrained", checkpoint=img_pretrained
+                )
+
+        if self.with_pts_backbone:
+            if pts_pretrained is not None:
+                warnings.warn(
+                    "DeprecationWarning: pretrained is a deprecated \
+                    key, please consider using init_cfg"
+                )
+                self.pts_backbone.init_cfg = dict(
+                    type="Pretrained", checkpoint=pts_pretrained
+                )
+
+    @property
+    def with_img_shared_head(self):
+        return hasattr(self, "img_shared_head") and self.img_shared_head is not None
+
+    @property
+    def with_pts_bbox(self):
+        return hasattr(self, "pts_bbox_head") and self.pts_bbox_head is not None
+
+    @property
+    def with_img_bbox(self):
+        return hasattr(self, "img_bbox_head") and self.img_bbox_head is not None
+
+    @property
+    def with_img_backbone(self):
+        return hasattr(self, "img_backbone") and self.img_backbone is not None
+
+    @property
+    def with_pts_backbone(self):
+        return hasattr(self, "pts_backbone") and self.pts_backbone is not None
+
+    @property
+    def with_fusion(self):
+        return hasattr(self, "pts_fusion_layer") and self.fusion_layer is not None
+
+    @property
+    def with_img_neck(self):
+        return hasattr(self, "img_neck") and self.img_neck is not None
+
+    @property
+    def with_pts_neck(self):
+        return hasattr(self, "pts_neck") and self.pts_neck is not None
+
+    @property
+    def with_img_rpn(self):
+        return hasattr(self, "img_rpn_head") and self.img_rpn_head is not None
+
+    @property
+    def with_img_roi_head(self):
+        return hasattr(self, "img_roi_head") and self.img_roi_head is not None
+
+    @property
+    def with_voxel_encoder(self):
+        return hasattr(self, "voxel_encoder") and self.voxel_encoder is not None
+
+    @property
+    def with_middle_encoder(self):
+        return hasattr(self, "middle_encoder") and self.middle_encoder is not None
+
+
+class GridMask(nn.Module):
+    def __init__(
+        self, use_h, use_w, rotate=1, offset=False, ratio=0.5, mode=0, prob=1.0
+    ):
+        super(GridMask, self).__init__()
+        self.use_h = use_h
+        self.use_w = use_w
+        self.rotate = rotate
+        self.offset = offset
+        self.ratio = ratio
+        self.mode = mode
+        self.st_prob = prob
+        self.prob = prob
+
+    def set_prob(self, epoch, max_epoch):
+        self.prob = self.st_prob * epoch / max_epoch
+
+    def forward(self, x):
+        if np.random.rand() > self.prob or not self.training:
+            return x
+        n, c, h, w = x.size()
+        x = x.view(-1, h, w)
+        hh = int(1.5 * h)
+        ww = int(1.5 * w)
+        d = np.random.randint(2, h)
+        self.l = min(max(int(d * self.ratio + 0.5), 1), d - 1)
+        mask = np.ones((hh, ww), np.float32)
+        st_h = np.random.randint(d)
+        st_w = np.random.randint(d)
+        if self.use_h:
+            for i in range(hh // d):
+                s = d * i + st_h
+                t = min(s + self.l, hh)
+                mask[s:t, :] *= 0
+        if self.use_w:
+            for i in range(ww // d):
+                s = d * i + st_w
+                t = min(s + self.l, ww)
+                mask[:, s:t] *= 0
+
+        r = np.random.randint(self.rotate)
+        mask = Image.fromarray(np.uint8(mask))
+        mask = mask.rotate(r)
+        mask = np.asarray(mask)
+        mask = mask[
+            (hh - h) // 2 : (hh - h) // 2 + h, (ww - w) // 2 : (ww - w) // 2 + w
+        ]
+
+        mask = torch.from_numpy(mask).float().cuda()
+        if self.mode == 1:
+            mask = 1 - mask
+        mask = mask.expand_as(x)
+        if self.offset:
+            offset = torch.from_numpy(2 * (np.random.rand(h, w) - 0.5)).float().cuda()
+            x = x * mask + offset * (1 - mask)
+        else:
+            x = x * mask
+
+        return x.view(n, c, h, w)
+
+
+@DETECTORS.register_module()
+class Petr3D(MVXTwoStageDetector):
+    def __init__(
+        self,
+        use_grid_mask=False,
+        pts_voxel_layer=None,
+        pts_voxel_encoder=None,
+        pts_middle_encoder=None,
+        pts_fusion_layer=None,
+        img_backbone=None,
+        pts_backbone=None,
+        img_neck=None,
+        pts_neck=None,
+        pts_bbox_head=None,
+        img_roi_head=None,
+        img_rpn_head=None,
+        train_cfg=None,
+        test_cfg=None,
+        pretrained=None,
+    ):
+        super(Petr3D, self).__init__(
+            pts_voxel_layer,
+            pts_voxel_encoder,
+            pts_middle_encoder,
+            pts_fusion_layer,
+            img_backbone,
+            pts_backbone,
+            img_neck,
+            pts_neck,
+            pts_bbox_head,
+            img_roi_head,
+            img_rpn_head,
+            train_cfg,
+            test_cfg,
+            pretrained,
+        )
+        self.grid_mask = GridMask(
+            True, True, rotate=1, offset=False, ratio=0.5, mode=1, prob=0.7
+        )
+        self.use_grid_mask = use_grid_mask
+
+    def extract_img_feat(self, img, img_metas):
+        if isinstance(img, list):
+            img = torch.stack(img, dim=0)
+
+        B = img.size(0)
+        if img is not None:
+            input_shape = img.shape[-2:]
+            for img_meta in img_metas:
+                img_meta.update(input_shape=input_shape)
+            if img.dim() == 5:
+                if img.size(0) == 1 and img.size(1) != 1:
+                    img.squeeze_()
+                else:
+                    B, N, C, H, W = img.size()
+                    img = img.view(B * N, C, H, W)
+            if self.use_grid_mask:
+                img = self.grid_mask(img)
+            img_feats = self.img_backbone(img)
+            if isinstance(img_feats, dict):
+                img_feats = list(img_feats.values())
+        else:
+            return None
+        if self.with_img_neck:
+            img_feats = self.img_neck(img_feats)
+        img_feats_reshaped = []
+        for img_feat in img_feats:
+            BN, C, H, W = img_feat.size()
+            img_feats_reshaped.append(img_feat.view(B, int(BN / B), C, H, W))
+        return img_feats_reshaped
+
+    def extract_feat(self, img, img_metas):
+        img_feats = self.extract_img_feat(img, img_metas)
+        return img_feats
+
+    def forward(self, **kwargs):
+        outputs = self.forward_test(**kwargs)
+        return outputs
+
+    def forward_test(self, img_metas, img=None, **kwargs):
+        for var, name in [(img_metas, "img_metas")]:
+            if not isinstance(var, list):
+                raise TypeError("{} must be a list, but got {}".format(name, type(var)))
+        img = [img] if img is None else img
+        return self.simple_test(img_metas[0], img[0], **kwargs)
+
+    def simple_test_pts(self, x, img_metas, rescale=False):
+        outs = self.pts_bbox_head(x, img_metas)
+        bbox_list = self.pts_bbox_head.get_bboxes(outs, img_metas, rescale=rescale)
+        bbox_results = [
+            bbox3d2result(bboxes, scores, labels)
+            for bboxes, scores, labels in bbox_list
+        ]
+        return bbox_results
+
+    def simple_test(self, img_metas, img=None, rescale=False):
+        img_feats = self.extract_feat(img=img, img_metas=img_metas)
+
+        bbox_list = [dict() for i in range(len(img_metas))]
+        bbox_pts = self.simple_test_pts(img_feats, img_metas, rescale=rescale)
+        for result_dict, pts_bbox in zip(bbox_list, bbox_pts):
+            result_dict["pts_bbox"] = pts_bbox
+        return bbox_list
+
+
+@POSITIONAL_ENCODING.register_module()
+class SinePositionalEncoding3D(BaseModule):
+    def __init__(
+        self,
+        num_feats,
+        temperature=10000,
+        normalize=False,
+        scale=2 * math.pi,
+        eps=1e-6,
+        offset=0.0,
+        init_cfg=None,
+    ):
+        super(SinePositionalEncoding3D, self).__init__(init_cfg)
+        if normalize:
+            assert isinstance(scale, (float, int)), (
+                "when normalize is set,"
+                "scale should be provided and in float or int type, "
+                f"found {type(scale)}"
+            )
+        self.num_feats = num_feats
+        self.temperature = temperature
+        self.normalize = normalize
+        self.scale = scale
+        self.eps = eps
+        self.offset = offset
+
+    def forward(self, mask):
+        mask = mask.to(torch.int)
+        not_mask = 1 - mask
+        n_embed = not_mask.cumsum(1, dtype=torch.float32)
+        y_embed = not_mask.cumsum(2, dtype=torch.float32)
+        x_embed = not_mask.cumsum(3, dtype=torch.float32)
+        if self.normalize:
+            n_embed = (
+                (n_embed + self.offset)
+                / (n_embed[:, -1:, :, :] + self.eps)
+                * self.scale
+            )
+            y_embed = (
+                (y_embed + self.offset)
+                / (y_embed[:, :, -1:, :] + self.eps)
+                * self.scale
+            )
+            x_embed = (
+                (x_embed + self.offset)
+                / (x_embed[:, :, :, -1:] + self.eps)
+                * self.scale
+            )
+        dim_t = torch.arange(self.num_feats, dtype=torch.float32, device=mask.device)
+        dim_t = self.temperature ** (2 * (dim_t // 2) / self.num_feats)
+        pos_n = n_embed[:, :, :, :, None] / dim_t
+        pos_x = x_embed[:, :, :, :, None] / dim_t
+        pos_y = y_embed[:, :, :, :, None] / dim_t
+        B, N, H, W = mask.size()
+        pos_n = torch.stack(
+            (pos_n[:, :, :, :, 0::2].sin(), pos_n[:, :, :, :, 1::2].cos()), dim=4
+        ).view(B, N, H, W, -1)
+        pos_x = torch.stack(
+            (pos_x[:, :, :, :, 0::2].sin(), pos_x[:, :, :, :, 1::2].cos()), dim=4
+        ).view(B, N, H, W, -1)
+        pos_y = torch.stack(
+            (pos_y[:, :, :, :, 0::2].sin(), pos_y[:, :, :, :, 1::2].cos()), dim=4
+        ).view(B, N, H, W, -1)
+        pos = torch.cat((pos_n, pos_y, pos_x), dim=4).permute(0, 1, 4, 2, 3)
+        return pos
+
+
+@POSITIONAL_ENCODING.register_module()
+class LearnedPositionalEncoding3D(BaseModule):
+    def __init__(
+        self,
+        num_feats,
+        row_num_embed=50,
+        col_num_embed=50,
+        init_cfg=dict(type="Uniform", layer="Embedding"),
+    ):
+        super(LearnedPositionalEncoding3D, self).__init__(init_cfg)
+        self.row_embed = nn.Embedding(row_num_embed, num_feats)
+        self.col_embed = nn.Embedding(col_num_embed, num_feats)
+        self.num_feats = num_feats
+        self.row_num_embed = row_num_embed
+        self.col_num_embed = col_num_embed
+
+    def forward(self, mask):
+        h, w = mask.shape[-2:]
+        x = torch.arange(w, device=mask.device)
+        y = torch.arange(h, device=mask.device)
+        x_embed = self.col_embed(x)
+        y_embed = self.row_embed(y)
+        pos = (
+            torch.cat(
+                (
+                    x_embed.unsqueeze(0).repeat(h, 1, 1),
+                    y_embed.unsqueeze(1).repeat(1, w, 1),
+                ),
+                dim=-1,
+            )
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            .repeat(mask.shape[0], 1, 1, 1)
+        )
+        return pos
+
+
+@HEADS.register_module()
+class PETRHead(AnchorFreeHead):
+    _version = 2
+
+    def __init__(
+        self,
+        num_classes,
+        in_channels,
+        num_query=100,
+        num_reg_fcs=2,
+        transformer=None,
+        sync_cls_avg_factor=False,
+        positional_encoding=dict(
+            type="SinePositionalEncoding", num_feats=128, normalize=True
+        ),
+        code_weights=None,
+        bbox_coder=None,
+        loss_cls=dict(
+            type="CrossEntropyLoss",
+            bg_cls_weight=0.1,
+            use_sigmoid=False,
+            loss_weight=1.0,
+            class_weight=1.0,
+        ),
+        loss_bbox=dict(type="L1Loss", loss_weight=5.0),
+        loss_iou=dict(type="GIoULoss", loss_weight=2.0),
+        train_cfg=dict(
+            assigner=dict(
+                type="HungarianAssigner",
+                cls_cost=dict(type="ClassificationCost", weight=1.0),
+                reg_cost=dict(type="BBoxL1Cost", weight=5.0),
+                iou_cost=dict(type="IoUCost", iou_mode="giou", weight=2.0),
+            )
+        ),
+        test_cfg=dict(max_per_img=100),
+        with_position=True,
+        with_multiview=False,
+        depth_step=0.8,
+        depth_num=64,
+        LID=False,
+        depth_start=1,
+        position_range=[-65, -65, -8.0, 65, 65, 8.0],
+        init_cfg=None,
+        normedlinear=False,
+        **kwargs,
+    ):
+        if "code_size" in kwargs:
+            self.code_size = kwargs["code_size"]
+        else:
+            self.code_size = 10
+        if code_weights is not None:
+            self.code_weights = code_weights
+        else:
+            self.code_weights = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.2, 0.2]
+        self.code_weights = self.code_weights[: self.code_size]
+        self.bg_cls_weight = 0
+        self.sync_cls_avg_factor = sync_cls_avg_factor
+        class_weight = loss_cls.get("class_weight", None)
+        if class_weight is not None and (self.__class__ is PETRHead):
+            assert isinstance(class_weight, float), (
+                "Expected "
+                "class_weight to have type float. Found "
+                f"{type(class_weight)}."
+            )
+            bg_cls_weight = loss_cls.get("bg_cls_weight", class_weight)
+            assert isinstance(bg_cls_weight, float), (
+                "Expected "
+                "bg_cls_weight to have type float. Found "
+                f"{type(bg_cls_weight)}."
+            )
+            class_weight = torch.ones(num_classes + 1) * class_weight
+            class_weight[num_classes] = bg_cls_weight
+            loss_cls.update({"class_weight": class_weight})
+            if "bg_cls_weight" in loss_cls:
+                loss_cls.pop("bg_cls_weight")
+            self.bg_cls_weight = bg_cls_weight
+
+        if train_cfg:
+            assert "assigner" in train_cfg, (
+                "assigner should be provided " "when train_cfg is set."
+            )
+            assigner = train_cfg["assigner"]
+            assert loss_cls["loss_weight"] == assigner["cls_cost"]["weight"], (
+                "The classification weight for loss and matcher should be"
+                "exactly the same."
+            )
+            assert loss_bbox["loss_weight"] == assigner["reg_cost"]["weight"], (
+                "The regression L1 weight for loss and matcher "
+                "should be exactly the same."
+            )
+            self.assigner = build_assigner(assigner)
+            sampler_cfg = dict(type="PseudoSampler")
+            self.sampler = build_sampler(sampler_cfg, context=self)
+
+        self.num_query = num_query
+        self.num_classes = num_classes
+        self.in_channels = in_channels
+        self.num_reg_fcs = num_reg_fcs
+        self.train_cfg = train_cfg
+        self.test_cfg = test_cfg
+        self.fp16_enabled = False
+        self.embed_dims = 256
+        self.depth_step = depth_step
+        self.depth_num = depth_num
+        self.position_dim = 3 * self.depth_num
+        self.position_range = position_range
+        self.LID = LID
+        self.depth_start = depth_start
+        self.position_level = 0
+        self.with_position = with_position
+        self.with_multiview = with_multiview
+        assert "num_feats" in positional_encoding
+        num_feats = positional_encoding["num_feats"]
+        assert num_feats * 2 == self.embed_dims, (
+            "embed_dims should"
+            f" be exactly 2 times of num_feats. Found {self.embed_dims}"
+            f" and {num_feats}."
+        )
+        self.act_cfg = transformer.get("act_cfg", dict(type="ReLU", inplace=True))
+        self.num_pred = 6
+        self.normedlinear = normedlinear
+        super(PETRHead, self).__init__(num_classes, in_channels, init_cfg=init_cfg)
+
+        self.loss_cls = build_loss(loss_cls)
+        self.loss_bbox = build_loss(loss_bbox)
+        self.loss_iou = build_loss(loss_iou)
+
+        if self.loss_cls.use_sigmoid:
+            self.cls_out_channels = num_classes
+        else:
+            self.cls_out_channels = num_classes + 1
+        self.positional_encoding = build_positional_encoding(positional_encoding)
+        self.transformer = build_transformer(transformer)
+        self.code_weights = nn.Parameter(
+            torch.tensor(self.code_weights, requires_grad=False), requires_grad=False
+        )
+        self.bbox_coder = build_bbox_coder(bbox_coder)
+        self.pc_range = self.bbox_coder.pc_range
+        self._init_layers()
+
+    def _init_layers(self):
+        if self.with_position:
+            self.input_proj = Conv2d(self.in_channels, self.embed_dims, kernel_size=1)
+        else:
+            self.input_proj = Conv2d(self.in_channels, self.embed_dims, kernel_size=1)
+
+        cls_branch = []
+        for _ in range(self.num_reg_fcs):
+            cls_branch.append(Linear(self.embed_dims, self.embed_dims))
+            cls_branch.append(nn.LayerNorm(self.embed_dims))
+            cls_branch.append(nn.ReLU(inplace=True))
+        if self.normedlinear:
+            cls_branch.append(NormedLinear(self.embed_dims, self.cls_out_channels))
+        else:
+            cls_branch.append(Linear(self.embed_dims, self.cls_out_channels))
+        fc_cls = nn.Sequential(*cls_branch)
+
+        reg_branch = []
+        for _ in range(self.num_reg_fcs):
+            reg_branch.append(Linear(self.embed_dims, self.embed_dims))
+            reg_branch.append(nn.ReLU())
+        reg_branch.append(Linear(self.embed_dims, self.code_size))
+        reg_branch = nn.Sequential(*reg_branch)
+
+        self.cls_branches = nn.ModuleList([fc_cls for _ in range(self.num_pred)])
+        self.reg_branches = nn.ModuleList([reg_branch for _ in range(self.num_pred)])
+
+        if self.with_multiview:
+            self.adapt_pos3d = nn.Sequential(
+                nn.Conv2d(
+                    self.embed_dims * 3 // 2,
+                    self.embed_dims * 4,
+                    kernel_size=1,
+                    stride=1,
+                    padding=0,
+                ),
+                nn.ReLU(),
+                nn.Conv2d(
+                    self.embed_dims * 4,
+                    self.embed_dims,
+                    kernel_size=1,
+                    stride=1,
+                    padding=0,
+                ),
+            )
+        else:
+            self.adapt_pos3d = nn.Sequential(
+                nn.Conv2d(
+                    self.embed_dims, self.embed_dims, kernel_size=1, stride=1, padding=0
+                ),
+                nn.ReLU(),
+                nn.Conv2d(
+                    self.embed_dims, self.embed_dims, kernel_size=1, stride=1, padding=0
+                ),
+            )
+
+        if self.with_position:
+            self.position_encoder = nn.Sequential(
+                nn.Conv2d(
+                    self.position_dim,
+                    self.embed_dims * 4,
+                    kernel_size=1,
+                    stride=1,
+                    padding=0,
+                ),
+                nn.ReLU(),
+                nn.Conv2d(
+                    self.embed_dims * 4,
+                    self.embed_dims,
+                    kernel_size=1,
+                    stride=1,
+                    padding=0,
+                ),
+            )
+
+        self.reference_points = nn.Embedding(self.num_query, 3)
+        self.query_embedding = nn.Sequential(
+            nn.Linear(self.embed_dims * 3 // 2, self.embed_dims),
+            nn.ReLU(),
+            nn.Linear(self.embed_dims, self.embed_dims),
+        )
+
+    def init_weights(self):
+        self.transformer.init_weights()
+        nn.init.uniform_(self.reference_points.weight.data, 0, 1)
+        if self.loss_cls.use_sigmoid:
+            bias_init = bias_init_with_prob(0.01)
+            for m in self.cls_branches:
+                nn.init.constant_(m[-1].bias, bias_init)
+
+    def position_embeding(self, img_feats, img_metas, masks=None):
+        eps = 1e-5
+        pad_h, pad_w, _ = img_metas[0]["pad_shape"][0]
+        B, N, C, H, W = img_feats[self.position_level].shape
+        coords_h = torch.arange(H, device=img_feats[0].device).float() * pad_h / H
+        coords_w = torch.arange(W, device=img_feats[0].device).float() * pad_w / W
+
+        if self.LID:
+            index = torch.arange(
+                start=0, end=self.depth_num, step=1, device=img_feats[0].device
+            ).float()
+            index_1 = index + 1
+            bin_size = (self.position_range[3] - self.depth_start) / (
+                self.depth_num * (1 + self.depth_num)
+            )
+            coords_d = self.depth_start + bin_size * index * index_1
+        else:
+            index = torch.arange(
+                start=0, end=self.depth_num, step=1, device=img_feats[0].device
+            ).float()
+            bin_size = (self.position_range[3] - self.depth_start) / self.depth_num
+            coords_d = self.depth_start + bin_size * index
+
+        D = coords_d.shape[0]
+        coords = torch.stack(torch.meshgrid([coords_w, coords_h, coords_d])).permute(
+            1, 2, 3, 0
+        )
+        coords = torch.cat((coords, torch.ones_like(coords[..., :1])), -1)
+        coords[..., :2] = coords[..., :2] * torch.maximum(
+            coords[..., 2:3], torch.ones_like(coords[..., 2:3]) * eps
+        )
+
+        img2lidars = []
+        for img_meta in img_metas:
+            img2lidar = []
+            for i in range(len(img_meta["lidar2img"])):
+                img2lidar.append(np.linalg.inv(img_meta["lidar2img"][i]))
+            img2lidars.append(np.asarray(img2lidar))
+        img2lidars = np.asarray(img2lidars)
+        img2lidars = coords.new_tensor(img2lidars)
+
+        coords = coords.view(1, 1, W, H, D, 4, 1).repeat(B, N, 1, 1, 1, 1, 1)
+        img2lidars = img2lidars.view(B, N, 1, 1, 1, 4, 4).repeat(1, 1, W, H, D, 1, 1)
+        coords3d = torch.matmul(img2lidars, coords).squeeze(-1)[..., :3]
+        coords3d[..., 0:1] = (coords3d[..., 0:1] - self.position_range[0]) / (
+            self.position_range[3] - self.position_range[0]
+        )
+        coords3d[..., 1:2] = (coords3d[..., 1:2] - self.position_range[1]) / (
+            self.position_range[4] - self.position_range[1]
+        )
+        coords3d[..., 2:3] = (coords3d[..., 2:3] - self.position_range[2]) / (
+            self.position_range[5] - self.position_range[2]
+        )
+
+        coords_mask = (coords3d > 1.0) | (coords3d < 0.0)
+        coords_mask = coords_mask.flatten(-2).sum(-1) > (D * 0.5)
+        coords_mask = masks | coords_mask.permute(0, 1, 3, 2)
+        coords3d = coords3d.permute(0, 1, 4, 5, 3, 2).contiguous().view(B * N, -1, H, W)
+        coords3d = inverse_sigmoid(coords3d)
+        coords_position_embeding = self.position_encoder(coords3d)
+
+        return coords_position_embeding.view(B, N, self.embed_dims, H, W), coords_mask
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        version = local_metadata.get("version", None)
+        if (version is None or version < 2) and self.__class__ is PETRHead:
+            convert_dict = {
+                ".self_attn.": ".attentions.0.",
+                ".multihead_attn.": ".attentions.1.",
+                ".decoder.norm.": ".decoder.post_norm.",
+            }
+            state_dict_keys = list(state_dict.keys())
+            for k in state_dict_keys:
+                for ori_key, convert_key in convert_dict.items():
+                    if ori_key in k:
+                        convert_key = k.replace(ori_key, convert_key)
+                        state_dict[convert_key] = state_dict[k]
+                        del state_dict[k]
+
+        super(AnchorFreeHead, self)._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
+    def forward(self, mlvl_feats, img_metas):
+        x = mlvl_feats[0]
+        batch_size, num_cams = x.size(0), x.size(1)
+        input_img_h, input_img_w, _ = img_metas[0]["pad_shape"][0]
+        masks = x.new_ones((batch_size, num_cams, input_img_h, input_img_w))
+        for img_id in range(batch_size):
+            for cam_id in range(num_cams):
+                img_h, img_w, _ = img_metas[img_id]["img_shape"][cam_id]
+                masks[img_id, cam_id, :img_h, :img_w] = 0
+        x = self.input_proj(x.flatten(0, 1))
+        x = x.view(batch_size, num_cams, *x.shape[-3:])
+        masks = F.interpolate(masks, size=x.shape[-2:]).to(torch.bool)
+
+        if self.with_position:
+            coords_position_embeding, _ = self.position_embeding(
+                mlvl_feats, img_metas, masks
+            )
+            pos_embed = coords_position_embeding
+            if self.with_multiview:
+                sin_embed = self.positional_encoding(masks)
+                sin_embed = self.adapt_pos3d(sin_embed.flatten(0, 1)).view(x.size())
+                pos_embed = pos_embed + sin_embed
+            else:
+                pos_embeds = []
+                for i in range(num_cams):
+                    xy_embed = self.positional_encoding(masks[:, i, :, :])
+                    pos_embeds.append(xy_embed.unsqueeze(1))
+                sin_embed = torch.cat(pos_embeds, 1)
+                sin_embed = self.adapt_pos3d(sin_embed.flatten(0, 1)).view(x.size())
+                pos_embed = pos_embed + sin_embed
+        else:
+            if self.with_multiview:
+                pos_embed = self.positional_encoding(masks)
+                pos_embed = self.adapt_pos3d(pos_embed.flatten(0, 1)).view(x.size())
+            else:
+                pos_embeds = []
+                for i in range(num_cams):
+                    pos_embed = self.positional_encoding(masks[:, i, :, :])
+                    pos_embeds.append(pos_embed.unsqueeze(1))
+                pos_embed = torch.cat(pos_embeds, 1)
+
+        reference_points = self.reference_points.weight
+        query_embeds = self.query_embedding(pos2posemb3d(reference_points))
+        reference_points = reference_points.unsqueeze(0).repeat(batch_size, 1, 1)
+
+        outs_dec, _ = self.transformer(
+            x, masks, query_embeds, pos_embed, self.reg_branches
+        )
+        outs_dec = torch.nan_to_num(outs_dec)
+        outputs_classes = []
+        outputs_coords = []
+        for lvl in range(outs_dec.shape[0]):
+            reference = inverse_sigmoid(reference_points.clone())
+            assert reference.shape[-1] == 3
+            outputs_class = self.cls_branches[lvl](outs_dec[lvl])
+            tmp = self.reg_branches[lvl](outs_dec[lvl])
+
+            tmp[..., 0:2] += reference[..., 0:2]
+            tmp[..., 0:2] = tmp[..., 0:2].sigmoid()
+            tmp[..., 4:5] += reference[..., 2:3]
+            tmp[..., 4:5] = tmp[..., 4:5].sigmoid()
+
+            outputs_coord = tmp
+            outputs_classes.append(outputs_class)
+            outputs_coords.append(outputs_coord)
+
+        all_cls_scores = torch.stack(outputs_classes)
+        all_bbox_preds = torch.stack(outputs_coords)
+
+        all_bbox_preds[..., 0:1] = (
+            all_bbox_preds[..., 0:1] * (self.pc_range[3] - self.pc_range[0])
+            + self.pc_range[0]
+        )
+        all_bbox_preds[..., 1:2] = (
+            all_bbox_preds[..., 1:2] * (self.pc_range[4] - self.pc_range[1])
+            + self.pc_range[1]
+        )
+        all_bbox_preds[..., 4:5] = (
+            all_bbox_preds[..., 4:5] * (self.pc_range[5] - self.pc_range[2])
+            + self.pc_range[2]
+        )
+
+        outs = {
+            "all_cls_scores": all_cls_scores,
+            "all_bbox_preds": all_bbox_preds,
+            "enc_cls_scores": None,
+            "enc_bbox_preds": None,
+        }
+        return outs
+
+    def get_targets(
+        self,
+        cls_scores_list,
+        bbox_preds_list,
+        gt_bboxes_list,
+        gt_labels_list,
+        gt_bboxes_ignore_list=None,
+    ):
+        pass
+
+    def loss(self, gt_bboxes_list, gt_labels_list, preds_dicts, gt_bboxes_ignore=None):
+
+        pass
+
+    def get_bboxes(self, preds_dicts, img_metas, rescale=False):
+        preds_dicts = self.bbox_coder.decode(preds_dicts)
+        num_samples = len(preds_dicts)
+
+        ret_list = []
+        for i in range(num_samples):
+            preds = preds_dicts[i]
+            bboxes = preds["bboxes"]
+            bboxes[:, 2] = bboxes[:, 2] - bboxes[:, 5] * 0.5
+            bboxes = img_metas[i]["box_type_3d"](bboxes, bboxes.size(-1))
+            scores = preds["scores"]
+            labels = preds["labels"]
+            ret_list.append([bboxes, scores, labels])
+        return ret_list
+
+
+@TRANSFORMER_LAYER_SEQUENCE.register_module()
+class PETRTransformerDecoder(TransformerLayerSequence):
+    def __init__(
+        self, *args, post_norm_cfg=dict(type="LN"), return_intermediate=False, **kwargs
+    ):
+
+        super(PETRTransformerDecoder, self).__init__(*args, **kwargs)
+        self.return_intermediate = return_intermediate
+        if post_norm_cfg is not None:
+            self.post_norm = build_norm_layer(post_norm_cfg, self.embed_dims)[1]
+        else:
+            self.post_norm = None
+
+    def forward(self, query, *args, **kwargs):
+        if not self.return_intermediate:
+            x = super().forward(query, *args, **kwargs)
+            if self.post_norm:
+                x = self.post_norm(x)[None]
+            return x
+
+        intermediate = []
+        for layer in self.layers:
+            query = layer(query, *args, **kwargs)
+            if self.return_intermediate:
+                if self.post_norm is not None:
+                    intermediate.append(self.post_norm(query))
+                else:
+                    intermediate.append(query)
+        return torch.stack(intermediate)
+
+
+@BBOX_CODERS.register_module()
+class NMSFreeCoder(BaseBBoxCoder):
+    def __init__(
+        self,
+        pc_range,
+        voxel_size=None,
+        post_center_range=None,
+        max_num=100,
+        score_threshold=None,
+        num_classes=10,
+    ):
+
+        self.pc_range = pc_range
+        self.voxel_size = voxel_size
+        self.post_center_range = post_center_range
+        self.max_num = max_num
+        self.score_threshold = score_threshold
+        self.num_classes = num_classes
+
+    def encode(self):
+        pass
+
+    def decode_single(self, cls_scores, bbox_preds):
+        max_num = self.max_num
+
+        cls_scores = cls_scores.sigmoid()
+        scores, indexs = cls_scores.view(-1).topk(max_num)
+        labels = indexs % self.num_classes
+        bbox_index = indexs // self.num_classes
+        bbox_preds = bbox_preds[bbox_index]
+
+        final_box_preds = denormalize_bbox(bbox_preds, self.pc_range)
+        final_scores = scores
+        final_preds = labels
+
+        if self.score_threshold is not None:
+            thresh_mask = final_scores > self.score_threshold
+        if self.post_center_range is not None:
+            self.post_center_range = torch.tensor(
+                self.post_center_range, device=scores.device
+            )
+
+            mask = (final_box_preds[..., :3] >= self.post_center_range[:3]).all(1)
+            mask &= (final_box_preds[..., :3] <= self.post_center_range[3:]).all(1)
+
+            if self.score_threshold:
+                mask &= thresh_mask
+
+            boxes3d = final_box_preds[mask]
+            scores = final_scores[mask]
+            labels = final_preds[mask]
+            predictions_dict = {"bboxes": boxes3d, "scores": scores, "labels": labels}
+
+        else:
+            raise NotImplementedError(
+                "Need to reorganize output as a batch, only "
+                "support post_center_range is not None for now!"
+            )
+        return predictions_dict
+
+    def decode(self, preds_dicts):
+
+        all_cls_scores = preds_dicts["all_cls_scores"][-1]
+        all_bbox_preds = preds_dicts["all_bbox_preds"][-1]
+
+        batch_size = all_cls_scores.size()[0]
+        predictions_list = []
+        for i in range(batch_size):
+            predictions_list.append(
+                self.decode_single(all_cls_scores[i], all_bbox_preds[i])
+            )
+        return predictions_list
+
+
+def dw_conv3x3(
+    in_channels, out_channels, module_name, postfix, stride=1, kernel_size=3, padding=1
+):
+    return [
+        (
+            "{}_{}/dw_conv3x3".format(module_name, postfix),
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
+                groups=out_channels,
+                bias=False,
+            ),
+        ),
+        (
+            "{}_{}/pw_conv1x1".format(module_name, postfix),
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+                groups=1,
+                bias=False,
+            ),
+        ),
+        ("{}_{}/pw_norm".format(module_name, postfix), nn.BatchNorm2d(out_channels)),
+        ("{}_{}/pw_relu".format(module_name, postfix), nn.ReLU(inplace=True)),
+    ]
+
+
+def conv3x3(
+    in_channels,
+    out_channels,
+    module_name,
+    postfix,
+    stride=1,
+    groups=1,
+    kernel_size=3,
+    padding=1,
+):
+    return [
+        (
+            f"{module_name}_{postfix}/conv",
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
+                groups=groups,
+                bias=False,
+            ),
+        ),
+        (f"{module_name}_{postfix}/norm", nn.BatchNorm2d(out_channels)),
+        (f"{module_name}_{postfix}/relu", nn.ReLU(inplace=True)),
+    ]
+
+
+def conv1x1(
+    in_channels,
+    out_channels,
+    module_name,
+    postfix,
+    stride=1,
+    groups=1,
+    kernel_size=1,
+    padding=0,
+):
+    return [
+        (
+            f"{module_name}_{postfix}/conv",
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
+                groups=groups,
+                bias=False,
+            ),
+        ),
+        (f"{module_name}_{postfix}/norm", nn.BatchNorm2d(out_channels)),
+        (f"{module_name}_{postfix}/relu", nn.ReLU(inplace=True)),
+    ]
+
+
+class Hsigmoid(nn.Module):
+    def __init__(self, inplace=True):
+        super(Hsigmoid, self).__init__()
+        self.inplace = inplace
+
+    def forward(self, x):
+        return F.relu6(x + 3.0, inplace=self.inplace) / 6.0
+
+
+class eSEModule(nn.Module):
+    def __init__(self, channel, reduction=4):
+        super(eSEModule, self).__init__()
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Conv2d(channel, channel, kernel_size=1, padding=0)
+        self.hsigmoid = Hsigmoid()
+
+    def forward(self, x):
+        input = x
+        x = self.avg_pool(x)
+        x = self.fc(x)
+        x = self.hsigmoid(x)
+        return input * x
+
+
+VoVNet19_slim_dw_eSE = {
+    "stem": [64, 64, 64],
+    "stage_conv_ch": [64, 80, 96, 112],
+    "stage_out_ch": [112, 256, 384, 512],
+    "layer_per_block": 3,
+    "block_per_stage": [1, 1, 1, 1],
+    "eSE": True,
+    "dw": True,
+}
+
+
+VoVNet19_dw_eSE = {
+    "stem": [64, 64, 64],
+    "stage_conv_ch": [128, 160, 192, 224],
+    "stage_out_ch": [256, 512, 768, 1024],
+    "layer_per_block": 3,
+    "block_per_stage": [1, 1, 1, 1],
+    "eSE": True,
+    "dw": True,
+}
+
+VoVNet19_slim_eSE = {
+    "stem": [64, 64, 128],
+    "stage_conv_ch": [64, 80, 96, 112],
+    "stage_out_ch": [112, 256, 384, 512],
+    "layer_per_block": 3,
+    "block_per_stage": [1, 1, 1, 1],
+    "eSE": True,
+    "dw": False,
+}
+
+VoVNet19_eSE = {
+    "stem": [64, 64, 128],
+    "stage_conv_ch": [128, 160, 192, 224],
+    "stage_out_ch": [256, 512, 768, 1024],
+    "layer_per_block": 3,
+    "block_per_stage": [1, 1, 1, 1],
+    "eSE": True,
+    "dw": False,
+}
+
+VoVNet39_eSE = {
+    "stem": [64, 64, 128],
+    "stage_conv_ch": [128, 160, 192, 224],
+    "stage_out_ch": [256, 512, 768, 1024],
+    "layer_per_block": 5,
+    "block_per_stage": [1, 1, 2, 2],
+    "eSE": True,
+    "dw": False,
+}
+
+VoVNet57_eSE = {
+    "stem": [64, 64, 128],
+    "stage_conv_ch": [128, 160, 192, 224],
+    "stage_out_ch": [256, 512, 768, 1024],
+    "layer_per_block": 5,
+    "block_per_stage": [1, 1, 4, 3],
+    "eSE": True,
+    "dw": False,
+}
+
+VoVNet99_eSE = {
+    "stem": [64, 64, 128],
+    "stage_conv_ch": [128, 160, 192, 224],
+    "stage_out_ch": [256, 512, 768, 1024],
+    "layer_per_block": 5,
+    "block_per_stage": [1, 3, 9, 3],
+    "eSE": True,
+    "dw": False,
+}
+
+
+_STAGE_SPECS = {
+    "V-19-slim-dw-eSE": VoVNet19_slim_dw_eSE,
+    "V-19-dw-eSE": VoVNet19_dw_eSE,
+    "V-19-slim-eSE": VoVNet19_slim_eSE,
+    "V-19-eSE": VoVNet19_eSE,
+    "V-39-eSE": VoVNet39_eSE,
+    "V-57-eSE": VoVNet57_eSE,
+    "V-99-eSE": VoVNet99_eSE,
+}
+
+
+class _OSA_module(nn.Module):
+    def __init__(
+        self,
+        in_ch,
+        stage_ch,
+        concat_ch,
+        layer_per_block,
+        module_name,
+        SE=False,
+        identity=False,
+        depthwise=False,
+        with_cp=True,
+    ):
+
+        super(_OSA_module, self).__init__()
+
+        self.identity = identity
+        self.depthwise = depthwise
+        self.isReduced = False
+        self.use_checkpoint = with_cp
+        self.layers = nn.ModuleList()
+        in_channel = in_ch
+        if self.depthwise and in_channel != stage_ch:
+            self.isReduced = True
+            self.conv_reduction = nn.Sequential(
+                OrderedDict(
+                    conv1x1(
+                        in_channel, stage_ch, "{}_reduction".format(module_name), "0"
+                    )
+                )
+            )
+        for i in range(layer_per_block):
+            if self.depthwise:
+                self.layers.append(
+                    nn.Sequential(
+                        OrderedDict(dw_conv3x3(stage_ch, stage_ch, module_name, i))
+                    )
+                )
+            else:
+                self.layers.append(
+                    nn.Sequential(
+                        OrderedDict(conv3x3(in_channel, stage_ch, module_name, i))
+                    )
+                )
+            in_channel = stage_ch
+
+        in_channel = in_ch + layer_per_block * stage_ch
+        self.concat = nn.Sequential(
+            OrderedDict(conv1x1(in_channel, concat_ch, module_name, "concat"))
+        )
+
+        self.ese = eSEModule(concat_ch)
+
+    def _forward(self, x):
+
+        identity_feat = x
+
+        output = []
+        output.append(x)
+        if self.depthwise and self.isReduced:
+            x = self.conv_reduction(x)
+        for layer in self.layers:
+            x = layer(x)
+            output.append(x)
+
+        x = torch.cat(output, dim=1)
+        xt = self.concat(x)
+
+        xt = self.ese(xt)
+
+        if self.identity:
+            xt = xt + identity_feat
+
+        return xt
+
+    def forward(self, x):
+
+        if self.use_checkpoint and self.training:
+            xt = cp.checkpoint(self._forward, x)
+        else:
+            xt = self._forward(x)
+
+        return xt
+
+
+class _OSA_stage(nn.Sequential):
+    def __init__(
+        self,
+        in_ch,
+        stage_ch,
+        concat_ch,
+        block_per_stage,
+        layer_per_block,
+        stage_num,
+        SE=False,
+        depthwise=False,
+    ):
+
+        super(_OSA_stage, self).__init__()
+
+        if not stage_num == 2:
+            self.add_module(
+                "Pooling", nn.MaxPool2d(kernel_size=3, stride=2, ceil_mode=True)
+            )
+
+        if block_per_stage != 1:
+            SE = False
+        module_name = f"OSA{stage_num}_1"
+        self.add_module(
+            module_name,
+            _OSA_module(
+                in_ch,
+                stage_ch,
+                concat_ch,
+                layer_per_block,
+                module_name,
+                SE,
+                depthwise=depthwise,
+            ),
+        )
+        for i in range(block_per_stage - 1):
+            if i != block_per_stage - 2:
+                SE = False
+            module_name = f"OSA{stage_num}_{i + 2}"
+            self.add_module(
+                module_name,
+                _OSA_module(
+                    concat_ch,
+                    stage_ch,
+                    concat_ch,
+                    layer_per_block,
+                    module_name,
+                    SE,
+                    identity=True,
+                    depthwise=depthwise,
+                ),
+            )
+
+
+@BACKBONES.register_module()
+class VoVNetCP(BaseModule):
+    def __init__(
+        self,
+        spec_name,
+        input_ch=3,
+        out_features=None,
+        frozen_stages=-1,
+        norm_eval=True,
+        pretrained=None,
+        init_cfg=None,
+    ):
+        super(VoVNetCP, self).__init__(init_cfg)
+        self.frozen_stages = frozen_stages
+        self.norm_eval = norm_eval
+
+        if isinstance(pretrained, str):
+            warnings.warn(
+                "DeprecationWarning: pretrained is deprecated, "
+                'please use "init_cfg" instead'
+            )
+            self.init_cfg = dict(type="Pretrained", checkpoint=pretrained)
+        stage_specs = _STAGE_SPECS[spec_name]
+
+        stem_ch = stage_specs["stem"]
+        config_stage_ch = stage_specs["stage_conv_ch"]
+        config_concat_ch = stage_specs["stage_out_ch"]
+        block_per_stage = stage_specs["block_per_stage"]
+        layer_per_block = stage_specs["layer_per_block"]
+        SE = stage_specs["eSE"]
+        depthwise = stage_specs["dw"]
+
+        self._out_features = out_features
+
+        conv_type = dw_conv3x3 if depthwise else conv3x3
+        stem = conv3x3(input_ch, stem_ch[0], "stem", "1", 2)
+        stem += conv_type(stem_ch[0], stem_ch[1], "stem", "2", 1)
+        stem += conv_type(stem_ch[1], stem_ch[2], "stem", "3", 2)
+        self.add_module("stem", nn.Sequential((OrderedDict(stem))))
+        current_stirde = 4
+        self._out_feature_strides = {"stem": current_stirde, "stage2": current_stirde}
+        self._out_feature_channels = {"stem": stem_ch[2]}
+
+        stem_out_ch = [stem_ch[2]]
+        in_ch_list = stem_out_ch + config_concat_ch[:-1]
+        self.stage_names = []
+        for i in range(4):
+            name = "stage%d" % (i + 2)
+            self.stage_names.append(name)
+            self.add_module(
+                name,
+                _OSA_stage(
+                    in_ch_list[i],
+                    config_stage_ch[i],
+                    config_concat_ch[i],
+                    block_per_stage[i],
+                    layer_per_block,
+                    i + 2,
+                    SE,
+                    depthwise,
+                ),
+            )
+
+            self._out_feature_channels[name] = config_concat_ch[i]
+            if not i == 0:
+                self._out_feature_strides[name] = current_stirde = int(
+                    current_stirde * 2
+                )
+
+    def _initialize_weights(self):
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight)
+
+    def forward(self, x):
+        outputs = []
+        x = self.stem(x)
+        if "stem" in self._out_features:
+            outputs.append(x)
+        for name in self.stage_names:
+            x = getattr(self, name)(x)
+            if name in self._out_features:
+                outputs.append(x)
+
+        return outputs
+
+    def _freeze_stages(self):
+        if self.frozen_stages >= 0:
+            m = getattr(self, "stem")
+            m.eval()
+            for param in m.parameters():
+                param.requires_grad = False
+
+        for i in range(1, self.frozen_stages + 1):
+            m = getattr(self, f"stage{i+1}")
+            m.eval()
+            for param in m.parameters():
+                param.requires_grad = False
+
+    def train(self, mode=True):
+        super(VoVNetCP, self).train(mode)
+        self._freeze_stages()
+        if mode and self.norm_eval:
+            for m in self.modules():
+                if isinstance(m, _BatchNorm):
+                    m.eval()
+
+
+@NECKS.register_module()
+class CPFPN(BaseModule):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        num_outs,
+        start_level=0,
+        end_level=-1,
+        add_extra_convs=False,
+        relu_before_extra_convs=False,
+        no_norm_on_lateral=False,
+        conv_cfg=None,
+        norm_cfg=None,
+        act_cfg=None,
+        upsample_cfg=dict(mode="nearest"),
+        init_cfg=dict(type="Xavier", layer="Conv2d", distribution="uniform"),
+    ):
+        super(CPFPN, self).__init__(init_cfg)
+        assert isinstance(in_channels, list)
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.num_ins = len(in_channels)
+        self.num_outs = num_outs
+        self.relu_before_extra_convs = relu_before_extra_convs
+        self.no_norm_on_lateral = no_norm_on_lateral
+        self.fp16_enabled = False
+        self.upsample_cfg = upsample_cfg.copy()
+
+        if end_level == -1:
+            self.backbone_end_level = self.num_ins
+            assert num_outs >= self.num_ins - start_level
+        else:
+            self.backbone_end_level = end_level
+            assert end_level <= len(in_channels)
+            assert num_outs == end_level - start_level
+        self.start_level = start_level
+        self.end_level = end_level
+        self.add_extra_convs = add_extra_convs
+        assert isinstance(add_extra_convs, (str, bool))
+        if isinstance(add_extra_convs, str):
+            assert add_extra_convs in ("on_input", "on_lateral", "on_output")
+        elif add_extra_convs:
+            self.add_extra_convs = "on_input"
+
+        self.lateral_convs = nn.ModuleList()
+        self.fpn_convs = nn.ModuleList()
+
+        for i in range(self.start_level, self.backbone_end_level):
+            l_conv = ConvModule(
+                in_channels[i],
+                out_channels,
+                1,
+                conv_cfg=conv_cfg,
+                norm_cfg=norm_cfg if not self.no_norm_on_lateral else None,
+                act_cfg=act_cfg,
+                inplace=False,
+            )
+            self.lateral_convs.append(l_conv)
+            if i == 0:
+                fpn_conv = ConvModule(
+                    out_channels,
+                    out_channels,
+                    3,
+                    padding=1,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    act_cfg=act_cfg,
+                    inplace=False,
+                )
+                self.fpn_convs.append(fpn_conv)
+        extra_levels = num_outs - self.backbone_end_level + self.start_level
+        if self.add_extra_convs and extra_levels >= 1:
+            for i in range(extra_levels):
+                if i == 0 and self.add_extra_convs == "on_input":
+                    in_channels = self.in_channels[self.backbone_end_level - 1]
+                else:
+                    in_channels = out_channels
+                extra_fpn_conv = ConvModule(
+                    in_channels,
+                    out_channels,
+                    3,
+                    stride=2,
+                    padding=1,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    act_cfg=act_cfg,
+                    inplace=False,
+                )
+                self.fpn_convs.append(extra_fpn_conv)
+
+    def forward(self, inputs):
+        assert len(inputs) == len(self.in_channels)
+        laterals = [
+            lateral_conv(inputs[i + self.start_level])
+            for i, lateral_conv in enumerate(self.lateral_convs)
+        ]
+
+        used_backbone_levels = len(laterals)
+        for i in range(used_backbone_levels - 1, 0, -1):
+            if "scale_factor" in self.upsample_cfg:
+                laterals[i - 1] += F.interpolate(laterals[i], **self.upsample_cfg)
+            else:
+                prev_shape = laterals[i - 1].shape[2:]
+                laterals[i - 1] += F.interpolate(
+                    laterals[i], size=prev_shape, **self.upsample_cfg
+                )
+
+        outs = [
+            self.fpn_convs[i](laterals[i]) if i == 0 else laterals[i]
+            for i in range(used_backbone_levels)
+        ]
+        if self.num_outs > len(outs):
+            if not self.add_extra_convs:
+                for i in range(self.num_outs - used_backbone_levels):
+                    outs.append(F.max_pool2d(outs[-1], 1, stride=2))
+            else:
+                if self.add_extra_convs == "on_input":
+                    extra_source = inputs[self.backbone_end_level - 1]
+                elif self.add_extra_convs == "on_lateral":
+                    extra_source = laterals[-1]
+                elif self.add_extra_convs == "on_output":
+                    extra_source = outs[-1]
+                else:
+                    raise NotImplementedError
+                outs.append(self.fpn_convs[used_backbone_levels](extra_source))
+                for i in range(used_backbone_levels + 1, self.num_outs):
+                    if self.relu_before_extra_convs:
+                        outs.append(self.fpn_convs[i](F.relu(outs[-1])))
+                    else:
+                        outs.append(self.fpn_convs[i](outs[-1]))
+        return tuple(outs)
+
+
+# ============================================================================
+# INPUT UTILS
+# ============================================================================
+
+
+class BaseInstance3DBoxes(object):
+    def __init__(self, tensor, box_dim=7, with_yaw=True, origin=(0.5, 0.5, 0)):
+        if isinstance(tensor, torch.Tensor):
+            device = tensor.device
+        else:
+            device = torch.device("cpu")
+        tensor = torch.as_tensor(tensor, dtype=torch.float32, device=device)
+        if tensor.numel() == 0:
+            tensor = tensor.reshape((0, box_dim)).to(dtype=torch.float32, device=device)
+        assert tensor.dim() == 2 and tensor.size(-1) == box_dim, tensor.size()
+
+        if tensor.shape[-1] == 6:
+            assert box_dim == 6
+            fake_rot = tensor.new_zeros(tensor.shape[0], 1)
+            tensor = torch.cat((tensor, fake_rot), dim=-1)
+            self.box_dim = box_dim + 1
+            self.with_yaw = False
+        else:
+            self.box_dim = box_dim
+            self.with_yaw = with_yaw
+        self.tensor = tensor.clone()
+
+        if origin != (0.5, 0.5, 0):
+            dst = self.tensor.new_tensor((0.5, 0.5, 0))
+            src = self.tensor.new_tensor(origin)
+            self.tensor[:, :3] += self.tensor[:, 3:6] * (dst - src)
+
+    def to(self, device):
+
+        original_type = type(self)
+        return original_type(
+            self.tensor.to(device), box_dim=self.box_dim, with_yaw=self.with_yaw
+        )
+
+    def __repr__(self):
+        return self.__class__.__name__ + "(\n    " + str(self.tensor) + ")"
+
+
+class LiDARInstance3DBoxes(BaseInstance3DBoxes):
+    pass
+
+
+# ============================================================================
+# MODEL CONFIG
+# ============================================================================
+
+# Common configuration
+point_cloud_range = [-51.2, -51.2, -5.0, 51.2, 51.2, 3.0]
+voxel_size = [0.2, 0.2, 8]
+
+# Backbone configurations
+resnet50_dcn_backbone_cfg = dict(
+    type="ResNet",
+    depth=50,
+    num_stages=4,
+    out_indices=(
+        2,
+        3,
+    ),
+    frozen_stages=-1,
+    norm_cfg=dict(type="BN2d", requires_grad=False),
+    norm_eval=True,
+    style="caffe",
+    with_cp=True,
+    dcn=dict(type="DCNv2", deform_groups=1, fallback_on_stride=False),
+    stage_with_dcn=(False, False, True, True),
+)
+
+# Base model configuration
+model_cfg = dict(
+    type="Petr3D",
+    use_grid_mask=True,
+    img_backbone=dict(
+        type="VoVNetCP",
+        spec_name="V-99-eSE",
+        norm_eval=True,
+        frozen_stages=-1,
+        input_ch=3,
+        out_features=(
+            "stage4",
+            "stage5",
+        ),
+    ),
+    img_neck=dict(type="CPFPN", in_channels=[768, 1024], out_channels=256, num_outs=2),
+    pts_bbox_head=dict(
+        type="PETRHead",
+        num_classes=10,
+        in_channels=256,
+        num_query=900,
+        LID=True,
+        with_position=True,
+        with_multiview=True,
+        position_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
+        normedlinear=False,
+        transformer=dict(
+            type="PETRTransformer",
+            decoder=dict(
+                type="PETRTransformerDecoder",
+                return_intermediate=True,
+                num_layers=6,
+                transformerlayers=dict(
+                    type="PETRTransformerDecoderLayer",
+                    attn_cfgs=[
+                        dict(
+                            type="MultiheadAttention",
+                            embed_dims=256,
+                            num_heads=8,
+                            dropout=0.1,
+                        ),
+                        dict(
+                            type="PETRMultiheadAttention",
+                            embed_dims=256,
+                            num_heads=8,
+                            dropout=0.1,
+                        ),
+                    ],
+                    feedforward_channels=2048,
+                    ffn_dropout=0.1,
+                    operation_order=(
+                        "self_attn",
+                        "norm",
+                        "cross_attn",
+                        "norm",
+                        "ffn",
+                        "norm",
+                    ),
+                ),
+            ),
+        ),
+        bbox_coder=dict(
+            type="NMSFreeCoder",
+            post_center_range=[-61.2, -61.2, -10.0, 61.2, 61.2, 10.0],
+            pc_range=point_cloud_range,
+            max_num=300,
+            voxel_size=voxel_size,
+            num_classes=10,
+        ),
+        positional_encoding=dict(
+            type="SinePositionalEncoding3D", num_feats=128, normalize=True
+        ),
+        loss_cls=dict(
+            type="FocalLoss", use_sigmoid=True, gamma=2.0, alpha=0.25, loss_weight=2.0
+        ),
+        loss_bbox=dict(type="L1Loss", loss_weight=0.25),
+        loss_iou=dict(type="GIoULoss", loss_weight=0.0),
+    ),
+    train_cfg=dict(
+        pts=dict(
+            grid_size=[512, 512, 1],
+            voxel_size=voxel_size,
+            point_cloud_range=point_cloud_range,
+            out_size_factor=4,
+            assigner=dict(
+                type="HungarianAssigner3D",
+                cls_cost=dict(type="FocalLossCost", weight=2.0),
+                reg_cost=dict(type="BBox3DL1Cost", weight=0.25),
+                iou_cost=dict(type="IoUCost", weight=0.0),
+                pc_range=point_cloud_range,
+            ),
+        )
+    ),
+)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1894

### Problem description

- Bringup following PETR variants 
  - [r50dcn_gridmask_c5](https://github.com/megvii-research/PETR/blob/main/projects/configs/petr/petr_r50dcn_gridmask_c5.py)
  - [r50dcn_gridmask_p4](https://github.com/megvii-research/PETR/blob/main/projects/configs/petr/petr_r50dcn_gridmask_p4.py)
  - [vovnet_gridmask_p4_800x320](https://github.com/megvii-research/PETR/blob/main/projects/configs/petr/petr_vovnet_gridmask_p4_800x320.py)
  - [vovnet_gridmask_p4_1600x640](https://github.com/megvii-research/PETR/blob/main/projects/configs/petr/petr_vovnet_gridmask_p4_1600x640.py)

### What's changed

- Added support for mentioned variants
- Note : Replaced the custom [ModulatedDeformConv2dFunction.apply](https://github.com/open-mmlab/mmcv/blob/7207397de3c2ffaef878628a55fa2ab37ac0bbc7/mmcv/ops/modulated_deform_conv.py#L153) call with torchvision.ops.deform_conv2d in resnet based variants
- Results were verified by passing actual inputs to org CPU implementation vs our code. [pcc.log](https://github.com/user-attachments/files/23483152/nov11_pcc_from_loader_1.log)


### Checklist
- [x] Verified the changes through local testing

### Logs

- [nov11_petr_cpu_run_for_actual_inputs.log](https://github.com/user-attachments/files/23483189/nov11_petr_fl_2.log)
- [nov11_petr_cpu_run_for_random_inputs.log](https://github.com/user-attachments/files/23483185/nov11_petr_fl_rand_ip_final_f.log)
- [nov11_petr_xla_run.log](https://github.com/user-attachments/files/23483186/nov11_petr_xla.log)
