### PR TITLE
Fix Runtime error in yolox model

### DIFF
--- a/yolox/pytorch/loader.py
+++ b/yolox/pytorch/loader.py
@@ -23,6 +23,7 @@ from ...config import (
 )
 from ...base import ForgeModel
 from ...tools.utils import get_file
+from .src.utils import _forward_patch, _decode_outputs
 
 
 class ModelVariant(StrEnum):
@@ -110,6 +111,10 @@ class ModelLoader(ForgeModel):
             torch.nn.Module: The YOLOX model instance.
         """
         from yolox.exp import get_exp  # Defer heavy import
+        from yolox.models.yolo_head import YOLOXHead
+
+        YOLOXHead.forward = _forward_patch
+        YOLOXHead.decode_outputs = _decode_outputs
 
         # Get the model name from the instance's variant config
         model_name = self._variant_config.pretrained_model_name

--- a/yolox/pytorch/src/utils.py
+++ b/yolox/pytorch/src/utils.py
@@ -4,8 +4,6 @@
 import cv2
 import numpy as np
 import torch
-from yolox.data.datasets import COCO_CLASSES
-from yolox.utils import demo_postprocess, multiclass_nms
 
 
 def print_detection_results(co_out, ratio, input_shape):
@@ -15,6 +13,9 @@ def print_detection_results(co_out, ratio, input_shape):
     This function converts model outputs into bounding boxes, applies non-maximum suppression (NMS),
     and prints the class name, confidence score, and bounding box coordinates for each detected object.
     """
+    from yolox.data.datasets import COCO_CLASSES
+    from yolox.utils import demo_postprocess, multiclass_nms
+
     for i in range(len(co_out)):
         co_out[i] = co_out[i].detach().float().numpy()
 
@@ -37,3 +38,100 @@ def print_detection_results(co_out, ratio, input_shape):
             print(
                 f"Class: {class_name}, Confidence: {score}, Coordinates: ({x_min}, {y_min}, {x_max}, {y_max})"
             )
+
+
+def _forward_patch(self, xin, labels=None, imgs=None):
+    outputs = []
+    origin_preds = []
+    x_shifts = []
+    y_shifts = []
+    expanded_strides = []
+
+    for k, (cls_conv, reg_conv, stride_this_level, x) in enumerate(
+        zip(self.cls_convs, self.reg_convs, self.strides, xin)
+    ):
+        x = self.stems[k](x)
+        cls_x = x
+        reg_x = x
+
+        cls_feat = cls_conv(cls_x)
+        cls_output = self.cls_preds[k](cls_feat)
+
+        reg_feat = reg_conv(reg_x)
+        reg_output = self.reg_preds[k](reg_feat)
+        obj_output = self.obj_preds[k](reg_feat)
+
+        if self.training:
+            output = torch.cat([reg_output, obj_output, cls_output], 1)
+            output, grid = self.get_output_and_grid(
+                output, k, stride_this_level, xin[0].type()
+            )
+            x_shifts.append(grid[:, :, 0])
+            y_shifts.append(grid[:, :, 1])
+            expanded_strides.append(
+                torch.zeros(1, grid.shape[1]).fill_(stride_this_level).type_as(xin[0])
+            )
+            if self.use_l1:
+                batch_size = reg_output.shape[0]
+                hsize, wsize = reg_output.shape[-2:]
+                reg_output = reg_output.view(
+                    batch_size, self.n_anchors, 4, hsize, wsize
+                )
+                reg_output = reg_output.permute(0, 1, 3, 4, 2).reshape(
+                    batch_size, -1, 4
+                )
+                origin_preds.append(reg_output.clone())
+
+        else:
+            output = torch.cat(
+                [reg_output, obj_output.sigmoid(), cls_output.sigmoid()], 1
+            )
+
+        outputs.append(output)
+
+    if self.training:
+        return self.get_losses(
+            imgs,
+            x_shifts,
+            y_shifts,
+            expanded_strides,
+            labels,
+            torch.cat(outputs, 1),
+            origin_preds,
+            dtype=xin[0].dtype,
+        )
+    else:
+        self.hw = [x.shape[-2:] for x in outputs]
+        # [batch, n_anchors_all, 85]
+        outputs = torch.cat([x.flatten(start_dim=2) for x in outputs], dim=2).permute(
+            0, 2, 1
+        )
+        if self.decode_in_inference:
+            return self.decode_outputs(outputs, dtype=xin[0].dtype)
+        else:
+            return outputs
+
+
+def _decode_outputs(self, outputs, dtype):
+    from yolox.utils import meshgrid
+
+    grids = []
+    strides = []
+    for (hsize, wsize), stride in zip(self.hw, self.strides):
+        yv, xv = meshgrid(
+            [
+                torch.arange(hsize, device=outputs.device),
+                torch.arange(wsize, device=outputs.device),
+            ]
+        )
+        grid = torch.stack((xv, yv), 2).view(1, -1, 2)
+        grids.append(grid)
+        shape = grid.shape[:2]
+        strides.append(torch.full((*shape, 1), stride, device=outputs.device))
+
+    grids = torch.cat(grids, dim=1).to(dtype=dtype, device=outputs.device)
+    strides = torch.cat(strides, dim=1).to(dtype=dtype, device=outputs.device)
+
+    outputs[..., :2] = (outputs[..., :2] + grids) * strides
+    outputs[..., 2:4] = torch.exp(outputs[..., 2:4]) * strides
+    return outputs


### PR DESCRIPTION
### Ticket

Fixes[ #2365](https://github.com/tenstorrent/tt-xla/issues/2365)

### Problem description
Below yolox variants face torch dynamo failure:

- yolox/pytorch-yolox_s-single_device-full-inference

- yolox/pytorch-yolox_l-single_device-full-inference

- yolox/pytorch-yolox_m-single_device-full-inference

- yolox/pytorch-yolox_nano-single_device-full-inference

- yolox/pytorch-yolox_s-single_device-full-inference

-  `torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_method type(*(FakeTensor(..., size=(1, 8400, 2), dtype=torch.int64), 'torch.xla.BFloat16Tensor'), **{}): got ValueError("invalid type: 'torch.xla.BFloat16Tensor'")`

### What's changed

- This error occurs because YOLOX calls tensor.type("some_dtype") using a dtype string taken from xin[0].type(). Under XLA, that string becomes torch.xla.BFloat16Tensor.
TorchDynamo/FakeTensor doesn’t comprehend that string, so when YOLOX tries to use it, it crashes with the error: “invalid type: 'torch.xla.BFloat16Tensor'”

- Changing the type here to dtype fixes this issue and later model fails with 
` RuntimeError('Unhandled FakeTensor Device Propagation for aten.add.Tensor, found two different devices xla:0, cpu')`

- The above error was caused because of a device mismatch in decode_outputs function of YOLOXHead class . The outputs were on XLA device, but grids and strides are created on CPU through torch.arange and only cast for dtype, not device. Hence device of grids has been moved to same device as outputs.

- Post this changes, it bypasses these original issues and fails with a pcc drop of 0.95

### Logs
[yolox_nano.log](https://github.com/user-attachments/files/23825364/yolox_nano.log)
