### PR TITLE
Bringup Gemma_3 Causal_LM Model

### DIFF
--- a/gemma3/causal_lm/pytorch/__init__.py
+++ b/gemma3/causal_lm/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma3 causal_lm PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/gemma3/causal_lm/pytorch/loader.py
+++ b/gemma3/causal_lm/pytorch/loader.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Gemma3 model loader implementation for causal language modeling.
+"""
+
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from typing import Optional
+
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....base import ForgeModel
+from ....tools.utils import cast_input_to_type
+
+
+class ModelVariant(StrEnum):
+    """Available Gemma3 model variants for causal LM."""
+
+    GEMMA_3_270M_IT = "google/gemma-3-270m-it"
+    GEMMA_3_1B_IT = "google/gemma-3-1b-it"
+
+
+class ModelLoader(ForgeModel):
+    """Gemma3 model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.GEMMA_3_270M_IT: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.GEMMA_3_270M_IT),
+            max_length=256,
+        ),
+        ModelVariant.GEMMA_3_1B_IT: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.GEMMA_3_1B_IT),
+            max_length=256,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.GEMMA_3_270M_IT
+
+    sample_text = "What is your favorite city?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        super().__init__(variant)
+        self.tokenizer = None
+        self.seq_len = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        group = ModelGroup.GENERALITY
+
+        return ModelInfo(
+            model="gemma_3_causal_lm",
+            variant=variant,
+            group=group,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current causal_lm variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name, **tokenizer_kwargs
+        )
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        return self.tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the Gemma3 causal_lm model instance.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Gemma3 model instance for causal language modeling.
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+        model_kwargs = {"use_cache": False}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+        model.eval()
+        self.model = model
+        self.config = model.config
+        return model
+
+    def load_inputs(
+        self,
+        dtype_override=None,
+        batch_size=1,
+        max_new_tokens: int = 256,
+        prompt: Optional[str] = None,
+    ):
+        """Load and return sample inputs for the Gemma3 model with default settings.
+
+        Returns:
+            dict: Input tensors and attention masks that can be fed to the model.
+        """
+        max_length = self._variant_config.max_length
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+        input_prompt = [
+            {
+                "role": "user",
+                "content": prompt or self.sample_text,
+            }
+        ]
+        input_text = self.tokenizer.apply_chat_template(
+            input_prompt,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        inputs = self.tokenizer(
+            [input_text],
+            return_tensors="pt",
+            max_length=max_length,
+            padding="max_length",
+            truncation=True,
+        )
+        for key in inputs:
+            inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+
+        input_ids = inputs["input_ids"]
+        attn_mask = inputs["attention_mask"]
+        if dtype_override is not None:
+            input_ids = cast_input_to_type(input_ids, dtype_override)
+            attn_mask = cast_input_to_type(attn_mask, dtype_override)
+        return [input_ids, attn_mask]


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/1295)

### Problem description
Bring up support for the following Gemma 3 instruction-tuned model variants:
- google/gemma-3-270m-it
- google/gemma-3-1b-it

### What's changed
Added support for Gemma3 causal_lm variants in loader.py.
Both the variants are passed.

### Logs
[gemma-3-1b-it.log](https://github.com/user-attachments/files/24433706/gemma-3-1b-it.log)
[gemma-3-270m-it.log](https://github.com/user-attachments/files/24433708/gemma-3-270m-it.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
