### PR TITLE
Add `rngs` Parameter for Dropout in MNIST

### DIFF
--- a/mnist/image_classification/jax/loader.py
+++ b/mnist/image_classification/jax/loader.py
@@ -363,10 +363,11 @@ class ModelLoader(ForgeModel):
     def get_static_argnames(self):
         """Get static argument names for the forward method.
 
-        For Flax models using apply, 'train' needs to be static when the model
+        For Flax models using apply, `train` needs to be static when the model
         uses it, because the model uses 'not train' which requires a concrete boolean value.
-        Additionally, 'mutable' must be static when using batch normalization
-        because it contains string values that cannot be traced.
+        Additionally, `mutable` must be static when using batch normalization
+        because it contains string values that cannot be traced. `rngs` must be static for
+        dropout models because it contains a random key that cannot be traced.
 
         Returns:
             list: List containing static argument names
@@ -374,19 +375,19 @@ class ModelLoader(ForgeModel):
         static_args = []
 
         # Check if the model actually has a `train` parameter
-        # Only CNN models have it, not the MLP models
+        # Only CNN models have it, not the MLP models.
         if self._variant in [ModelVariant.CNN_BATCHNORM, ModelVariant.CNN_DROPOUT]:
             # `train` must be static because the model does boolean operations on it
-            # (e.g., use_running_average=not train) which don't work with traced values
+            # (e.g., use_running_average=not train) which don't work with traced values.
             static_args.append("train")
 
         # `mutable` must be static for batch norm models because it contains strings
-        # which cannot be traced by JAX
+        # which cannot be traced by JAX.
         if self._variant == ModelVariant.CNN_BATCHNORM:
             static_args.append("mutable")
-        
+
         # `rngs` must be static for dropout models because it contains a random key
-        # which cannot be traced by JAX
+        # which cannot be traced by JAX.
         if self._variant == ModelVariant.CNN_DROPOUT:
             static_args.append("rngs")
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When switching training test in JAX to infra in TT-XLA, we noticed that a test was erroneously not passing `rngs` as a static argument in MNIST model with dropout which resulted in `vjp` calculating results on 2 parameters instead of one.

### What's changed
This PR addresses:
- Adding `rngs` to static arguments
- Separation of if statements for different static arguments
- Stylistic comment fixes

### Checklist
- [x] New/Existing tests provide coverage for changes
