### PR TITLE
Fix Torch Dynamo Failure in BEVFormer and Maptr

### DIFF
--- a/bevformer/pytorch/src/model.py
+++ b/bevformer/pytorch/src/model.py
@@ -1063,11 +1063,20 @@ class BEVFormer(MVXTwoStageDetector):
         if not self.video_test_mode:
             self.prev_frame_info["prev_bev"] = None
 
-        tmp_pos = copy.deepcopy(img_metas[0][0]["can_bus"][:3])
-        tmp_angle = copy.deepcopy(img_metas[0][0]["can_bus"][-1])
+        tmp_pos = [
+            float(img_metas[0][0]["can_bus"][0]),
+            float(img_metas[0][0]["can_bus"][1]),
+            float(img_metas[0][0]["can_bus"][2]),
+        ]
+        tmp_angle = float(img_metas[0][0]["can_bus"][-1])
         if self.prev_frame_info["prev_bev"] is not None:
-            img_metas[0][0]["can_bus"][:3] -= self.prev_frame_info["prev_pos"]
-            img_metas[0][0]["can_bus"][-1] -= self.prev_frame_info["prev_angle"]
+            can_bus = img_metas[0][0]["can_bus"]
+            can_bus[:3] = [
+                float(can_bus[0]) - float(self.prev_frame_info["prev_pos"][0]),
+                float(can_bus[1]) - float(self.prev_frame_info["prev_pos"][1]),
+                float(can_bus[2]) - float(self.prev_frame_info["prev_pos"][2]),
+            ]
+            can_bus[-1] = float(can_bus[-1]) - float(self.prev_frame_info["prev_angle"])
         else:
             img_metas[0][0]["can_bus"][-1] = 0
             img_metas[0][0]["can_bus"][:3] = 0
@@ -3907,32 +3916,49 @@ class PerceptionTransformer(BaseModule):
         bev_queries = bev_queries.unsqueeze(1).repeat(1, bs, 1)
         bev_pos = bev_pos.flatten(2).permute(2, 0, 1)
 
-        delta_x = np.array([each["can_bus"][0] for each in kwargs["img_metas"]])
-        delta_y = np.array([each["can_bus"][1] for each in kwargs["img_metas"]])
-        ego_angle = np.array(
-            [each["can_bus"][-2] / np.pi * 180 for each in kwargs["img_metas"]]
+        can_bus_list = [each["can_bus"] for each in kwargs["img_metas"]]
+        if torch.is_tensor(can_bus_list[0]):
+            can_bus_raw = torch.stack(can_bus_list, dim=0).to(
+                device=bev_queries.device, dtype=bev_queries.dtype
+            )
+        else:
+            can_bus_raw = torch.as_tensor(
+                can_bus_list, device=bev_queries.device, dtype=bev_queries.dtype
+            )
+
+        delta_x = can_bus_raw[:, 0]
+        delta_y = can_bus_raw[:, 1]
+        ego_angle = can_bus_raw[:, -2] / torch.pi * 180.0
+        grid_length_y = torch.as_tensor(
+            grid_length[0], device=bev_queries.device, dtype=bev_queries.dtype
         )
-        grid_length_y = grid_length[0]
-        grid_length_x = grid_length[1]
-        translation_length = np.sqrt(delta_x**2 + delta_y**2)
-        translation_angle = np.arctan2(delta_y, delta_x) / np.pi * 180
+        grid_length_x = torch.as_tensor(
+            grid_length[1], device=bev_queries.device, dtype=bev_queries.dtype
+        )
+        bev_h_t = torch.as_tensor(
+            bev_h, device=bev_queries.device, dtype=bev_queries.dtype
+        )
+        bev_w_t = torch.as_tensor(
+            bev_w, device=bev_queries.device, dtype=bev_queries.dtype
+        )
+        translation_length = torch.sqrt(delta_x**2 + delta_y**2)
+        translation_angle = torch.atan2(delta_y, delta_x) / torch.pi * 180.0
         bev_angle = ego_angle - translation_angle
         shift_y = (
-            translation_length * np.cos(bev_angle / 180 * np.pi) / grid_length_y / bev_h
+            translation_length
+            * torch.cos(bev_angle / 180.0 * torch.pi)
+            / grid_length_y
+            / bev_h_t
         )
         shift_x = (
-            translation_length * np.sin(bev_angle / 180 * np.pi) / grid_length_x / bev_w
+            translation_length
+            * torch.sin(bev_angle / 180.0 * torch.pi)
+            / grid_length_x
+            / bev_w_t
         )
         shift_y = shift_y * self.use_shift
         shift_x = shift_x * self.use_shift
-        # Build tensors directly on correct device/dtype to avoid .to on FakeTensors
-        shift_x_t = torch.as_tensor(
-            shift_x, device=bev_queries.device, dtype=bev_queries.dtype
-        )
-        shift_y_t = torch.as_tensor(
-            shift_y, device=bev_queries.device, dtype=bev_queries.dtype
-        )
-        shift = torch.stack([shift_x_t, shift_y_t], dim=0).permute(1, 0)
+        shift = torch.stack([shift_x, shift_y], dim=0).permute(1, 0)
 
         if prev_bev is not None:
             if prev_bev.shape[1] == bev_h * bev_w:
@@ -3951,16 +3977,7 @@ class PerceptionTransformer(BaseModule):
                     )
                     prev_bev[:, i] = tmp_prev_bev[:, 0]
 
-        can_bus_list = [each["can_bus"] for each in kwargs["img_metas"]]
-        if torch.is_tensor(can_bus_list[0]):
-            can_bus = torch.stack(can_bus_list, dim=0).to(
-                device=bev_queries.device, dtype=bev_queries.dtype
-            )
-        else:
-            can_bus = torch.as_tensor(
-                can_bus_list, device=bev_queries.device, dtype=bev_queries.dtype
-            )  # [:, :]
-        can_bus = self.can_bus_mlp(can_bus)[None, :, :]
+        can_bus = self.can_bus_mlp(can_bus_raw)[None, :, :]
         bev_queries = bev_queries + can_bus * self.use_can_bus
 
         feat_flatten = []


### PR DESCRIPTION
### Ticket
Fixes [#2532](https://github.com/tenstorrent/tt-xla/issues/2532)

### Problem description

Following variants of BEVFormer and Maptr fail with` torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <Wrapped method <original div>>(*(FakeTensor(..., size=(), dtype=torch.float64), 3.141592653589793), **{}): got AttributeError("'ndarray' object has no attribute 'div'")` error:

- bevformer/pytorch-BEVFormer-base-single_device-full-inference

- bevformer/pytorch-BEVFormer-small-single_device-full-inference

- bevformer/pytorch-BEVFormer-tiny-single_device-full-inference

- maptr/pytorch-tiny_r50_24e_bevformer-single_device-full-inference

- maptr/pytorch-tiny_r50_110e-single_device-full-inference

### What's changed
This error arises from mixing NumPy arrays with Torch math during TorchDynamo tracing.During tracing, with FakeTensors, it tries to lower ops like division/subtraction using tensor methods, so when numpy nd array is traced, there’s no .div method, so this hits the AttributeError("'ndarray' object has no attribute 'div'").Hence a single torch tensor has been built and numpy operations have been replaced with equivalent torch operations to fix this issue.No deviation in model outputs is noticed post these changes. After these changes, bevformer model fails with Bad status access error while maptr fails with Out of Memory Error.

### Logs
[bevformer_before_fix.log](https://github.com/user-attachments/files/24156633/bevformer_xla_before.log)
[bevformer_post_fix.log](https://github.com/user-attachments/files/24344870/bevformer_post_fix.log)

[maptr_before_fix.log](https://github.com/user-attachments/files/24344877/maptr_before_fix.log)
[maptr_post_fix.log](https://github.com/user-attachments/files/24344890/maptr_post_fix.log)
