### PR TITLE
PCC drop fix for Phi3 & Phi3_5

### DIFF
--- a/phi3/causal_lm/pytorch/loader.py
+++ b/phi3/causal_lm/pytorch/loader.py
@@ -76,12 +76,18 @@ class ModelLoader(ForgeModel):
 
     def load_inputs(self, dtype_override=None, prompt: Optional[str] = None):
         self._ensure_tokenizer()
-        input_prompt = (
-            prompt
-            or "Can you provide ways to eat combinations of bananas and dragonfruits?"
+        input_prompt = [
+            {
+                "role": "user",
+                "content": prompt
+                or "Can you provide ways to eat combinations of bananas and dragonfruits?",
+            }
+        ]
+        text = self.tokenizer.apply_chat_template(
+            input_prompt, add_generation_prompt=True, tokenize=False
         )
         inputs = self.tokenizer(
-            input_prompt,
+            [text],
             return_tensors="pt",
             padding=True,
             truncation=True,

--- a/phi3/phi_3_5/pytorch/loader.py
+++ b/phi3/phi_3_5/pytorch/loader.py
@@ -96,12 +96,19 @@ class ModelLoader(ForgeModel):
         """Load and return sample inputs for the Phi 3.5 model with this instance's variant settings."""
         if self.tokenizer is None:
             self._load_tokenizer(dtype_override)
-        prompt = "Africa is an emerging economy because"
+        prompt = [
+            {
+                "role": "user",
+                "content": "Can you provide ways to eat combinations of bananas and dragonfruits?",
+            },
+        ]
+        text = self.tokenizer.apply_chat_template(
+            prompt, tokenize=False, add_generation_prompt=True, enable_thinking=True
+        )
         inputs = self.tokenizer(
-            prompt,
+            [text],
             return_tensors="pt",
-            max_length=256,
-            padding="max_length",
+            padding=True,
             truncation=True,
         )
         for key in inputs:

--- a/phi3/token_cls/pytorch/loader.py
+++ b/phi3/token_cls/pytorch/loader.py
@@ -74,8 +74,17 @@ class ModelLoader(ForgeModel):
 
     def load_inputs(self, dtype_override=None, text: Optional[str] = None):
         self._ensure_tokenizer()
-        input_prompt = text or "HuggingFace is a company based in Paris and New York"
-        inputs = self.tokenizer(input_prompt, return_tensors="pt")
+        input_prompt = [
+            {
+                "role": "user",
+                "content": text
+                or "Can you provide ways to eat combinations of bananas and dragonfruits?",
+            }
+        ]
+        text = self.tokenizer.apply_chat_template(
+            input_prompt, add_generation_prompt=True, tokenize=False
+        )
+        inputs = self.tokenizer([text], return_tensors="pt")
         input_ids = inputs["input_ids"]
         if dtype_override is not None:
             input_ids = cast_input_to_type(input_ids, dtype_override)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1443)

### Problem description
PCC drop observed in the following models:

> phi3/causal_lm/pytorch-microsoft/Phi-3-mini-128k-instruct-single_device-full-inference PCC = 0.969300389289856
> phi3/causal_lm/pytorch-microsoft/Phi-3-mini-4k-instruct-single_device-full-inference PCC = 0.9838218688964844
> phi3/token_cls/pytorch-microsoft/Phi-3-mini-4k-instruct-single_device-full-inference PCC = 0.981175423
> phi3/phi_3_5/pytorch-mini_instruct-single_device-full-inference PCC = 0.7597435116767883

### What's changed
Modified the input generation using apply_chat_template and padding = true in loader.py
After applying the changes all the above models passed.

**Logs:**
[phi3_5.log](https://github.com/user-attachments/files/24170308/phi3_5.log)
[phi3_causal_lm_128k_input.log](https://github.com/user-attachments/files/24170309/phi3_causal_lm_128k_input.log)
[phi3_token_cls_4k.log](https://github.com/user-attachments/files/24170310/phi3_token_cls_4k.log)
[phi3_causal_lm_4k_input.log](https://github.com/user-attachments/files/24170414/phi3_causal_lm_4k_input.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
