### PR TITLE
Reverting changes needed for torch 2.9.0 and transformers 4.57.1 uplift

### DIFF
--- a/fuyu/pytorch/loader.py
+++ b/fuyu/pytorch/loader.py
@@ -209,7 +209,7 @@ class ModelLoader(ForgeModel):
         inputs_embeds = generate_fuyu_embedding(
             self.model,
             model_inputs["input_ids"],
-            model_inputs["image_patches"],
+            model_inputs["image_patches"][0],
             model_inputs["image_patches_indices"],
         )
         inputs_embeds = inputs_embeds.clone().detach()

--- a/gemma/codegemma/pytorch/loader.py
+++ b/gemma/codegemma/pytorch/loader.py
@@ -133,7 +133,6 @@ def calculate_age(birth_year):
             self._load_tokenizer(dtype_override=dtype_override)
 
         input_prompt = prompt or self.sample_text
-        self.tokenizer.padding_side = "right"
         inputs = self.tokenizer(
             input_prompt,
             return_tensors="pt",
@@ -148,5 +147,11 @@ def calculate_age(birth_year):
         if dtype_override is not None:
             for key in inputs:
                 inputs[key] = cast_input_to_type(inputs[key], dtype_override)
+
+        padded_input_ids, seq_len = pad_inputs(inputs["input_ids"], max_new_tokens)
+        padded_attention_mask, _ = pad_inputs(inputs["attention_mask"], max_new_tokens)
+        self.seq_len = seq_len
+        inputs["input_ids"] = padded_input_ids
+        inputs["attention_mask"] = padded_attention_mask
 
         return inputs

--- a/gemma/pytorch/loader.py
+++ b/gemma/pytorch/loader.py
@@ -155,8 +155,6 @@ class ModelLoader(ForgeModel):
         if self.tokenizer is None:
             self._load_tokenizer(dtype_override=dtype_override)
         input_prompt = prompt or self.sample_text
-
-        self.tokenizer.padding_side = "right"
         inputs = self.tokenizer(
             input_prompt,
             return_tensors="pt",
@@ -169,6 +167,11 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             for key in inputs:
                 inputs[key] = cast_input_to_type(inputs[key], dtype_override)
+        padded_input_ids, seq_len = pad_inputs(inputs["input_ids"], max_new_tokens)
+        padded_attention_mask, _ = pad_inputs(inputs["attention_mask"], max_new_tokens)
+        self.seq_len = seq_len
+        inputs["input_ids"] = padded_input_ids
+        inputs["attention_mask"] = padded_attention_mask
         return inputs
 
     def get_mesh_config(self, num_devices: int):

--- a/gpt2/pytorch/loader.py
+++ b/gpt2/pytorch/loader.py
@@ -91,7 +91,7 @@ class ModelLoader(ForgeModel):
         if self._variant == ModelVariant.GPT2_BASE:
             config = GPT2Config.from_pretrained(model_name)
             config_dict = config.to_dict()
-            config_dict["use_cache"] = True
+            config_dict["use_cache"] = False
             if dtype_override is not None:
                 config_dict["torch_dtype"] = dtype_override
             config = GPT2Config(**config_dict)

--- a/huggyllama/pytorch/loader.py
+++ b/huggyllama/pytorch/loader.py
@@ -137,7 +137,6 @@ class ModelLoader(ForgeModel):
         test_input = "This is a sample text from "
 
         # Tokenize input
-        self.tokenizer.padding_side = "right"
         inputs = self.tokenizer.encode_plus(
             test_input,
             return_tensors="pt",

--- a/minicpm_o_2_6/pytorch/loader.py
+++ b/minicpm_o_2_6/pytorch/loader.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 from transformers import AutoModel, AutoTokenizer
-from transformers.integrations.tensor_parallel import ALL_PARALLEL_STYLES
+from transformers.modeling_utils import ALL_PARALLEL_STYLES
 from PIL import Image
 import requests
 from io import BytesIO

--- a/mistral/pytorch/loader.py
+++ b/mistral/pytorch/loader.py
@@ -87,7 +87,6 @@ class ModelLoader(ForgeModel):
         """
         super().__init__(variant)
         self.tokenizer = None
-        self.model = None
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -143,7 +142,7 @@ class ModelLoader(ForgeModel):
             return self.tokenizer
 
         tokenizer_kwargs = {
-            "padding_side": "right",
+            "padding_side": "left",
         }
         if dtype_override is not None:
             tokenizer_kwargs["torch_dtype"] = dtype_override
@@ -199,9 +198,6 @@ class ModelLoader(ForgeModel):
         if self.tokenizer is None:
             self._load_tokenizer(dtype_override)
 
-        if self.model is None:
-            self.load_model(dtype_override)
-
         # Set up sample input
         test_input = "How often does the letter r occur in Mistral?"
 
@@ -223,14 +219,6 @@ class ModelLoader(ForgeModel):
 
         else:
             inputs = self.tokenizer.encode_plus(test_input, return_tensors="pt")
-
-        if (
-            hasattr(self.model.config, "sliding_window")
-            and self.model.config.sliding_window is not None
-        ):
-            # if the model uses sliding window attention, match sliding window value to input size so it
-            # does not go out of bounds when updating the cache
-            self.model.config.sliding_window = inputs["input_ids"].shape[1]
 
         # Add batch dimension
         for key in inputs:

--- a/openvla/pytorch/src/modeling_prismatic.py
+++ b/openvla/pytorch/src/modeling_prismatic.py
@@ -474,8 +474,6 @@ class PrismaticForConditionalGeneration(PrismaticPreTrainedModel):
 class OpenVLAForActionPrediction(PrismaticForConditionalGeneration):
     config_class: PretrainedConfig = OpenVLAConfig
 
-    _supports_sdpa: bool = True
-
     def __init__(self, config: OpenVLAConfig) -> None:
         super().__init__(config)
         self.norm_stats = config.norm_stats
@@ -484,9 +482,3 @@ class OpenVLAForActionPrediction(PrismaticForConditionalGeneration):
         self.vocab_size = (
             self.config.text_config.vocab_size - self.config.pad_to_multiple_of
         )
-
-    @property
-    def _supports_sdpa(self) -> bool:
-        if hasattr(self, "language_model"):
-            return self.language_model._supports_sdpa
-        return True  # Default value during initialization

--- a/whisper/audio_classification/jax/requirements.txt
+++ b/whisper/audio_classification/jax/requirements.txt
@@ -3,5 +3,6 @@ datasets
 soundfile
 librosa
 
-# Override system-wide torchcodec - version 0.8 is compatible with PyTorch 2.9
-torchcodec==0.8
+# Override system-wide torchcodec - version 0.5 is compatible with PyTorch 2.7
+# Note: torchcodec 0.8+ has issues with FFmpeg 4.x and PyTorch 2.7
+torchcodec==0.5


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge/issues/735

### Problem description
Reverting commit https://github.com/tenstorrent/tt-forge-models/commit/646e25055e7d3e564e0161d345bc6e33ea5745b3 due to reversal of commit https://github.com/tenstorrent/tt-xla/commit/81e993b2bb855535af76a570701bb70b472a49db in tt-xla repo. New transformers/torch version produces very different graphs and the existing fusing patterns no longer work properly.
We are keeping track of the main issue in https://github.com/tenstorrent/tt-mlir/issues/6335
### What's changed
Reverts the changes needed for torch 2.9.0 and transformers 4.57.1 updates

### Checklist
- [x] New/Existing tests provide coverage for changes
