### PR TITLE
Bringup Ultrafast Lane Detection V2 model

### DIFF
--- a/ultra_fast_lane_detection_v2/pytorch/__init__.py
+++ b/ultra_fast_lane_detection_v2/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Ultra-Fast-Lane-Detection-v2 PyTorch implementation
+"""
+
+from .loader import ModelLoader, ModelVariant

--- a/ultra_fast_lane_detection_v2/pytorch/loader.py
+++ b/ultra_fast_lane_detection_v2/pytorch/loader.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Ultra-Fast-Lane-Detection-v2 model loader implementation
+"""
+
+import torch
+import os
+from typing import Optional
+from dataclasses import dataclass
+
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ...base import ForgeModel
+from ...tools.utils import get_file
+
+
+@dataclass
+class LaneDetectionV2Config(ModelConfig):
+    """Configuration specific to Ultra-Fast-Lane-Detection-v2 models"""
+
+    input_height: int  # Model input height
+    input_width: int  # Model input width
+
+
+class ModelVariant(StrEnum):
+    """Available Ultra-Fast-Lane-Detection-v2 model variants."""
+
+    TUSIMPLE_RESNET34 = "tusimple_resnet34"
+
+
+class ModelLoader(ForgeModel):
+    """Ultra-Fast-Lane-Detection-v2 model loader implementation."""
+
+    _VARIANTS = {
+        ModelVariant.TUSIMPLE_RESNET34: LaneDetectionV2Config(
+            pretrained_model_name="tusimple_res34",
+            input_height=320,
+            input_width=800,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.TUSIMPLE_RESNET34
+
+    def __init__(
+        self,
+        variant: Optional[ModelVariant] = None,
+    ):
+        """
+        Initialize the Ultra-Fast-Lane-Detection-v2 model loader.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.config: LaneDetectionV2Config = self._variant_config
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="ultra-fast-lane-detection-v2",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            source=ModelSource.GITHUB,
+            task=ModelTask.CV_IMAGE_SEG,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(
+        self, dtype_override: Optional[torch.dtype] = None
+    ) -> torch.nn.Module:
+        """
+        Load the Ultra-Fast-Lane-Detection-v2 TuSimple34 model.
+
+        Args:
+            dtype_override: Optional torch.dtype override (default: float32).
+
+        Returns:
+            torch.nn.Module: Loaded TuSimple34 model
+        """
+        from .src.utils import load_model
+
+        model = load_model(
+            model_path=get_file(
+                "test_files/pytorch/Ultrafast_lane_detection_v2/tusimple_res34.pth"
+            ),
+            input_height=self.config.input_height,
+            input_width=self.config.input_width,
+        )
+        model.eval()
+
+        # Convert model dtype if requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
+        return model
+
+    def load_inputs(
+        self, batch_size: int = 1, dtype_override: Optional[torch.dtype] = None
+    ) -> torch.Tensor:
+        """
+        Generate random input tensor for the model.
+
+        Args:
+            batch_size: Batch size for the input tensor. Default: 1
+            dtype_override: Optional torch.dtype override (default: float32).
+
+        Returns:
+            torch.Tensor: Random input tensor
+        """
+        # Generate random input tensor with specified batch size directly
+        inputs = torch.randn(
+            batch_size,
+            3,
+            self.config.input_height,
+            self.config.input_width,
+            dtype=torch.float32,
+        )
+
+        # Convert dtype if explicitly requested
+        if dtype_override is not None:
+            inputs = inputs.to(dtype_override)
+
+        return inputs

--- a/ultra_fast_lane_detection_v2/pytorch/src/model.py
+++ b/ultra_fast_lane_detection_v2/pytorch/src/model.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Ported from https://github.com/tenstorrent/tt-metal/blob/main/models/demos/ufld_v2/reference/ufld_v2_model.py
+
+from typing import Callable, List, Optional
+
+import torch
+import torch.nn as nn
+
+
+def conv3x3(
+    in_planes: int, out_planes: int, stride: int = 1, groups: int = 1, dilation: int = 1
+) -> nn.Conv2d:
+    return nn.Conv2d(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=stride,
+        padding=dilation,
+        groups=groups,
+        bias=False,
+        dilation=dilation,
+    )
+
+
+def conv1x1(in_planes: int, out_planes: int, stride: int = 1) -> nn.Conv2d:
+    return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
+
+
+class BasicBlock(nn.Module):
+    expansion: int = 1
+
+    def __init__(
+        self,
+        inplanes: int,
+        planes: int,
+        stride: int = 1,
+        downsample: Optional[nn.Module] = None,
+        groups: int = 1,
+        base_width: int = 64,
+        dilation: int = 1,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+
+        self.conv1 = conv3x3(inplanes, planes, stride)
+        self.bn1 = norm_layer(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = conv3x3(planes, planes)
+        self.bn2 = norm_layer(planes)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x):
+        identity = x
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+        out = self.conv2(out)
+        out = self.bn2(out)
+        if self.downsample is not None:
+            identity = self.downsample(x)
+        out += identity
+        out = self.relu(out)
+        return out
+
+
+class CustomResNet34(nn.Module):
+    def __init__(
+        self,
+        block: BasicBlock,
+        layers: List[int],
+        num_classes: int = 1000,
+        zero_init_residual: bool = False,
+        groups: int = 1,
+        width_per_group: int = 64,
+        replace_stride_with_dilation: Optional[List[bool]] = None,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            replace_stride_with_dilation = [False, False, False]
+
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = nn.Conv2d(
+            3, self.inplanes, kernel_size=7, stride=2, padding=3, bias=False
+        )
+        self.bn1 = norm_layer(self.inplanes)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.layer1 = self._make_layer(block, 64, layers[0])
+        self.layer2 = self._make_layer(
+            block, 128, layers[1], stride=2, dilate=replace_stride_with_dilation[0]
+        )
+        self.layer3 = self._make_layer(
+            block, 256, layers[2], stride=2, dilate=replace_stride_with_dilation[1]
+        )
+        self.layer4 = self._make_layer(
+            block, 512, layers[3], stride=2, dilate=replace_stride_with_dilation[2]
+        )
+
+    def _make_layer(
+        self,
+        block: BasicBlock,
+        planes: int,
+        blocks: int,
+        stride: int = 1,
+        dilate: bool = False,
+    ) -> nn.Sequential:
+        norm_layer = self._norm_layer
+        downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                conv1x1(self.inplanes, planes * block.expansion, stride),
+                norm_layer(planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(
+            block(
+                self.inplanes,
+                planes,
+                stride,
+                downsample,
+                self.groups,
+                self.base_width,
+                previous_dilation,
+                norm_layer,
+            )
+        )
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(
+                block(
+                    self.inplanes,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    dilation=self.dilation,
+                    norm_layer=norm_layer,
+                )
+            )
+
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+        x = self.layer1(x)
+        x2 = self.layer2(x)
+        x3 = self.layer3(x2)
+        x4 = self.layer4(x3)
+        return [x2, x3, x4]
+
+
+class TuSimple34(nn.Module):
+    def __init__(self, input_height=320, input_width=800):
+        super(TuSimple34, self).__init__()
+        self.num_grid_row = 100
+        self.num_cls_row = 56
+        self.num_grid_col = 100
+        self.num_cls_col = 41
+        self.num_lane_on_row = 4
+        self.num_lane_on_col = 4
+        self.use_aux = False
+        self.dim1 = self.num_grid_row * self.num_cls_row * self.num_lane_on_row
+        self.dim2 = self.num_grid_col * self.num_cls_col * self.num_lane_on_col
+        self.dim3 = 2 * self.num_cls_row * self.num_lane_on_row
+        self.dim4 = 2 * self.num_cls_col * self.num_lane_on_col
+        self.total_dim = self.dim1 + self.dim2 + self.dim3 + self.dim4
+        mlp_mid_dim = 2048
+        self.input_height = input_height
+        self.input_width = input_width
+        self.input_dim = input_height // 32 * input_width // 32 * 8
+        self.fc_norm = False
+        self.res_model = CustomResNet34(BasicBlock, [3, 4, 6, 3])
+
+        self.cls = torch.nn.Sequential(
+            torch.nn.Identity(),
+            torch.nn.Linear(self.input_dim, mlp_mid_dim),
+            torch.nn.ReLU(),
+            torch.nn.Linear(mlp_mid_dim, self.total_dim),
+        )
+        self.pool = torch.nn.Conv2d(512, 8, 1)
+
+    def forward(self, x):
+        x2, x3, fea = self.res_model(x)
+        fea = self.pool(fea)
+        fea = fea.view(-1, self.input_dim)
+        out = self.cls[0](fea)
+        out = self.cls[1](out)
+        out = self.cls[2](out)
+        out = self.cls[3](out)
+        pred_dict = {
+            "loc_row": out[:, : self.dim1].view(
+                -1, self.num_grid_row, self.num_cls_row, self.num_lane_on_row
+            ),
+            "loc_col": out[:, self.dim1 : self.dim1 + self.dim2].view(
+                -1, self.num_grid_col, self.num_cls_col, self.num_lane_on_col
+            ),
+            "exist_row": out[
+                :, self.dim1 + self.dim2 : self.dim1 + self.dim2 + self.dim3
+            ].view(-1, 2, self.num_cls_row, self.num_lane_on_row),
+            "exist_col": out[:, -self.dim4 :].view(
+                -1, 2, self.num_cls_col, self.num_lane_on_col
+            ),
+        }
+        return out, pred_dict

--- a/ultra_fast_lane_detection_v2/pytorch/src/utils.py
+++ b/ultra_fast_lane_detection_v2/pytorch/src/utils.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Ported from https://github.com/tenstorrent/tt-metal/blob/main/models/demos/ufld_v2/reference/ufld_v2_model.py
+
+"""
+Utility functions for Ultra-Fast-Lane-Detection-v2 model
+"""
+
+import torch
+
+
+def load_model(model_path, input_height=320, input_width=800):
+    """Load a TuSimple34 model with pretrained weights
+
+    Args:
+        model_path: Path to the pretrained model weights (.pth file)
+        input_height: Input height for the model. Default: 320
+        input_width: Input width for the model. Default: 800
+
+    Returns:
+        torch.nn.Module: Loaded TuSimple34 model
+    """
+    from .model import TuSimple34
+
+    torch_model = TuSimple34(input_height=input_height, input_width=input_width)
+    torch_model.eval()
+
+    # Load weights
+    state_dict = torch.load(model_path, map_location="cpu")
+    new_state_dict = {}
+    for key, value in state_dict["model"].items():
+        new_key = key.replace("model.", "res_model.")
+        new_state_dict[new_key] = value
+
+    torch_model.load_state_dict(new_state_dict)
+    return torch_model


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-forge-models/issues/285

### Problem description

- Currently we have only Ultra-Fast-Lane-Detection available in tt-forge-models and running in CI ([reference](https://github.com/cfzd/Ultra-Fast-Lane-Detection)). But in tt-metal we have perf target for [Ultra-Fast-Lane-Detection v2](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/wormhole/ufld_v2) ([reference](https://github.com/cfzd/Ultra-Fast-Lane-Detection-v2)).
- To enable meaningful perf comparison between tt-forge and tt-metal, we need to add the v2 variant to tt-forge-models with the same configuration used in tt-metal:
  - Input size: 320 × 800
  - Backbone: ResNet-34

### What's changed

- Added support for UFLD V2's TUSIMPLE_RESNET34 variant for 320x800 input_size
- **Note**: Model code ported from [tt-metal reference implementation](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/ufld_v2/reference/ufld_v2_model.py)

### Checklist
- [x] Verified the changes through local testing

### Logs

- UFLD_v2's cpu run results 
  - tt-forge - [dec9_ufldv2_tt_forge.log](https://github.com/user-attachments/files/24052066/dec9_ufld_v2_f.log)
  - tt-metal - [dec9_ufldv2_tt_metal.log](https://github.com/user-attachments/files/24052075/dec9_ufldv2_tt_metal_info.log)
  - Results comparison - [dec9_pcc_check.log](https://github.com/user-attachments/files/24052089/dec9_pcc_check.log)
- UFLD_v2's xla run result
  - [dec9_ufld_v2_xla.log](https://github.com/user-attachments/files/24052099/dec9_ufld_v2_xla.log)




