### PR TITLE
 Bringup Gemma_3 Model

### DIFF
--- a/gemma3/causal_lm/pytorch/__init__.py
+++ b/gemma3/causal_lm/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma_3 causal_lm PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/gemma3/causal_lm/pytorch/loader.py
+++ b/gemma3/causal_lm/pytorch/loader.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma 3 model loader implementation for causal language modeling.
+"""
+
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from typing import Optional
+
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+from .src.model_utils import pad_inputs
+from ....tools.utils import cast_input_to_type
+
+
+class ModelVariant(StrEnum):
+    """Available Gemma3 model variants for causal LM."""
+
+    GEMMA_3_270M_IT = "google/gemma-3-270m-it"
+    GEMMA_3_1B_IT = "google/gemma-3-1b-it"
+
+
+class ModelLoader(ForgeModel):
+    """Gemma3 model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.GEMMA_3_270M_IT: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.GEMMA_3_270M_IT),
+            max_length=256,
+        ),
+        ModelVariant.GEMMA_3_1B_IT: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.GEMMA_3_1B_IT),
+            max_length=256,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.GEMMA_3_270M_IT
+
+    sample_text = "What is your favorite city?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        super().__init__(variant)
+        self.tokenizer = None
+        self.seq_len = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        group = ModelGroup.GENERALITY
+
+        return ModelInfo(
+            model="gemma_3_causal_lm",
+            variant=variant,
+            group=group,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current causal_lm variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name, **tokenizer_kwargs
+        )
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        return self.tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the Gemma 3 causal_lm model instance.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Gemma 3 model instance for causal language modeling.
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+        model_kwargs = {"use_cache": False}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+        model.eval()
+        self.model = model
+        self.config = model.config
+        return model
+
+    def load_inputs(
+        self,
+        dtype_override=None,
+        batch_size=1,
+        max_new_tokens: int = 256,
+        prompt: Optional[str] = None,
+    ):
+        """Load and return sample inputs for the Gemma3 model with default settings.
+
+        Returns:
+            dict: Input tensors and attention masks that can be fed to the model.
+        """
+        max_length = self._variant_config.max_length
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+        input_prompt = [
+            {
+                "role": "user",
+                "content": prompt or self.sample_text,
+            }
+        ]
+        input_text = self.tokenizer.apply_chat_template(
+            input_prompt,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        inputs = self.tokenizer(
+            [input_text],
+            return_tensors="pt",
+            max_length=max_length,
+            padding="max_length",
+            truncation=True,
+        )
+        for key in inputs:
+            inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+        if dtype_override is not None:
+            for key in inputs:
+                inputs[key] = cast_input_to_type(inputs[key], dtype_override)
+        padded_input_ids, seq_len = pad_inputs(inputs["input_ids"], max_new_tokens)
+        padded_attention_mask, _ = pad_inputs(inputs["attention_mask"], max_new_tokens)
+        self.seq_len = seq_len
+        inputs["input_ids"] = padded_input_ids
+        inputs["attention_mask"] = padded_attention_mask
+        return inputs

--- a/gemma3/causal_lm/pytorch/src/model_utils.py
+++ b/gemma3/causal_lm/pytorch/src/model_utils.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+
+def pad_inputs(inputs, max_new_tokens):
+    batch_size, seq_len = inputs.shape
+    max_seq_len = seq_len + max_new_tokens
+    padded_inputs = torch.zeros(
+        (batch_size, max_seq_len), dtype=inputs.dtype, device=inputs.device
+    )
+    padded_inputs[:, :seq_len] = inputs
+    return padded_inputs, seq_len

--- a/gemma3/multimodal/pytorch/__init__.py
+++ b/gemma3/multimodal/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma_3 multimodal PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/gemma3/multimodal/pytorch/loader.py
+++ b/gemma3/multimodal/pytorch/loader.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma 3 model loader implementation for multimodal modeling.
+"""
+
+from typing import Optional, List, Dict, Any
+from PIL import Image
+
+from transformers import (
+    AutoProcessor,
+    Gemma3ForConditionalGeneration,
+)
+
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+from ....tools.utils import cast_input_to_type, get_file
+
+
+class ModelVariant(StrEnum):
+    """Available Gemma 3 multimodal model variants."""
+
+    GEMMA_3_4B_IT = "google/gemma-3-4b-it"
+    GEMMA_3_12B_IT = "google/gemma-3-12b-it"
+    GEMMA_3_27B_IT = "google/gemma-3-27b-it"
+
+
+class ModelLoader(ForgeModel):
+    """Gemma3 model loader implementation for multimodal modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.GEMMA_3_4B_IT: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.GEMMA_3_4B_IT)
+        ),
+        ModelVariant.GEMMA_3_12B_IT: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.GEMMA_3_12B_IT)
+        ),
+        ModelVariant.GEMMA_3_27B_IT: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.GEMMA_3_27B_IT)
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.GEMMA_3_4B_IT
+
+    sample_text = "What do you see in this image?"
+    sample_image_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/p-blog/candy.JPG"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        super().__init__(variant)
+        self.processor = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        if any(x in variant.value for x in ["12b", "27b"]):
+            group = ModelGroup.RED
+        else:
+            group = ModelGroup.GENERALITY
+
+        return ModelInfo(
+            model="gemma_3_multimodal",
+            variant=variant,
+            group=group,
+            task=ModelTask.MM_CONDITIONAL_GENERATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_processor(self, dtype_override=None):
+        kwargs = {}
+        if dtype_override is not None:
+            kwargs["torch_dtype"] = dtype_override
+
+        self.processor = AutoProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name,
+            **kwargs,
+        )
+        return self.processor
+
+    def load_model(self, dtype_override=None):
+        """Load and return the Gemma 3 multimodal model instance.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Gemma 3 model instance for multimodal modeling.
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+        if self.processor is None:
+            self._load_processor(dtype_override=dtype_override)
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model = Gemma3ForConditionalGeneration.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+
+        model.eval()
+        self.model = model
+        self.config = model.config
+        return model
+
+    def load_inputs(
+        self,
+        dtype_override=None,
+        batch_size: int = 1,
+        prompt: Optional[str] = None,
+        image_url: Optional[str] = None,
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ):
+        """Load and return sample inputs for the Gemma3 multimodal model with default settings.
+
+        Returns:
+            dict: Input tensors and attention masks that can be fed to the model.
+        """
+        max_length = self._variant_config.max_length
+        if self.processor is None:
+            self._load_processor(dtype_override=dtype_override)
+
+        image_file = get_file(image_url or self.sample_image_url)
+        image = Image.open(image_file).convert("RGB")
+
+        message = {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": prompt or self.sample_text},
+            ],
+        }
+
+        inputs = self.processor.apply_chat_template(
+            [message],
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        if dtype_override is not None:
+            if "pixel_values" in inputs:
+                inputs["pixel_values"] = cast_input_to_type(
+                    inputs["pixel_values"], dtype_override
+                )
+
+        inputs = {
+            "input_ids": inputs["input_ids"],
+            "attention_mask": inputs["attention_mask"],
+            "pixel_values": inputs.get("pixel_values", None),
+            "use_cache": False,
+        }
+        print(inputs)
+        return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        """Get the mesh configuration for tensor parallel execution.
+
+        Args:
+            num_devices: Number of devices to shard across.
+
+        Returns:
+            tuple: (mesh_shape, mesh_axis_names) where mesh_shape is (batch_dim, model_dim)
+                   and mesh_axis_names are ("batch", "model").
+        """
+        mesh_shape = (1, num_devices)
+        # Only 27b variant needs tensor parallelism
+        if self._variant == ModelVariant.GEMMA_3_27B_IT:
+            assert (
+                self.config.text_config.num_attention_heads % mesh_shape[1] == 0
+            ), "Attention heads must be divisible by the model axis size"
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        """Load the sharding specification for tensor parallel execution.
+
+        Args:
+            model: The Gemma3 multimodal model instance.
+
+        Returns:
+            dict: Dictionary mapping model parameters to their sharding specification,
+                  or None if tensor parallelism is not needed for this variant.
+        """
+        # Only 27b variant needs tensor parallelism
+        if self._variant != ModelVariant.GEMMA_3_27B_IT:
+            return None
+
+        shard_specs = {}
+
+        for layer in model.language_model.model.layers:
+            # MLP layer sharding
+            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+
+            # Self-attention layer sharding
+            shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
+
+        return shard_specs


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1295)

### Problem description
Bring up support for the following **Gemma 3 instruction-tuned model variants**:

* `google/gemma-3-270m-it`
* `google/gemma-3-1b-it`
* `google/gemma-3-4b-it`
* `google/gemma-3-12b-it`
* `google/gemma-3-27b-it`


### What's changed
Added support for Gemma3 variants in loader.py.

### Checklist
- [ ] New/Existing tests provide coverage for changes
