### PR TITLE
Fix broadcasting error in efficientdet by setting explicit dim=0 to torch.sum()

### DIFF
--- a/efficientdet/pytorch/src/efficientdet.py
+++ b/efficientdet/pytorch/src/efficientdet.py
@@ -344,7 +344,7 @@ class FpnCombine(nn.Module):
             out = torch.stack(nodes, dim=-1) * normalized_weights
         elif self.weight_method == "fastattn":
             edge_weights = nn.functional.relu(self.edge_weights.to(dtype=dtype))
-            weights_sum = torch.sum(edge_weights)
+            weights_sum = torch.sum(edge_weights, dim=0)
             out = torch.stack(
                 [
                     (nodes[i] * edge_weights[i]) / (weights_sum + 0.0001)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/1898
- https://github.com/tenstorrent/tt-xla/issues/2206

### Problem description

- The EfficientDet-D0 variant encounters the following runtime error. similar issue observed in d1,d2,d3,d4,d5 variants too.

```
RuntimeError: Shapes are not compatible for broadcasting: bf16[1,64,8,8] vs. bf16[2]. Expected dimension 3 of shape bf16[1,64,8,8] (8) to match dimension 0 of shape bf16[2] (2). Either that or that any of them is either 1 or unbounded. Try reshaping one of the tensors to match the other
```

### Root cause 

- Issue originates from [sum](https://github.com/rwightman/efficientdet-pytorch/blob/c6dff775a36cea0bf9b76c58e59f936411c5ce01/effdet/efficientdet.py#L303C13-L303C50) + [div](https://github.com/rwightman/efficientdet-pytorch/blob/c6dff775a36cea0bf9b76c58e59f936411c5ce01/effdet/efficientdet.py#L305C47-L305C48) operations. [nov26_sum_div.log](https://github.com/user-attachments/files/23768858/nov26_z_sum_div.log)
- VHLO itself is buggy!
  - reduce (sum) op is missing in VHLO
  - So, we are getting weights_sum as tensor with values [1.2969, 0.5703] instead of scalar 1.8672 (the sum)
  - For addition, 0.0001 gets broadcasted to [0.0001, 0.0001] to match shape [2] -> `"vhlo.constant_v1"() <{value = dense<1.001360e-04> : tensor<2xbf16>}>`
  - So, as denom is now not scalar, it throws the error: RuntimeError: Shapes are not compatible for broadcasting: `bf16[1,64,8,8] vs. bf16[2]`
  - For complete context pls checkout - https://github.com/tenstorrent/tt-xla/issues/2206

### What's changed

- The issue was resolved by explicitly specifying dim=0 in the problematic torch.sum operation, Since the edge weights tensor is 1-dimensional.
- Note : CPU Results are cross verified before and after change. - [diff](https://www.diffchecker.com/vPEJ2fwx/) , [nov27_effdet_pcc.log](https://github.com/user-attachments/files/23794614/nov27_effdet_pcc.log)


### Checklist
- [x] verified the changes through local testing

### Logs

- [nov27_effdet_before_fix.log.zip](https://github.com/user-attachments/files/23795150/nov27_effdet_before_fix.log.zip)
- [nov27_effdet_after_fix.log.zip](https://github.com/user-attachments/files/23795148/nov27_effdet_after_fix.log.zip)


