### PR TITLE
PCC drop fix for Phi4 Causal_lm

### DIFF
--- a/phi4/causal_lm/pytorch/loader.py
+++ b/phi4/causal_lm/pytorch/loader.py
@@ -139,8 +139,7 @@ class ModelLoader(ForgeModel):
         inputs = self.tokenizer(
             input_prompt,
             return_tensors="pt",
-            max_length=128,
-            padding="max_length",
+            padding=True,
             truncation=True,
         )
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1443)

### Problem description
The PCC drop is observed in the model.
FAILED tests/runner/test_models.py::test_all_models_torch[phi4/causal_lm/pytorch-microsoft/phi-4-single_device-full-inference] error_message='PCC comparison failed. Calculated: pcc=0.9868718981742859

### What's changed
Re-tested Phi-4 causal LM with padding = true:
pcc=0.9995734095573425

**Logs**
[phi4_padding.log](https://github.com/user-attachments/files/24129928/phi4_padding.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
