### PR TITLE
Remove generation parameters from Phi-3.5 Vision forward() inputs

### DIFF
--- a/phi3/phi_3_5_vision/pytorch/loader.py
+++ b/phi3/phi_3_5_vision/pytorch/loader.py
@@ -152,9 +152,6 @@ class ModelLoader(ForgeModel):
         arguments = {
             **inputs,
             "use_cache": False,
-            "max_new_tokens": 20,
-            "do_sample": False,
-            "pad_token_id": self.tokenizer.eos_token_id,
         }
 
         return arguments


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1865

### Problem description

- Phi-3.5 Vision  model faced `TypeError: Phi3VForCausalLM.forward() got an unexpected keyword argument 'max_new_tokens'`

### Root cause 

- [max_new_tokens, do_sample,pad_token_id](https://github.com/tenstorrent/tt-forge-models/blob/3feef86b842abc8712f514b8aa24d8ceb48769ae/phi3/phi_3_5_vision/pytorch/loader.py#L155C13-L157C57) are generation parameters and should not be passed to [forward()](https://huggingface.co/microsoft/Phi-3.5-vision-instruct/blob/main/modeling_phi3_v.py#L1555)

### What's changed

- Removed generation parameters from Phi-3.5 Vision forward() inputs

### Checklist
- [x] verified the changes through local testing

### Logs

- [nov19_phi3_5_vision_before_fix.log](https://github.com/user-attachments/files/23620589/nov19_phi3_5_vision_bf.log)
- [nov19_phi3_5_vision_after_fix.log](https://github.com/user-attachments/files/23620588/nov19_phi3_5_vision_af.log)

