### PR TITLE
Fix HF tokenizer ValueError by manual tensor conversion for yoloworld

### DIFF
--- a/yoloworld/pytorch/loader.py
+++ b/yoloworld/pytorch/loader.py
@@ -83,12 +83,12 @@ class ModelLoader(ForgeModel):
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
         if variant is None:
-            variant = self.DEFAULT_VARIANT
+            variant = cls.DEFAULT_VARIANT
         return ModelInfo(
             model="yoloworld",
             variant=variant,
             group=ModelGroup.RED
-            if variant == self.DEFAULT_VARIANT
+            if variant == cls.DEFAULT_VARIANT
             else ModelGroup.GENERALITY,
             task=ModelTask.CV_OBJECT_DET,
             source=ModelSource.CUSTOM,
@@ -109,7 +109,7 @@ class ModelLoader(ForgeModel):
             self.model = self.model.to(dtype_override)
         return self.model
 
-    def load_inputs(self, dtype_override=None, batch_size=1):
+    def load_inputs(self, dtype_override=None):
         self.image_file = get_file("https://ultralytics.com/images/bus.jpg")
         test_pipeline_cfg = get_test_pipeline_cfg(cfg=self.config)
         test_pipeline = Compose(test_pipeline_cfg)

--- a/yoloworld/pytorch/requirements.txt
+++ b/yoloworld/pytorch/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python
 yapf
 supervision==0.19.0
-lvis
+lvis==0.5.3
+Cython==3.2.3

--- a/yoloworld/pytorch/src/model.py
+++ b/yoloworld/pytorch/src/model.py
@@ -1524,9 +1524,18 @@ class HuggingCLIPLanguageBackbone(BaseModule):
             text_mask = torch.tensor(
                 [x != self.pad_value for x in text], requires_grad=False
             )
-        text = self.tokenizer(text=text, return_tensors="pt", padding=True)
-        text["input_ids"] = text["input_ids"].to(self.model.device)
-        text["attention_mask"] = text["attention_mask"].to(self.model.device)
+        text = self.tokenizer(text=text, return_tensors=None, padding=True)
+        input_ids = torch.tensor(text["input_ids"], dtype=torch.long).to(
+            self.model.device
+        )
+        attention_mask = torch.tensor(text["attention_mask"], dtype=torch.long).to(
+            self.model.device
+        )
+
+        text = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+        }
         if len(self.frozen_modules) > 0:
             with torch.no_grad():
                 txt_outputs = self.model(**text)


### PR DESCRIPTION
### Problem description

- The current transformers  package versions introduce stricter internal PyTorch tensor conversion when `return_tensors="pt"` is used.
- With YOLO-World’s existing text preprocessing (which uses flattened character-level inputs), the tokenizer attempts to create PyTorch tensors before padding and shape normalization are fully resolved, resulting in a ValueError during inference.

### What's changed

- Tokenization is now performed with `return_tensors=None,` allowing the tokenizer to return plain Python lists.
- PyTorch tensors for `input_ids` and `attention_mask` are then created manually after tokenization, ensuring padding and shapes are fully resolved before tensor conversion.
- This fix preserves the original text processing logic and batch semantics while restoring compatibility with newer transformers versions and avoiding runtime failures.
- Dependency versions (including Cython, lvis, and supervision) were pinned to specific validated releases to prevent incompatible latest versions from being installed at runtime.

### Checklist
- [x] New/Existing tests provide coverage for changes

### Logs
- [small_1280_after_fix.log](https://github.com/user-attachments/files/24212015/small_1280_after_fix.log)
- [small_1280_before_fix.log](https://github.com/user-attachments/files/24212018/small_1280_before_fix.log)

