### PR TITLE
Move logits tensor to CPU before returning

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -705,16 +705,16 @@ class VisionPostprocessor:
         """
         if hasattr(output, "logits"):
             # HuggingFace ModelOutput object
-            return output.logits
+            return output.logits.to("cpu")
         elif isinstance(output, (list, tuple)):
             # Some models return tuple/list of outputs
             if len(output) > 0:
-                return output[0]
+                return output[0].to("cpu")
             else:
                 raise ValueError("Empty output list/tuple")
         elif isinstance(output, torch.Tensor):
             # Already a tensor
-            return output
+            return output.to("cpu")
         else:
             raise TypeError(
                 f"Unsupported output type: {type(output)}. "


### PR DESCRIPTION

### Ticket
N/A

### Problem description
There is crash in postprocess when running multiplication on tt card. 
```
top_probs_list = (top_probs * 100).tolist()
```

### What's changed
Fixed by moving logits to cpu

### Checklist
- [ ] New/Existing tests provide coverage for changes
