### PR TITLE
PCC Drop Fix for Generality Models(set2)

### DIFF
--- a/opt/qa/pytorch/loader.py
+++ b/opt/qa/pytorch/loader.py
@@ -159,7 +159,7 @@ class ModelLoader(ForgeModel):
             self.sample_question,
             self.sample_context,
             max_length=self._variant_config.max_length,
-            padding="max_length",
+            padding=True,
             truncation=True,
             return_tensors="pt",
         )


### PR DESCRIPTION
### Ticket
[2641](https://github.com/tenstorrent/tt-xla/issues/2641)

### Problem description
PCC drop observed in the following models:

> test_all_models_torch[gpt_neo/causal_lm/pytorch-gpt_neo_125M-single_device-full-inference] 
> test_all_models_torch[gpt_neo/causal_lm/pytorch-gpt_neo_2_7B-single_device-full-inference]
> test_all_models_torch[opt/qa/pytorch-facebook/opt-1.3b-single_device-full-inference] 

### What's changed
**gpt_neo** Model:
Modified the input generation logic by enabling padding (padding=True) and reformatted the code in loader.py.

| Model | Changes | pcc |
|--------|--------|--------|
| gpt_neo 125m | Intial | 0.865210473537445 |
| gpt_neo 125m | padding=True | 0.987863600254058 |
| gpt_neo 2.7b  | Intial |  0.7228165864944458     | 
| gpt_neo 2.7b | padding=True | 0.989716947078704 |

[gpt_neo_2_7.log](https://github.com/user-attachments/files/24322549/gpt_neo_2_7.log)
[gpt_neo_125.log](https://github.com/user-attachments/files/24322550/gpt_neo_125.log)

**opt/qa** Model:
Modified the input generation logic by enabling padding (padding=True) in loader.py.

| Changes | Pcc |
|--------|--------|
| Initial  | 0.91 |
| padding=True | 0.94 | 


### Checklist
- [ ] New/Existing tests provide coverage for changes
