### PR TITLE
Phi3 & Phi2 causal_lm variants fix

### DIFF
--- a/phi2/causal_lm/pytorch/loader.py
+++ b/phi2/causal_lm/pytorch/loader.py
@@ -34,11 +34,9 @@ class ModelLoader(ForgeModel):
     _VARIANTS = {
         ModelVariant.PHI2: LLMModelConfig(
             pretrained_model_name="microsoft/phi-2",
-            max_length=256,
         ),
         ModelVariant.PHI2_PYTDML: LLMModelConfig(
             pretrained_model_name="microsoft/phi-2-pytdml",
-            max_length=256,
         ),
     }
 
@@ -151,8 +149,7 @@ class ModelLoader(ForgeModel):
         inputs = self.tokenizer(
             self.sample_text,
             return_tensors="pt",
-            max_length=self._variant_config.max_length,
-            padding="max_length",
+            padding=True,
             truncation=True,
         )
 

--- a/phi3/causal_lm/pytorch/loader.py
+++ b/phi3/causal_lm/pytorch/loader.py
@@ -76,12 +76,14 @@ class ModelLoader(ForgeModel):
 
     def load_inputs(self, dtype_override=None, prompt: Optional[str] = None):
         self._ensure_tokenizer()
-        input_prompt = prompt or "Africa is an emerging economy because"
+        input_prompt = (
+            prompt
+            or "Can you provide ways to eat combinations of bananas and dragonfruits?"
+        )
         inputs = self.tokenizer(
             input_prompt,
             return_tensors="pt",
-            max_length=256,
-            padding="max_length",
+            padding=True,
             truncation=True,
         )
         input_ids = inputs["input_ids"]


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1443)

### Problem description
The PCC drop is observed in the following models.
```
phi2/causal_lm/pytorch-microsoft/phi-2-single_device-full-inference pcc=0.9500633478164673
phi3/causal_lm/pytorch-microsoft/Phi-3-mini-4k-instruct-single_device-full-inference pcc=0.9027385711669922
phi3/causal_lm/pytorch-microsoft/Phi-3-mini-128k-instruct-single_device-full-inference pcc=0.9565072059631348
```
### What's changed
- Enabled padding=True.
- Updated the input prompt to the original Hugging Face example from their official website.
- Re-tested causal LM variants with the updated inputs:
  - Phi-3-mini-4k-instruct: PCC =  0.9838218688964844
  - Phi-3-mini-128k-instruct: PCC =0.969300389289856
- Re-tested Phi-2 causal LM with padding enabled:
  - PCC = 0.9964904189109802
- These updates in loader.py contributed to improved PCC results.

**Logs:**
[phi2_causal_lm.log](https://github.com/user-attachments/files/24082785/phi2_causal_lm.log)
[phi3_cl_4k_org.log](https://github.com/user-attachments/files/24082786/phi3_cl_4k_org.log)
[phi3_cl_128k_org.log](https://github.com/user-attachments/files/24082789/phi3_cl_128k_org.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
