### PR TITLE
Remove ultralytics dependency, Fix weights loading issue in YOLOv6 and Add post processing steps in yolov7 

### DIFF
--- a/yolov6/pytorch/loader.py
+++ b/yolov6/pytorch/loader.py
@@ -87,9 +87,6 @@ class ModelLoader(ForgeModel):
         )
 
     def load_model(self, dtype_override=None):
-
-        from yolov6.layers.common import DetectBackend
-
         """Load and return the YOLOv6 model instance with default settings.
 
         Args:
@@ -99,6 +96,13 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.nn.Module: The YOLOv6 model instance.
         """
+        # Disable weights_only check for PyTorch 2.6+ to load YOLOv6 checkpoint with custom classes
+        import os
+
+        os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
+
+        from yolov6.layers.common import DetectBackend
+
         # Get the model name from the instance's variant config
         variant = self._variant_config.pretrained_model_name
         weight_url = (
@@ -155,7 +159,7 @@ class ModelLoader(ForgeModel):
 
         det = non_max_suppression(output.detach().float())
 
-        coco_yaml_path = get_file("FIND_NEW_PATH")
+        coco_yaml_path = get_file("test_files/pytorch/yolo/coco.yaml")
         with open(coco_yaml_path, "r") as f:
             coco_yaml = yaml.safe_load(f)
         class_names = coco_yaml["names"]

--- a/yolov7/pytorch/loader.py
+++ b/yolov7/pytorch/loader.py
@@ -20,12 +20,12 @@ from ...config import (
     StrEnum,
 )
 from ...base import ForgeModel
-from ...tools.utils import yolo_postprocess
 
 from third_party.tt_forge_models.yolov7.pytorch.src.model_utils import (
     check_img_size,
     attempt_load,
     letterbox,
+    yolov7_postprocess,
 )
 from third_party.tt_forge_models.tools.utils import get_file
 
@@ -192,4 +192,4 @@ class ModelLoader(ForgeModel):
         Returns:
             Post-processed detection results.
         """
-        return yolo_postprocess(co_out)
+        return yolov7_postprocess(co_out, self.img_src, self.input_batch)

--- a/yolov7/pytorch/src/model_utils.py
+++ b/yolov7/pytorch/src/model_utils.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+from ....tools.utils import get_file
+
 import torch.nn as nn
 import subprocess
 from pathlib import Path
@@ -15,6 +17,8 @@ import importlib
 import types
 from torch.hub import download_url_to_file
 from urllib.parse import urljoin
+import torchvision
+import yaml
 
 
 def make_divisible(x, divisor):
@@ -203,3 +207,209 @@ def attempt_load(weights, map_location=None):
         for k in ["names", "stride"]:
             setattr(model, k, getattr(model[-1], k))
         return model
+
+
+def xywh2xyxy(x):
+    # Convert nx4 boxes from [x, y, w, h] to [x1, y1, x2, y2] where xy1=top-left, xy2=bottom-right
+    y = x.clone() if isinstance(x, torch.Tensor) else np.copy(x)
+    y[:, 0] = x[:, 0] - x[:, 2] / 2  # top left x
+    y[:, 1] = x[:, 1] - x[:, 3] / 2  # top left y
+    y[:, 2] = x[:, 0] + x[:, 2] / 2  # bottom right x
+    y[:, 3] = x[:, 1] + x[:, 3] / 2  # bottom right y
+    return y
+
+
+def box_iou(box1, box2):
+    # https://github.com/pytorch/vision/blob/master/torchvision/ops/boxes.py
+    """
+    Return intersection-over-union (Jaccard index) of boxes.
+    Both sets of boxes are expected to be in (x1, y1, x2, y2) format.
+    Arguments:
+        box1 (Tensor[N, 4])
+        box2 (Tensor[M, 4])
+    Returns:
+        iou (Tensor[N, M]): the NxM matrix containing the pairwise
+            IoU values for every element in boxes1 and boxes2
+    """
+
+    def box_area(box):
+        # box = 4xn
+        return (box[2] - box[0]) * (box[3] - box[1])
+
+    area1 = box_area(box1.T)
+    area2 = box_area(box2.T)
+
+    # inter(N,M) = (rb(N,M,2) - lt(N,M,2)).clamp(0).prod(2)
+    inter = (
+        (
+            torch.min(box1[:, None, 2:], box2[:, 2:])
+            - torch.max(box1[:, None, :2], box2[:, :2])
+        )
+        .clamp(0)
+        .prod(2)
+    )
+    return inter / (
+        area1[:, None] + area2 - inter
+    )  # iou = inter / (area1 + area2 - inter)
+
+
+def clip_coords(boxes, img_shape):
+    # Clip bounding xyxy bounding boxes to image shape (height, width)
+    boxes[:, 0].clamp_(0, img_shape[1])  # x1
+    boxes[:, 1].clamp_(0, img_shape[0])  # y1
+    boxes[:, 2].clamp_(0, img_shape[1])  # x2
+    boxes[:, 3].clamp_(0, img_shape[0])  # y2
+
+
+def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None):
+    # Rescale coords (xyxy) from img1_shape to img0_shape
+    if ratio_pad is None:  # calculate from img0_shape
+        gain = min(
+            img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1]
+        )  # gain  = old / new
+        pad = (img1_shape[1] - img0_shape[1] * gain) / 2, (
+            img1_shape[0] - img0_shape[0] * gain
+        ) / 2  # wh padding
+    else:
+        gain = ratio_pad[0][0]
+        pad = ratio_pad[1]
+
+    coords[:, [0, 2]] -= pad[0]  # x padding
+    coords[:, [1, 3]] -= pad[1]  # y padding
+    coords[:, :4] /= gain
+    clip_coords(coords, img0_shape)
+    return coords
+
+
+def non_max_suppression(
+    prediction,
+    conf_thres=0.25,
+    iou_thres=0.45,
+    classes=None,
+    agnostic=False,
+    multi_label=False,
+    labels=(),
+):
+    """Runs Non-Maximum Suppression (NMS) on inference results
+
+    Returns:
+         list of detections, on (n,6) tensor per image [xyxy, conf, cls]
+    """
+
+    nc = prediction.shape[2] - 5  # number of classes
+    xc = prediction[..., 4] > conf_thres  # candidates
+
+    # Settings
+    min_wh, max_wh = 2, 4096  # (pixels) minimum and maximum box width and height
+    max_det = 300  # maximum number of detections per image
+    max_nms = 30000  # maximum number of boxes into torchvision.ops.nms()
+    time_limit = 10.0  # seconds to quit after
+    redundant = True  # require redundant detections
+    multi_label &= nc > 1  # multiple labels per box (adds 0.5ms/img)
+    merge = False  # use merge-NMS
+
+    output = [torch.zeros((0, 6), device=prediction.device)] * prediction.shape[0]
+    for xi, x in enumerate(prediction):  # image index, image inference
+        # Apply constraints
+        # x[((x[..., 2:4] < min_wh) | (x[..., 2:4] > max_wh)).any(1), 4] = 0  # width-height
+        x = x[xc[xi]]  # confidence
+
+        # Cat apriori labels if autolabelling
+        if labels and len(labels[xi]):
+            l = labels[xi]
+            v = torch.zeros((len(l), nc + 5), device=x.device)
+            v[:, :4] = l[:, 1:5]  # box
+            v[:, 4] = 1.0  # conf
+            v[range(len(l)), l[:, 0].long() + 5] = 1.0  # cls
+            x = torch.cat((x, v), 0)
+
+        # If none remain process next image
+        if not x.shape[0]:
+            continue
+
+        # Compute conf
+        if nc == 1:
+            x[:, 5:] = x[
+                :, 4:5
+            ]  # for models with one class, cls_loss is 0 and cls_conf is always 0.5,
+            # so there is no need to multiplicate.
+        else:
+            x[:, 5:] *= x[:, 4:5]  # conf = obj_conf * cls_conf
+
+        # Box (center x, center y, width, height) to (x1, y1, x2, y2)
+        box = xywh2xyxy(x[:, :4])
+
+        # Detections matrix nx6 (xyxy, conf, cls)
+        if multi_label:
+            i, j = (x[:, 5:] > conf_thres).nonzero(as_tuple=False).T
+            x = torch.cat((box[i], x[i, j + 5, None], j[:, None].float()), 1)
+        else:  # best class only
+            conf, j = x[:, 5:].max(1, keepdim=True)
+            x = torch.cat((box, conf, j.float()), 1)[conf.view(-1) > conf_thres]
+
+        # Filter by class
+        if classes is not None:
+            x = x[(x[:, 5:6] == torch.tensor(classes, device=x.device)).any(1)]
+
+        # Check shape
+        n = x.shape[0]  # number of boxes
+        if not n:  # no boxes
+            continue
+        elif n > max_nms:  # excess boxes
+            x = x[x[:, 4].argsort(descending=True)[:max_nms]]  # sort by confidence
+
+        # Batched NMS
+        c = x[:, 5:6] * (0 if agnostic else max_wh)  # classes
+        boxes, scores = x[:, :4] + c, x[:, 4]  # boxes (offset by class), scores
+        i = torchvision.ops.nms(boxes, scores, iou_thres)  # NMS
+        if i.shape[0] > max_det:  # limit detections
+            i = i[:max_det]
+        if merge and (1 < n < 3e3):  # Merge NMS (boxes merged using weighted mean)
+            # update boxes as boxes(i,4) = weights(i,n) * boxes(n,4)
+            iou = box_iou(boxes[i], boxes) > iou_thres  # iou matrix
+            weights = iou * scores[None]  # box weights
+            x[i, :4] = torch.mm(weights, x[:, :4]).float() / weights.sum(
+                1, keepdim=True
+            )  # merged boxes
+            if redundant:
+                i = i[iou.sum(1) > 1]  # require redundancy
+
+        output[xi] = x[i]
+
+    return output
+
+
+def yolov7_postprocess(pred, org_img, img):
+
+    # Apply NMS
+    pred = non_max_suppression(pred)
+
+    # Get class names
+    coco_yaml_path = get_file("test_files/pytorch/yolo/coco.yaml")
+    with open(coco_yaml_path, "r") as f:
+        coco_yaml = yaml.safe_load(f)
+    names = coco_yaml["names"]
+
+    # Process detections
+    for i, det in enumerate(pred):  # detections per image
+
+        if len(det):
+            # Rescale boxes from img_size to im0 size
+            det[:, :4] = scale_coords(img.shape[2:], det[:, :4], org_img.shape).round()
+
+            # Print detections
+            for *xyxy, conf, cls in reversed(det):
+                class_num = int(cls.item()) if hasattr(cls, "item") else int(cls)
+                conf_value = (
+                    float(conf.item()) if hasattr(conf, "item") else float(conf)
+                )
+                coordinates = [
+                    int(x.item()) if hasattr(x, "item") else int(x) for x in xyxy
+                ]
+                label = names[class_num]
+
+                print(
+                    f"Coordinates: {coordinates}, Class: {label}, Confidence: {conf_value:.2f}"
+                )
+
+        print("\n")


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/2163
- https://github.com/tenstorrent/tt-xla/issues/2164

### Problem description

- YOLOv6 weight loading was failing with the following error due to changes in PyTorch 2.6:
```
WeightsUnpickler error: Unsupported global: GLOBAL yolov6.models.yolo.Model was not an allowed global by default.
```
- PyTorch 2.6 changed the default weights_only parameter in torch.load() from False to True. The yolov6 model checkpoint contains custom classes (yolov6.models.yolo.Model) that aren't allowed with the new stricter setting.
- Ultralytics dependency from YOLOv6's post processing steps should be removed.
- Post postprocessing steps for yolov7 without ultralytics dependency should be added.


### What's changed

- Fixed YOLOv6 weight-loading failure by setting: `os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1" ` 
- This disables weights_only check for PyTorch 2.6+ to load YOLOv6 checkpoint with custom classes.
- Removed Ultralytics Dependency in YOLOv6 : [coco.yaml](https://raw.githubusercontent.com/ultralytics/yolov5/master/data/coco.yaml) downloaded & now added to s3 bucket.
- Added post processing steps for yolov7 

### Checklist
- [x] Verified the changes through local testing

### Logs

- [nov17_yolov6.log](https://github.com/user-attachments/files/23582552/nov17_yolov6_af_ff.log)
- [nov17_yolov7.log](https://github.com/user-attachments/files/23582553/nov17_yolov7_af_ff_1.log)

