### PR TITLE
Resolve chat template error in Llama-3.2-11B-Vision model

### DIFF
--- a/llama/llama_3_2_vision/pytorch/loader.py
+++ b/llama/llama_3_2_vision/pytorch/loader.py
@@ -134,6 +134,9 @@ class ModelLoader(ForgeModel):
         Returns:
             dict: Input arguments that can be fed to the model.
         """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
         # Ensure processor is initialized
         if self.processor is None:
             self._load_processor()
@@ -144,15 +147,20 @@ class ModelLoader(ForgeModel):
         )
         image = Image.open(image_file)
 
-        # Set up messages
-        self.messages = [
-            {"role": "user", "content": "<|image_1|>\nWhat is this image about?"},
-        ]
+        if pretrained_model_name == "meta-llama/Llama-3.2-11B-Vision":
+            # Base model: Use raw prompt
+            prompt = "<|image|><|begin_of_text|> What is this image about?"
 
-        # Apply chat template
-        prompt = self.tokenizer.apply_chat_template(
-            self.messages, tokenize=False, add_generation_prompt=True
-        )
+        elif pretrained_model_name == "meta-llama/Llama-3.2-11B-Vision-Instruct":
+            # Set up messages
+            self.messages = [
+                {"role": "user", "content": "<|image_1|>\nWhat is this image about?"},
+            ]
+
+            # Apply chat template
+            prompt = self.tokenizer.apply_chat_template(
+                self.messages, tokenize=False, add_generation_prompt=True
+            )
 
         # Process inputs
         device = self.model.device if self.model is not None else "cpu"


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1861

### Problem description

- Llama-3.2-11B-Vision model fails with the following error: 
```
ValueError: Cannot use chat template functions because tokenizer.chat_template is not set and no template argument was passed!
```

### Root cause

- Base models such as Llama-3.2-11B-Vision do not provide a chat_template in their tokenizer configuration. [tokenizer_config.json](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision/blob/main/tokenizer_config.json)
- Attempting to use apply_chat_template on these models results in the above exception.
- Instruction variants (e.g., Llama-3.2-11B-Vision-Instruct) do include the chat_template attribute and support apply_chat_template. [tokenizer_config.json](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct/blob/main/tokenizer_config.json) 

### What's changed

- Updated the logic to use raw prompt for Llama-3.2-11B-Vision, as recommended in the [model card](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision#use-with-transformers)

### Checklist
- [x] verified the changes through local testing

### Logs

- [nov25_llama_3_2_vision_before_fix.log](https://github.com/user-attachments/files/23747195/nov25_llama_3_2_vision_org.log)
- [nov25_llama_3_2_vision_after_fix.log](https://github.com/user-attachments/files/23747192/nov25_llama_3_2_vision_af_1.log)


