### PR TITLE
PCC Drop Fix for Generality Models

### DIFF
--- a/albert/token_classification/pytorch/loader.py
+++ b/albert/token_classification/pytorch/loader.py
@@ -179,7 +179,7 @@ class ModelLoader(ForgeModel):
         inputs = self.tokenizer(
             self.sample_text,
             max_length=max_length,
-            padding="max_length",
+            padding=True,
             truncation=True,
             return_tensors="pt",
         )

--- a/gemma/pytorch/loader.py
+++ b/gemma/pytorch/loader.py
@@ -157,7 +157,7 @@ class ModelLoader(ForgeModel):
                 input_prompt,
                 return_tensors="pt",
                 max_length=max_length,
-                padding="max_length",
+                padding=True,
                 truncation=True,
             )
         else:
@@ -178,16 +178,18 @@ class ModelLoader(ForgeModel):
                 padding=True,
                 truncation=True,
             )
-        for key in inputs:
-            inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
-        if dtype_override is not None:
             for key in inputs:
-                inputs[key] = cast_input_to_type(inputs[key], dtype_override)
-        padded_input_ids, seq_len = pad_inputs(inputs["input_ids"], max_new_tokens)
-        padded_attention_mask, _ = pad_inputs(inputs["attention_mask"], max_new_tokens)
-        self.seq_len = seq_len
-        inputs["input_ids"] = padded_input_ids
-        inputs["attention_mask"] = padded_attention_mask
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+            if dtype_override is not None:
+                for key in inputs:
+                    inputs[key] = cast_input_to_type(inputs[key], dtype_override)
+            padded_input_ids, seq_len = pad_inputs(inputs["input_ids"], max_new_tokens)
+            padded_attention_mask, _ = pad_inputs(
+                inputs["attention_mask"], max_new_tokens
+            )
+            self.seq_len = seq_len
+            inputs["input_ids"] = padded_input_ids
+            inputs["attention_mask"] = padded_attention_mask
         return inputs
 
     def get_mesh_config(self, num_devices: int):

--- a/opt/causal_lm/pytorch/loader.py
+++ b/opt/causal_lm/pytorch/loader.py
@@ -149,7 +149,7 @@ class ModelLoader(ForgeModel):
         input_tokens = self.tokenizer(
             self.sample_text,
             max_length=self._variant_config.max_length,
-            padding="max_length",
+            padding=True,
             truncation=True,
             return_tensors="pt",
         )


### PR DESCRIPTION
### Ticket
[2641](https://github.com/tenstorrent/tt-xla/issues/2641)

### Problem description
PCC drop observed in the following models:

> test_all_models_torch[albert/token_classification/pytorch-xlarge_v2-single_device-full-inference]
> test_all_models_torch[albert/token_classification/pytorch-xxlarge_v2-single_device-full-inference]
> test_all_models_torch[opt/causal_lm/pytorch-facebook/opt-1.3b-single_device-full-inference]  
> test_all_models_torch[gemma/pytorch-google/gemma-2b-single_device-full-inference]

### What's changed
Modified the input generation logic by enabling padding (padding=True) in loader.py.
After applying the changes all the above models passed.
[albert_xlarge1.log](https://github.com/user-attachments/files/24288783/albert_xlarge1.log)
[albert_xxlarge.log](https://github.com/user-attachments/files/24288784/albert_xxlarge.log)
[opt_1.3_1.log](https://github.com/user-attachments/files/24288788/opt_1.3_1.log)
[gemma_2b.log](https://github.com/user-attachments/files/24290414/gemma_2b.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
