### PR TITLE
Fix: Download OpenVLA weights to HF_HOME instead of CWD

### DIFF
--- a/openvla/pytorch/loader.py
+++ b/openvla/pytorch/loader.py
@@ -143,8 +143,18 @@ class ModelLoader(ForgeModel):
 
         repo_id = self._variant_config.pretrained_model_name
 
-        # Create a local folder name from the model name
-        model_path = repo_id.split("/")[-1].replace("-", "_") + "_weights"
+        # Use HF_HOME for model storage
+        hf_home = os.environ.get("HF_HOME")
+
+        if not hf_home:
+            # Fallback to default HuggingFace cache if HF_HOME is not set
+            # This uses ~/.cache/huggingface instead of current directory
+            hf_home = os.path.expanduser("~/.cache/huggingface")
+
+        # Create a local folder name from the model name under HF_HOME
+        model_path = os.path.join(
+            hf_home, "hub", repo_id.split("/")[-1].replace("-", "_") + "_weights"
+        )
 
         # create folder if it doesn't exist
         os.makedirs(model_path, exist_ok=True)


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-forge-models/issues/309

### Problem description

- OpenVLA model loader was downloading ~52GB model weights to the current working directory instead of using HF_HOME. This causes disk to run out of space before it can get cleaned up.

### What's changed

- Modified `load_model()` in `openvla/pytorch/loader.py` to use HF_HOME environment variable for model weight storage
- If HF_HOME is set, weights are downloaded to `$HF_HOME/hub/<model_name>_weights`
- If HF_HOME is not set, falls back to `~/.cache/huggingface/hub/<model_name>_weights` (user's home cache)
- Weights are never downloaded to the current working directory, preventing local disk space exhaustion

### Checklist
- [x] verified the changes through local testing


### Logs

- [nov28_openvla_7b_default_hf.log](https://github.com/user-attachments/files/23814460/nov28_openvla_7b_default_hf.log)
- [nov28_openvla_7b_hf_set.log](https://github.com/user-attachments/files/23814462/nov28_openvla_7b_hf_set.log)

