### PR TITLE
Fixed the PCC drop affecting Qwen3 models

### DIFF
--- a/qwen_3/causal_lm/pytorch/loader.py
+++ b/qwen_3/causal_lm/pytorch/loader.py
@@ -181,7 +181,7 @@ class ModelLoader(ForgeModel):
         inputs = self.tokenizer(
             prompts,
             return_tensors="pt",
-            padding="max_length",
+            padding=True,
             truncation=True,
             max_length=max_length,
         )


### PR DESCRIPTION
### Ticket
[1474](https://github.com/tenstorrent/tt-xla/issues/1474)

### Problem description
Debug PCC drop issues in Qwen_3 models—0.6B, 1.7B, and 4B variants.

During the process of debugging the model's PCC drop, I investigated the [original implementation](https://huggingface.co/Qwen/Qwen3-1.7B) and found a key difference in how input data (.pt files) is generated within the TT-XLA framework.
The TT-XLA implementation uses the following three new parameters during input tokenization/generation, which are absent in the original implementation:

> padding="max_length"
> truncation=True
> max_length=max_length

While debugging, I found that using padding="max_length" results in the generation of invalid tokens, which causes a drop in PCC for the model.
Identified that setting padding=True eliminates invalid token generation, which resolves the issue and allows the model to pass.

### What's changed

Set padding=True in tt-forge-models/qwen_3/causal_lm/pytorch/loader.py
Attached are passing-case logs for the Qwen3 0.6B, 1.7B, and 4B models.
[qwen_3_0_6b.log](https://github.com/user-attachments/files/23619735/qwen_3_0_6b.log)
[qwen_3_1_7b.log](https://github.com/user-attachments/files/23619736/qwen_3_1_7b.log)
[qwen_3_4b.log](https://github.com/user-attachments/files/23619737/qwen_3_4b.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
