### PR TITLE
Skip BFloat16 conversion in ssd300_vgg16 & retinanet_resnet50_fpn_v2 (nms_kernel lacks BFloat16 support)

### DIFF
--- a/retinanet/pytorch/loader.py
+++ b/retinanet/pytorch/loader.py
@@ -161,6 +161,8 @@ class ModelLoader(ForgeModel):
         Args:
             dtype_override: Optional torch.dtype to override the model's default dtype.
                            If not provided, the model will use its default dtype (typically float32).
+                           NOTE: This parameter is currently ignored for retinanet_resnet50_fpn_v2(model always uses float32).
+                           TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
 
         Returns:
             torch.nn.Module: The RetinaNet model instance.
@@ -183,7 +185,13 @@ class ModelLoader(ForgeModel):
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
-            model = model.to(dtype_override)
+            if model_name == "retinanet_resnet50_fpn_v2":
+                # TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
+                print(
+                    "NOTE: dtype_override ignored - batched_nms lacks BFloat16 support"
+                )
+            else:
+                model = model.to(dtype_override)
 
         return model
 
@@ -193,13 +201,16 @@ class ModelLoader(ForgeModel):
         Args:
             dtype_override: Optional torch.dtype to override the inputs' default dtype.
                            If not provided, inputs will use the default dtype (typically float32).
+                           NOTE: This parameter is currently ignored for retinanet_resnet50_fpn_v2(model always uses float32).
+                           TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
             batch_size: Optional batch size to override the default batch size of 1.
 
         Returns:
             torch.Tensor: Preprocessed input tensor suitable for RetinaNet.
         """
-        # Get the source from the instance's variant config
+        # Get the pretrained model name  amd source from the instance's variant config
         source = self._variant_config.source
+        model_name = self._variant_config.pretrained_model_name
 
         if source == ModelSource.TORCHVISION:
             weight_name = self._TORCHVISION_WEIGHTS[self._variant]
@@ -236,7 +247,13 @@ class ModelLoader(ForgeModel):
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
-            batch_t = batch_t.to(dtype_override)
+            if model_name == "retinanet_resnet50_fpn_v2":
+                # TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
+                print(
+                    "NOTE: dtype_override ignored - batched_nms lacks BFloat16 support"
+                )
+            else:
+                batch_t = batch_t.to(dtype_override)
 
         return batch_t
 

--- a/ssd300_vgg16/pytorch/loader.py
+++ b/ssd300_vgg16/pytorch/loader.py
@@ -79,7 +79,8 @@ class ModelLoader(ForgeModel):
 
         Args:
             dtype_override: Optional torch.dtype to override the model's default dtype.
-                           If not provided, the model will use its default dtype (typically float32).
+                          NOTE: This parameter is currently ignored (model always uses float32).
+                          TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
 
         Returns:
             torch.nn.Module: The SSD300 VGG16 model instance for object detection.
@@ -91,7 +92,9 @@ class ModelLoader(ForgeModel):
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
-            model = model.to(dtype_override)
+            # model = model.to(dtype_override)
+            # TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
+            print("NOTE: dtype_override ignored - batched_nms lacks BFloat16 support")
 
         return model
 
@@ -100,6 +103,8 @@ class ModelLoader(ForgeModel):
 
         Args:
             dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+                          NOTE: This parameter is currently ignored (model always uses float32).
+                          TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
 
         Returns:
             torch.Tensor: Preprocessed input tensor suitable for SSD300 VGG16.
@@ -120,7 +125,9 @@ class ModelLoader(ForgeModel):
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
-            batch_t = batch_t.to(dtype_override)
+            # batch_t = batch_t.to(dtype_override)
+            # TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
+            print("NOTE: dtype_override ignored - batched_nms lacks BFloat16 support")
 
         return batch_t
 


### PR DESCRIPTION

### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/1816

### Problem description

- ssd300_vgg16 & retinanet_resnet50_fpn_v2  encounters `RuntimeError: "nms_kernel" not implemented for 'BFloat16'`

### What's changed

-  These models uses batched_nms which is currently not supported in bfloat16.
- [batched_nms](https://github.com/pytorch/vision/blob/59a3e1f9f78cfe44cb989877cc6f4ea77c8a75ca/torchvision/models/detection/ssd.py#L453) in ssd300_vgg16 
- [bacthed_nms](https://github.com/pytorch/vision/blob/main/torchvision/models/detection/retinanet.py#L560) in retinanet_resnet50_fpn_v2

### Fix

- Skipped BFloat16 conversion for this model

### Checklist
- [x] verified the changes through local testing 


### Logs

- [dec5_ret_res50_fpn_v2_before_fix.log](https://github.com/user-attachments/files/23957191/dec5_ret_res50_fpn_v2_before_fix.log)
- [dec5_ret_res50_fpn_v2_after_fix.log](https://github.com/user-attachments/files/23957189/dec5_ret_res50_fpn_v2_after_fix.log)
- [dec5_ssd_vgg_before_fix.log](https://github.com/user-attachments/files/23957193/dec5_ssd_vgg_before_fix.log)
- [dec5_ssd_vgg_after_fix.log](https://github.com/user-attachments/files/23957192/dec5_ssd_vgg_after_fix.log)


