### PR TITLE
Fix Tensor Stride Mismatch Runtime Error in Resnet

### DIFF
--- a/resnet/pytorch/loader.py
+++ b/resnet/pytorch/loader.py
@@ -263,11 +263,12 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.Tensor: Preprocessed input tensor.
         """
-        return self.input_preprocess(
+        inputs = self.input_preprocess(
             image=image,
             dtype_override=dtype_override,
             batch_size=batch_size,
         )
+        return inputs if inputs.is_contiguous() else inputs.contiguous()
 
     def output_postprocess(
         self,


### PR DESCRIPTION

### Ticket

Fixes [#3115](https://github.com/tenstorrent/tt-forge-fe/issues/3115)

### Problem description
Resnet 152 variant demo Fails with this issue `RuntimeError: Tensor 0 - stride mismatch: expected [150528, 50176, 224, 1], got [3, 1, 672, 3]
`
### What's changed

- Making inputs contiguous fixes this issue. Calling inputs.contiguous() reorders/copies the data to be contiguous in the current dimension order , changing inputs stride that aligns with the runtime’s requirement and removes the stride mismatch.

### Logs
[resnet_before_fix.log](https://github.com/user-attachments/files/24364773/resnet_before_fix.log)
[resnet_after_fix.log](https://github.com/user-attachments/files/24364775/resnet_after_fix.log)
