### PR TITLE
Add bias sharding for Qwen 2.5 models

### DIFF
--- a/qwen_2_5/causal_lm/pytorch/loader.py
+++ b/qwen_2_5/causal_lm/pytorch/loader.py
@@ -270,8 +270,11 @@ class ModelLoader(ForgeModel):
             shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
 
             shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.q_proj.bias] = ("model",)
             shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.k_proj.bias] = ("model",)
             shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.v_proj.bias] = ("model",)
             shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
         shard_specs[model.lm_head.weight] = ("model", "batch")
 


### PR DESCRIPTION
### Ticket
[tt-xla#2150](https://github.com/tenstorrent/tt-xla/issues/2150)

### Problem description and changes
The Qwen 2.5 models have attention biases so they should also be sharded to save memory.

### Checklist
- [x] New/Existing tests provide coverage for changes
