### PR TITLE
Pad gpt_oss input

### DIFF
--- a/gpt_oss/pytorch/loader.py
+++ b/gpt_oss/pytorch/loader.py
@@ -152,6 +152,8 @@ class ModelLoader(ForgeModel):
             tokenize=True,
             return_dict=True,
             return_tensors="pt",
+            padding="max_length",
+            max_length=128,
         )
 
         return inputs


### PR DESCRIPTION
### Ticket
None

### Problem description
Before padding seq_len is 71. This is not divisible by 8, which causes problems with sharding. 

### What's changed
Adding padding so that seq_len=128.
