### PR TITLE
Fix for PCC drop in Phi-3.5

### DIFF
--- a/phi3/phi_3_5/pytorch/loader.py
+++ b/phi3/phi_3_5/pytorch/loader.py
@@ -71,7 +71,9 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             tokenizer_kwargs["torch_dtype"] = dtype_override
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+            self._variant_config.pretrained_model_name,
+            trust_remote_code=True,
+            **tokenizer_kwargs
         )
         # Ensure padding token is set
         if self.tokenizer.pad_token_id is None:
@@ -88,6 +90,7 @@ class ModelLoader(ForgeModel):
             pretrained_model_name,
             use_cache=False,
             torch_dtype=model_dtype,
+            trust_remote_code=True,
         )
         model.eval()
         return model


### PR DESCRIPTION
### Ticket
[1443](https://github.com/tenstorrent/tt-xla/issues/1443)

### Problem description
PCC drop was observed in the model, with the PCC value falling to 0.987

### What's changed
Transformers v4.57.1: PCC = 0.999
Transformers v4.52: PCC = 0.987
Further debugging was performed, and the parameter trust_remote_code=True was added to both:

- AutoTokenizer.from_pretrained

- AutoModelForCausalLM.from_pretrained

After this change, the model PCC improved to 0.989700257778167.
logs:
[phi3_5.log](https://github.com/user-attachments/files/24230480/phi3_5.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
