### PR TITLE
Fix AlexNet infra for TT-XLA

### DIFF
--- a/alexnet/image_classification/jax/loader.py
+++ b/alexnet/image_classification/jax/loader.py
@@ -369,3 +369,15 @@ class ModelLoader(ForgeModel):
             list: List containing 'train' as a static argument
         """
         return ["train"]
+
+    def get_forward_method_name(self):
+        """Get the forward method name for the model.
+
+        For Flax linen modules, we must use 'apply' to bind parameters
+        before calling the module. Calling '__call__' directly on an
+        unbound linen module will raise CallCompactUnboundModuleError.
+
+        Returns:
+            str: 'apply' for Flax linen modules
+        """
+        return "apply"


### PR DESCRIPTION
### Ticket
N/A

### Problem description
While running training tests for AlexNet in JAX TT-XLA infra, it was noticed that we get flax errors on the method being used to run forward pass.

### What's changed
Add explicit method name to AlexNet implementation.

### Checklist
- [ ] New/Existing tests provide coverage for changes
