### PR TITLE
Fix torch.sum graph capture & ndarray.add AttributeError

### DIFF
--- a/deepseek/deepseek_ocr/pytorch/src/modeling_deepseekocr.py
+++ b/deepseek/deepseek_ocr/pytorch/src/modeling_deepseekocr.py
@@ -64,7 +64,7 @@ class DeepseekOCRModel(DeepseekV2Model):
         if (
             sam_model is not None
             and (input_ids.shape[1] != 1 or self.training)
-            and torch.sum(images[0][1]).item() != 0
+            and torch.sum(images[0][1], dim=(0, 1, 2, 3)).item() != 0
         ):
 
             idx = 0

--- a/deepseek/deepseek_ocr/pytorch/src/modeling_deepseekv2.py
+++ b/deepseek/deepseek_ocr/pytorch/src/modeling_deepseekv2.py
@@ -402,7 +402,7 @@ class DeepseekV2MoE(nn.Module):
             gatherd_idxs = gatherd_idxs.argsort()
             sorted_tokens = gathered_tokens[gatherd_idxs]
             tokens_per_expert = tokens_per_expert_post_gather
-        tokens_per_expert = tokens_per_expert.cpu().numpy()
+        tokens_per_expert = tokens_per_expert.cpu().tolist()
 
         outputs = []
         start_idx = 0


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/2740
- fixes https://github.com/tenstorrent/tt-xla/issues/1772

### Problem description

- The model initially failed with the following error:

```
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <Wrapped method <original add>>(*(FakeTensor(..., size=(), dtype=torch.int64), 0), **{}): got AttributeError("'ndarray' object has no attribute 'add'")
```

- After addressing this issue, the model then failed with:`RuntimeError: a Tensor with 3145728 elements cannot be converted to Scalar`

### Root cause

- **First error** : Originates from this [addition](https://github.com/tenstorrent/tt-forge-models/blob/9298b79e02a74ca1540825bb1cfc0f656ec34e7c/deepseek/deepseek_ocr/pytorch/src/modeling_deepseekv2.py#L410) operation where start_idx is of type `<class 'int'>` while num_tokens is of type `<class 'numpy.int64'>`, leading to issues during Dynamo tracing.
- **Second error:** Originates from this [sum](https://github.com/tenstorrent/tt-forge-models/blob/9298b79e02a74ca1540825bb1cfc0f656ec34e7c/deepseek/deepseek_ocr/pytorch/src/modeling_deepseekocr.py#L67C17-L67C26) operation without dim argument.The torch.sum operation was not captured in the VHLO graph. As a result, the framework attempted to apply .item() directly on a tensor with shape (1, 3, 1024, 1024), which caused the scalar conversion error.

### What's changed

- Replaced .numpy() with .tolist() to resolve the first error.
- Explicitly specified the dim argument in torch.sum to resolve the second error.

### Checklist
- [x] Verified the changes through local testing

### Logs

- [jan6_deepseek_ocr_first_error.log](https://github.com/user-attachments/files/24450213/jan6_deepseek_ocr.log)
- [jan6_deepseek_ocr_second_error.log](https://github.com/user-attachments/files/24450209/jan6_deepseek_ocr_d1.log)
- [jan6_deepseek_ocr_current_error.log](https://github.com/user-attachments/files/24450211/jan6_deepseek_ocr_d2.log)


