### PR TITLE
add inference server support set4

### DIFF
--- a/unet/pytorch/requirements.txt
+++ b/unet/pytorch/requirements.txt
@@ -1,0 +1,1 @@
+segmentation_models_pytorch


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/2062)

### Problem description
Added a common preprocessor and postprocessor for Segformer,Vit,UNet had a dependence issue,I have added the required package,I have also attached the error log for reference

### What's changed
Modified Segformer,Vit,UNet models to support inference server

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_segformer_mit_b0.log](https://github.com/user-attachments/files/23748118/test_segformer_mit_b0.log)
[test_vit_large.log](https://github.com/user-attachments/files/23748119/test_vit_large.log)
[unet_error.log.rtf](https://github.com/user-attachments/files/23748105/pcc_unet.log.rtf)
[test_unet_resnet101.log.rtf](https://github.com/user-attachments/files/23748106/unet_resnet101.log.rtf)

