### PR TITLE
Add loaders for paddlepaddle models

### DIFF
--- a/albert/masked_lm/paddlepaddle/__init__.py
+++ b/albert/masked_lm/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/albert/masked_lm/paddlepaddle/loader.py
+++ b/albert/masked_lm/paddlepaddle/loader.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+ALBERT PaddlePaddle model loader implementation for masked language modeling.
+"""
+
+from typing import Optional, List
+
+import paddle
+from paddlenlp.transformers import AlbertForMaskedLM, AlbertTokenizer
+
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available ALBERT model variants for masked language modeling (Paddle)."""
+
+    ALBERT_CHINESE_TINY = "albert-chinese-tiny"
+
+
+class ModelLoader(ForgeModel):
+    """ALBERT Paddle model loader implementation for masked language modeling."""
+
+    _VARIANTS = {
+        ModelVariant.ALBERT_CHINESE_TINY: LLMModelConfig(
+            pretrained_model_name="albert-chinese-tiny",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.ALBERT_CHINESE_TINY
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant."""
+        super().__init__(variant)
+        self.tokenizer: Optional[AlbertTokenizer] = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="albert-maskedlm",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_MASKED_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.PADDLE,
+        )
+
+    def _get_sample_text(self) -> str:
+        """Return the sample masked sentence used by the test."""
+        return ["一，[MASK]，三，四"]
+
+    def load_model(self, dtype_override=None):
+        """Load Paddle ALBERT model for masked language modeling."""
+        model_name = self._variant_config.pretrained_model_name
+        # Initialize tokenizer
+        self.tokenizer = AlbertTokenizer.from_pretrained(model_name)
+
+        base_model = AlbertForMaskedLM.from_pretrained(model_name)
+
+        class AlbertWrapper(paddle.nn.Layer):
+            def __init__(self, model):
+                super().__init__()
+                self.model = model
+
+            def forward(self, input_ids, token_type_ids, position_ids, attention_mask):
+                return self.model(
+                    input_ids=input_ids,
+                    token_type_ids=token_type_ids,
+                    position_ids=position_ids,
+                    attention_mask=attention_mask,
+                )
+
+        wrapped = AlbertWrapper(base_model)
+        return wrapped
+
+    def load_inputs(self, dtype_override=None) -> List[paddle.Tensor]:
+        """Prepare sample inputs for ALBERT masked language modeling (Paddle)."""
+        if self.tokenizer is None:
+            self.load_model(dtype_override=dtype_override)
+
+        sample_text = self._get_sample_text()
+        encoded = self.tokenizer(
+            sample_text,
+            return_token_type_ids=True,
+            return_position_ids=True,
+            return_attention_mask=True,
+        )
+        inputs = [paddle.to_tensor(value) for value in encoded.values()]
+        return inputs

--- a/alexnet/image_classification/paddlepaddle/__init__.py
+++ b/alexnet/image_classification/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/alexnet/image_classification/paddlepaddle/loader.py
+++ b/alexnet/image_classification/paddlepaddle/loader.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+AlexNet PaddlePaddle model loader implementation.
+"""
+
+from typing import Optional
+
+import paddle
+from paddle.vision.models import alexnet
+
+from ....config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available AlexNet model variants (Paddle)."""
+
+    DEFAULT = "alexnet"
+
+
+class ModelLoader(ForgeModel):
+    """AlexNet PaddlePaddle model loader implementation."""
+
+    _VARIANTS = {
+        ModelVariant.DEFAULT: ModelConfig(
+            pretrained_model_name="alexnet",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.DEFAULT
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="alexnet",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.CUSTOM,
+            framework=Framework.PADDLE,
+        )
+
+    def load_model(self, dtype_override=None):
+        """Load pretrained AlexNet model (Paddle)."""
+        model = alexnet(pretrained=True)
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size: int = 1):
+        """Prepare sample input for AlexNet model (Paddle)."""
+        inputs = paddle.rand([batch_size, 3, 224, 224])
+        return [inputs]

--- a/bert/masked_lm/paddlepaddle/__init__.py
+++ b/bert/masked_lm/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/bert/masked_lm/paddlepaddle/loader.py
+++ b/bert/masked_lm/paddlepaddle/loader.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+BERT PaddlePaddle model loader implementation for masked language modeling.
+"""
+
+from typing import Optional, List
+
+import paddle
+from paddlenlp.transformers import BertForMaskedLM, BertTokenizer
+
+from ....config import (
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    LLMModelConfig,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available BERT model variants for masked language modeling (Paddle)."""
+
+    BERT_BASE_UNCASED = "bert-base-uncased"
+    BERT_BASE_JAPANESE = "cl-tohoku/bert-base-japanese"
+    CHINESE_ROBERTA_BASE = "uer/chinese-roberta-base"
+
+
+class ModelLoader(ForgeModel):
+    """BERT Paddle model loader implementation for masked language modeling."""
+
+    _VARIANTS = {
+        ModelVariant.BERT_BASE_UNCASED: LLMModelConfig(
+            pretrained_model_name="bert-base-uncased",
+        ),
+        ModelVariant.BERT_BASE_JAPANESE: LLMModelConfig(
+            pretrained_model_name="cl-tohoku/bert-base-japanese",
+        ),
+        ModelVariant.CHINESE_ROBERTA_BASE: LLMModelConfig(
+            pretrained_model_name="uer/chinese-roberta-base",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.BERT_BASE_UNCASED
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant."""
+        super().__init__(variant)
+        self.tokenizer: Optional[BertTokenizer] = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="bert-maskedlm",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_MASKED_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.PADDLE,
+        )
+
+    def _get_sample_text(self) -> str:
+        """Return a sample masked sentence based on variant language."""
+        model_name = self._variant_config.pretrained_model_name
+        if "japanese" in model_name:
+            return ["一つ、[MASK]、三、四"]
+        if "chinese" in model_name or "roberta" in model_name:
+            return ["一，[MASK]，三，四"]
+        return ["One, [MASK], three, four"]
+
+    def _get_max_length(self) -> int:
+        return getattr(self._variant_config, "max_length", 128) or 128
+
+    def load_model(self, dtype_override=None):
+        """Load Paddle BERT model for masked language modeling."""
+        model_name = self._variant_config.pretrained_model_name
+        # Initialize tokenizer
+        self.tokenizer = BertTokenizer.from_pretrained(model_name)
+
+        model = BertForMaskedLM.from_pretrained(model_name)
+        return model
+
+    def load_inputs(self, dtype_override=None) -> List[paddle.Tensor]:
+        """Prepare sample inputs for BERT masked language modeling (Paddle)."""
+
+        if self.tokenizer is None:
+            self.load_model(dtype_override=dtype_override)
+
+        sample_text = self._get_sample_text()
+        encoded_input = self.tokenizer(
+            sample_text,
+            return_token_type_ids=True,
+            return_position_ids=True,
+            return_attention_mask=True,
+        )
+        self.inputs = [paddle.to_tensor(value) for value in encoded_input.values()]
+        return self.inputs
+
+    def decode_output(self, outputs=None):
+        """Decode the model output for masked language modeling."""
+        if outputs is None or self.inputs is None or self.tokenizer is None:
+            return None
+        logits = outputs[0]
+        input_ids = self.inputs[0]
+        mask_token_index = (
+            (input_ids == self.tokenizer.mask_token_id)[0]
+            .nonzero(as_tuple=True)[0]
+            .item()
+        )
+        predicted_token_id = logits[0, mask_token_index].argmax(axis=-1).item()
+        return self.tokenizer.decode(predicted_token_id)

--- a/bert/question_answering/paddlepaddle/__init__.py
+++ b/bert/question_answering/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/bert/question_answering/paddlepaddle/loader.py
+++ b/bert/question_answering/paddlepaddle/loader.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+BERT PaddlePaddle model loader implementation for question answering.
+"""
+
+from typing import Optional, List
+
+import paddle
+from paddlenlp.transformers import BertForQuestionAnswering, BertTokenizer
+
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available BERT model variants for question answering (Paddle)."""
+
+    BERT_BASE_UNCASED = "bert-base-uncased"
+    BERT_BASE_JAPANESE = "cl-tohoku/bert-base-japanese"
+    CHINESE_ROBERTA_BASE = "uer/chinese-roberta-base"
+
+
+class ModelLoader(ForgeModel):
+    """BERT Paddle model loader implementation for question answering."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.BERT_BASE_UNCASED: LLMModelConfig(
+            pretrained_model_name="bert-base-uncased",
+        ),
+        ModelVariant.BERT_BASE_JAPANESE: LLMModelConfig(
+            pretrained_model_name="cl-tohoku/bert-base-japanese",
+        ),
+        ModelVariant.CHINESE_ROBERTA_BASE: LLMModelConfig(
+            pretrained_model_name="uer/chinese-roberta-base",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.BERT_BASE_UNCASED
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant."""
+        super().__init__(variant)
+        self.tokenizer: Optional[BertTokenizer] = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="bert-qa",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_QA,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.PADDLE,
+        )
+
+    def _get_sample_question(self) -> str:
+        """Return a sample question based on variant language (matches test inputs_map["..."]["question"])."""
+        model_name = self._variant_config.pretrained_model_name
+        if "japanese" in model_name:
+            return ["中国の首都はどこですか？"]
+        if "chinese" in model_name or "roberta" in model_name:
+            return ["中国的首都是哪里？"]
+        return ["What is the capital of China?"]
+
+    def load_model(self, dtype_override=None):
+        """Load Paddle BERT model for question answering."""
+        model_name = self._variant_config.pretrained_model_name
+        # Initialize tokenizer
+        self.tokenizer = BertTokenizer.from_pretrained(model_name)
+
+        model = BertForQuestionAnswering.from_pretrained(model_name)
+        model.eval()
+        return model
+
+    def load_inputs(self, dtype_override=None) -> List[paddle.Tensor]:
+        """Prepare sample inputs for BERT question answering (Paddle).
+
+        Matches the test's usage: tokenizer(question, return_* flags) and convert values to tensors.
+        """
+        if self.tokenizer is None:
+            self.load_model(dtype_override=dtype_override)
+
+        question = self._get_sample_question()
+        self.encoded = self.tokenizer(
+            question,
+            return_token_type_ids=True,
+            return_position_ids=True,
+            return_attention_mask=True,
+        )
+        inputs = [paddle.to_tensor(value) for value in self.encoded.values()]
+        return inputs
+
+    def decode_output(self, outputs=None):
+        """Decode the model output for question answering (mirrors the test)."""
+        start_logits, end_logits = outputs
+        start_index = start_logits.argmax(dim=-1).item()
+        end_index = end_logits.argmax(dim=-1).item()
+        answer = self.tokenizer.decode(
+            self.encoded["input_ids"][0][start_index : end_index + 1]
+        )
+        return answer

--- a/bert/sequence_classification/paddlepaddle/__init__.py
+++ b/bert/sequence_classification/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/bert/sequence_classification/paddlepaddle/loader.py
+++ b/bert/sequence_classification/paddlepaddle/loader.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+BERT PaddlePaddle model loader implementation for sequence classification.
+"""
+
+from typing import Optional, List, Union
+import random
+import numpy as np
+import paddle
+from paddlenlp.transformers import BertForSequenceClassification, BertTokenizer
+
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available BERT model variants for sequence classification (Paddle)."""
+
+    BERT_BASE_UNCASED = "bert-base-uncased"
+    BERT_BASE_JAPANESE = "cl-tohoku/bert-base-japanese"
+    CHINESE_ROBERTA_BASE = "uer/chinese-roberta-base"
+
+
+class ModelLoader(ForgeModel):
+    """BERT Paddle model loader implementation for sequence classification."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.BERT_BASE_UNCASED: LLMModelConfig(
+            pretrained_model_name="bert-base-uncased",
+        ),
+        ModelVariant.BERT_BASE_JAPANESE: LLMModelConfig(
+            pretrained_model_name="cl-tohoku/bert-base-japanese",
+        ),
+        ModelVariant.CHINESE_ROBERTA_BASE: LLMModelConfig(
+            pretrained_model_name="uer/chinese-roberta-base",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.BERT_BASE_UNCASED
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant."""
+        super().__init__(variant)
+        self.tokenizer: Optional[BertTokenizer] = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="bert-seqcls",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_SEQUENCE_CLASSIFICATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.PADDLE,
+        )
+
+    def _get_sample_text(self) -> List[str]:
+        """Return a sample sentence based on variant language (matches test inputs_map['...']['sequence'])."""
+        model_name = self._variant_config.pretrained_model_name
+        if "japanese" in model_name:
+            return ["こんにちは、私の犬はかわいいです"]
+        if "chinese" in model_name or "roberta" in model_name:
+            return ["你好，我的狗很可爱"]
+        return ["Hello, my dog is cute"]
+
+    def load_model(self, dtype_override=None):
+        """Load Paddle BERT model for sequence classification."""
+        model_name = self._variant_config.pretrained_model_name
+        self.tokenizer = BertTokenizer.from_pretrained(model_name)
+
+        model = BertForSequenceClassification.from_pretrained(model_name, num_classes=2)
+        return model
+
+    def load_inputs(
+        self,
+        dtype_override=None,
+    ) -> List[paddle.Tensor]:
+        """Prepare sample inputs for BERT sequence classification (Paddle)."""
+        if self.tokenizer is None:
+            self.load_model(dtype_override=dtype_override)
+        sample_text = self._get_sample_text()
+        encoded_input = self.tokenizer(
+            sample_text,
+            return_token_type_ids=True,
+            return_position_ids=True,
+            return_attention_mask=True,
+        )
+        inputs = [paddle.to_tensor(value) for value in encoded_input.values()]
+        return inputs

--- a/blip/vision_language/paddlepaddle/__init__.py
+++ b/blip/vision_language/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/blip/vision_language/paddlepaddle/loader.py
+++ b/blip/vision_language/paddlepaddle/loader.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+BLIP PaddlePaddle model loader implementation
+"""
+
+from typing import Optional, List
+from dataclasses import dataclass
+from PIL import Image
+import paddle
+from paddlenlp.transformers import (
+    BlipProcessor,
+    BlipModel,
+    BlipTextModel,
+    BlipVisionModel,
+)
+
+from ....config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+from ....tools.utils import get_file
+
+
+@dataclass
+class BlipConfig(ModelConfig):
+    """Configuration specific to BLIP models"""
+
+    task: "BlipTask"
+
+
+class BlipTask(StrEnum):
+    """Task types for BLIP models."""
+
+    TEXT = "text"
+    VISION = "vision"
+    BLIP_IMAGE_CAPTIONING = "blip_image_captioning"
+
+
+class ModelVariant(StrEnum):
+    """Available BLIP model variants (Paddle) by task."""
+
+    BLIP_IMAGE_CAPTIONING = "blip_image_captioning"
+    BLIP_TEXT = "blip_text"
+    BLIP_VISION = "blip_vision"
+
+
+class ModelLoader(ForgeModel):
+    """BLIP PaddlePaddle model loader implementation."""
+
+    _VARIANTS = {
+        ModelVariant.BLIP_IMAGE_CAPTIONING: BlipConfig(
+            pretrained_model_name="Salesforce/blip-image-captioning-base",
+            task=BlipTask.BLIP_IMAGE_CAPTIONING,
+        ),
+        ModelVariant.BLIP_TEXT: BlipConfig(
+            pretrained_model_name="Salesforce/blip-image-captioning-base",
+            task=BlipTask.TEXT,
+        ),
+        ModelVariant.BLIP_VISION: BlipConfig(
+            pretrained_model_name="Salesforce/blip-image-captioning-base",
+            task=BlipTask.VISION,
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.BLIP_IMAGE_CAPTIONING
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        task = cls._VARIANTS[variant].task
+        if task == BlipTask.BLIP_IMAGE_CAPTIONING:
+            model_task = ModelTask.NLP_EMBED_GEN
+        elif task == BlipTask.VISION:
+            model_task = ModelTask.CV_IMAGE_FE
+        else:
+            model_task = ModelTask.MM_IMAGE_TEXT_SIM
+
+        return ModelInfo(
+            model="blip_image_captioning",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=model_task,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.PADDLE,
+        )
+
+    def load_model(self, dtype_override=None):
+        """Load pretrained BLIP model for this instance's variant (Paddle)."""
+        model_name = self._variant_config.pretrained_model_name
+        task = self._variant_config.task
+
+        if task == BlipTask.TEXT:
+            model = BlipTextModel.from_pretrained(model_name)
+            model.eval()
+            return model
+        elif task == BlipTask.VISION:
+            model = BlipVisionModel.from_pretrained(model_name)
+            model.eval()
+            return model
+        else:
+            base_model = BlipModel.from_pretrained(model_name)
+
+            class BlipWrapper(paddle.nn.Layer):
+                def __init__(self, model: BlipModel):
+                    super().__init__()
+                    self.model = model
+
+                def forward(self, input_ids, pixel_values, attention_mask):
+                    output = self.model(
+                        input_ids=input_ids,
+                        pixel_values=pixel_values,
+                        attention_mask=attention_mask,
+                    )
+                    return output.text_embeds, output.image_embeds
+
+            wrapped = BlipWrapper(base_model)
+            return wrapped
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Prepare sample inputs for BLIP model with this instance's variant settings (Paddle)."""
+        model_name = self._variant_config.pretrained_model_name
+        task = self._variant_config.task
+        processor = BlipProcessor.from_pretrained(model_name)
+
+        image_path = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
+        image = Image.open(str(image_path))
+
+        if task == BlipTask.TEXT:
+            text = "a photo of cats in bed"
+            inputs = processor(text=text, return_tensors="pd", padding=True)
+            inputs = [inputs["input_ids"]]
+            return inputs
+
+        if task == BlipTask.VISION:
+            images = [image] * batch_size
+            enc = processor(images=images, return_tensors="pd", padding=True)
+            return [enc["pixel_values"]]
+
+        else:
+            text = [
+                "cats sleeping",
+                "snowy weather",
+            ]
+            inputs = processor(
+                images=image, text=text, return_tensors="pd", padding=True
+            )
+            self.text = text
+            return [
+                inputs["input_ids"],
+                inputs["pixel_values"],
+                inputs["attention_mask"],
+            ]

--- a/config.py
+++ b/config.py
@@ -97,6 +97,7 @@ class Framework(StrEnum):
     TORCH = "pytorch"
     NUMPY = "numpy"
     ONNX = "onnx"
+    PADDLE = "paddle"
 
 
 class Parallelism(StrEnum):

--- a/densenet/image_classification/paddlepaddle/__init__.py
+++ b/densenet/image_classification/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/densenet/image_classification/paddlepaddle/loader.py
+++ b/densenet/image_classification/paddlepaddle/loader.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Densenet PaddlePaddle model loader implementation.
+"""
+
+from typing import Optional
+
+import paddle
+from paddle.vision.models import densenet121
+
+from ....config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available Densenet model variants (Paddle)."""
+
+    DEFAULT = "densenet121"
+
+
+class ModelLoader(ForgeModel):
+    """Densenet PaddlePaddle model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.DEFAULT: ModelConfig(
+            pretrained_model_name="densenet121",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.DEFAULT
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="densenet",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.CUSTOM,
+            framework=Framework.PADDLE,
+        )
+
+    def load_model(self, dtype_override=None):
+        """Load pretrained Densenet model (Paddle)."""
+        model = eval("densenet121")(pretrained=True)
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size: int = 1):
+        """Prepare sample input for Densenet model (Paddle)."""
+        inputs = paddle.rand([batch_size, 3, 224, 224])
+        return [inputs]

--- a/googlenet/image_classification/paddlepaddle/__init__.py
+++ b/googlenet/image_classification/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/googlenet/image_classification/paddlepaddle/loader.py
+++ b/googlenet/image_classification/paddlepaddle/loader.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+GoogleNet PaddlePaddle model loader implementation.
+"""
+
+from typing import Optional
+
+import paddle
+from paddle.vision.models import googlenet
+
+from ....config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available GoogleNet model variants (Paddle)."""
+
+    DEFAULT = "googlenet"
+
+
+class ModelLoader(ForgeModel):
+    """GoogleNet PaddlePaddle model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.DEFAULT: ModelConfig(
+            pretrained_model_name="googlenet",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.DEFAULT
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="googlenet",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.CUSTOM,
+            framework=Framework.PADDLE,
+        )
+
+    def load_model(self, dtype_override=None):
+        """Load pretrained GoogleNet model (Paddle)."""
+        model = googlenet(pretrained=True)
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size: int = 1):
+        """Prepare sample input for GoogleNet model (Paddle)."""
+        inputs = paddle.rand([batch_size, 3, 224, 224])
+        return [inputs]

--- a/mobilenetv2/image_classification/paddlepaddle/__init__.py
+++ b/mobilenetv2/image_classification/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/mobilenetv2/image_classification/paddlepaddle/loader.py
+++ b/mobilenetv2/image_classification/paddlepaddle/loader.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MobileNetV2 PaddlePaddle model loader implementation.
+"""
+
+from typing import Optional
+
+import paddle
+from paddle.vision.models import mobilenet_v2
+
+from ....config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available MobileNetV2 model variants (Paddle)."""
+
+    DEFAULT = "mobilenet_v2"
+
+
+class ModelLoader(ForgeModel):
+    """MobileNetV2 PaddlePaddle model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.DEFAULT: ModelConfig(
+            pretrained_model_name="mobilenet_v2",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.DEFAULT
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="mobilenetv2",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.CUSTOM,
+            framework=Framework.PADDLE,
+        )
+
+    def load_model(self, dtype_override=None):
+        """Load pretrained MobileNetV2 model (Paddle)."""
+        model = mobilenet_v2(pretrained=True)
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size: int = 1):
+        """Prepare sample input for MobileNetV2 model (Paddle)."""
+        inputs = paddle.rand([batch_size, 3, 224, 224])
+        return [inputs]

--- a/resnet/image_classification/paddlepaddle/__init__.py
+++ b/resnet/image_classification/paddlepaddle/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/resnet/image_classification/paddlepaddle/loader.py
+++ b/resnet/image_classification/paddlepaddle/loader.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+ResNet PaddlePaddle model loader implementation.
+"""
+
+from typing import Optional
+
+import paddle
+from paddle.vision.models import (
+    resnet18,
+    resnet34,
+    resnet50,
+    resnet101,
+    resnet152,
+)
+
+from ....config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available ResNet model variants (Paddle)."""
+
+    RESNET18 = "resnet18"
+    RESNET34 = "resnet34"
+    RESNET50 = "resnet50"
+    RESNET101 = "resnet101"
+    RESNET152 = "resnet152"
+
+
+class ModelLoader(ForgeModel):
+    """ResNet PaddlePaddle model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.RESNET18: ModelConfig(
+            pretrained_model_name="resnet18",
+        ),
+        ModelVariant.RESNET34: ModelConfig(
+            pretrained_model_name="resnet34",
+        ),
+        ModelVariant.RESNET50: ModelConfig(
+            pretrained_model_name="resnet50",
+        ),
+        ModelVariant.RESNET101: ModelConfig(
+            pretrained_model_name="resnet101",
+        ),
+        ModelVariant.RESNET152: ModelConfig(
+            pretrained_model_name="resnet152",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.RESNET18
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model information for dashboard and metrics reporting."""
+        return ModelInfo(
+            model="resnet",
+            variant=variant.value,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.CUSTOM,
+            framework=Framework.PADDLE,
+        )
+
+    def load_model(self, dtype_override=None):
+        """Load pretrained ResNet model for this instance's variant (Paddle)."""
+        variant = self._variant
+        if variant == ModelVariant.RESNET18:
+            model = resnet18(pretrained=True)
+        elif variant == ModelVariant.RESNET34:
+            model = resnet34(pretrained=True)
+        elif variant == ModelVariant.RESNET50:
+            model = resnet50(pretrained=True)
+        elif variant == ModelVariant.RESNET101:
+            model = resnet101(pretrained=True)
+        elif variant == ModelVariant.RESNET152:
+            model = resnet152(pretrained=True)
+        else:
+            raise ValueError(f"Unsupported variant: {variant}")
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size: int = 1):
+        """Prepare sample input for ResNet model (Paddle)."""
+        inputs = paddle.rand([batch_size, 3, 224, 224])
+        return [inputs]


### PR DESCRIPTION
### Ticket

Fixes #378 

### Problem description
To Port the following paddlepaddle models from tt-forge-fe

- Bert model for Masked Language Modeling, Question Answering and Sequence Classification tasks
- Albert model for Masked Language Modeling task
- Blip model for Image Captioning, Image Encoding and Text Encoding tasks
- AlexNet
- DenseNet
- Googlenet
- MobileNetV2
- Resnet

### What's changed

- This PR adds loaders for above mentioned models

### Logs
[albert.log](https://github.com/user-attachments/files/24433237/albert_forge_loader.log)
[densenet.log](https://github.com/user-attachments/files/24433240/densenet_forge_loader.log)
[resnet.log](https://github.com/user-attachments/files/24433243/resnet_forge_loader.log)
[mobilenetv2.log](https://github.com/user-attachments/files/24433246/mobilenetv2_forge_loader.log)
[googlenet.log](https://github.com/user-attachments/files/24433251/googlenet_forge_loader.log)
[bert.log](https://github.com/user-attachments/files/24433258/bert_qa_forge_loader.log)
[blip.log](https://github.com/user-attachments/files/24433262/blip_img_capt_loader.log)
