### PR TITLE
Disable warning regarding model info variants

### DIFF
--- a/config.py
+++ b/config.py
@@ -121,13 +121,6 @@ class ModelInfo:
     source: ModelSource
     framework: Framework
 
-    def __post_init__(self):
-        if not isinstance(self.variant, StrEnum):
-            # TODO - Change to raise TypeError once all models updated.
-            print(
-                f"Warning: ModelInfo.variant should be a StrEnum, not {type(self.variant).__name__}"
-            )
-
     @property
     def name(self) -> str:
         """Generate a standardized model identifier"""


### PR DESCRIPTION
Since a lot of models do not handle variants properly, in tt-xla we get a lot of noise with the related warning. In agreement with @kmabeeTT, removing the warning.