### PR TITLE
Disable use_cache in Stereo Model to avoid low PCC in past_key_values

### DIFF
--- a/stereo/pytorch/loader.py
+++ b/stereo/pytorch/loader.py
@@ -166,5 +166,6 @@ class ModelLoader(ForgeModel):
             "input_ids": inputs["input_ids"],
             "attention_mask": inputs["attention_mask"],
             "decoder_input_ids": decoder_input_ids,
+            "use_cache": False,
         }
         return inputs


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/2413

### Problem description

- Stereo Musicgen-medium variant having PCC=-0.29713162779808044 & large variant having PCC=0.2638634443283081. [dec3_stereo_before_fix.log.zip](https://github.com/user-attachments/files/23900215/dec3_stereo_before_fix.log.zip)

### Root cause

- The low PCC values originated from past-key-value tensors, which are included in the model output. 
- These tensors are not required for now.
- For complete context, checkout https://github.com/tenstorrent/tt-xla/issues/2413#issue-3688566255


### Fix

- Past key values are now disabled by passing use_cache=False in the model’s forward call.


### Checklist
- [x] Verified the changes through local testing

### Logs

- [dec3_stereo_after_fix.log.zip](https://github.com/user-attachments/files/23900572/dec3_stereo_after_fix.log.zip)

