### PR TITLE
Hacky workaround for EfficientNet_B0_Weights bug in weight_class_name_fn()

### DIFF
--- a/efficientnet/pytorch/loader.py
+++ b/efficientnet/pytorch/loader.py
@@ -297,6 +297,14 @@ class ModelLoader(ForgeModel):
                     parts = name.split("_")
                     # Capitalize first letter of each part and join with underscore
                     capitalized_parts = [p.capitalize() for p in parts]
+
+                    # Workaround because this logic does not work as advertised.
+                    # https://github.com/tenstorrent/tt-forge-models/issues/293
+                    capitalized_parts = [
+                        p.replace("Efficientnet", "EfficientNet")
+                        for p in capitalized_parts
+                    ]
+
                     return "_".join(capitalized_parts) + "_Weights"
 
                 self._preprocessor = VisionPreprocessor(


### PR DESCRIPTION
### Ticket
#293 

### Problem description
- efficientnet/pytorch-efficientnet_b0-single_device-full-inference failing in tt-xla main after recent change
- weight_class_name_fn() is outputting Efficientnet_B0_Weights instead of EfficientNet_B0_Weights

### What's changed
- Apply a hack to special case and fix this breakage

### Checklist
- [x] Tested locally
