### PR TITLE
Add loaders for onnx models

### DIFF
--- a/alexnet/image_classification/onnx/__init__.py
+++ b/alexnet/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/alexnet/image_classification/onnx/loader.py
+++ b/alexnet/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+AlexNet ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """AlexNet ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load AlexNet as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.ALEXNET is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities.
+
+        Args:
+            outputs: Model outputs (tensor or list/tuple with logits at index 0).
+
+        Returns:
+            str: The top 1 predicted class label.
+        """
+        print_compiled_model_results(outputs)

--- a/densenet/image_classification/onnx/__init__.py
+++ b/densenet/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/densenet/image_classification/onnx/loader.py
+++ b/densenet/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DenseNet ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """DenseNet ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load DenseNet as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.DENSENET121 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities.
+
+        Args:
+            outputs: Model outputs (tensor or list/tuple with logits at index 0).
+
+        Returns:
+            str: The top 1 predicted class label.
+        """
+        print_compiled_model_results(outputs)

--- a/efficientnet/image_classification/onnx/__init__.py
+++ b/efficientnet/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/efficientnet/image_classification/onnx/loader.py
+++ b/efficientnet/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+EfficientNet ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """EfficientNet ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load EfficientNet as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.EFFICIENTNET_B0 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities.
+
+        Args:
+            outputs: Model outputs (tensor or list/tuple with logits at index 0).
+
+        Returns:
+            str: The top 1 predicted class label.
+        """
+        print_compiled_model_results(outputs)

--- a/googlenet/image_classification/onnx/__init__.py
+++ b/googlenet/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/googlenet/image_classification/onnx/loader.py
+++ b/googlenet/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+GoogLeNet ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """GoogLeNet ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load GoogLeNet as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.GOOGLENET_V1 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities.
+
+        Args:
+            outputs: Model outputs (tensor or list/tuple with logits at index 0).
+
+        Returns:
+            str: The top 1 predicted class label.
+        """
+        print_compiled_model_results(outputs)

--- a/mobilenetv1/image_classification/onnx/__init__.py
+++ b/mobilenetv1/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/mobilenetv1/image_classification/onnx/loader.py
+++ b/mobilenetv1/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MobilenetV1 ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """MobilenetV1 ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load MobilenetV1 as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.MOBILENET_V1_0_25 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities.
+
+        Args:
+            outputs: Model outputs (tensor or list/tuple with logits at index 0).
+
+        Returns:
+            str: The top 1 predicted class label.
+        """
+        print_compiled_model_results(outputs)

--- a/resnet/image_classification/onnx/__init__.py
+++ b/resnet/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/resnet/image_classification/onnx/loader.py
+++ b/resnet/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+ResNet ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """ResNet ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load ResNet as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.RESNET_50_HF is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities.
+
+        Args:
+            outputs: Model outputs (tensor or list/tuple with logits at index 0).
+
+        Returns:
+            str: The top 1 predicted class label.
+        """
+        print_compiled_model_results(outputs)

--- a/roberta/sequence_classification/onnx/__init__.py
+++ b/roberta/sequence_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/roberta/sequence_classification/onnx/loader.py
+++ b/roberta/sequence_classification/onnx/loader.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Roberta ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ModelLoader(PyTorchModelLoader):
+    """Roberta ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load Roberta as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.ROBERTA_BASE_SENTIMENT is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        self.model = getattr(self.torch_loader, "model", torch_model)
+        inputs = self.torch_loader.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for Roberta sequence classification.
+
+        Delegates to the underlying PyTorch loader to ensure tokenizer is initialized
+        without re-invoking this ONNX loader's load_model signature.
+        """
+        return self.torch_loader.load_inputs(**kwargs)

--- a/squeezebert/sequence_classification/onnx/__init__.py
+++ b/squeezebert/sequence_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/squeezebert/sequence_classification/onnx/loader.py
+++ b/squeezebert/sequence_classification/onnx/loader.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+SqueezeBERT ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ModelLoader(PyTorchModelLoader):
+    """SqueezeBERT ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load SqueezeBERT as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.MNLI is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        self.model = getattr(self.torch_loader, "model", torch_model)
+        inputs = self.torch_loader.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for SqueezeBERT sequence classification.
+
+        Delegates to the underlying PyTorch loader to ensure tokenizer is initialized
+        without re-invoking this ONNX loader's load_model signature.
+        """
+        return self.torch_loader.load_inputs(**kwargs)

--- a/t5/causal_lm/onnx/__init__.py
+++ b/t5/causal_lm/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/t5/causal_lm/onnx/loader.py
+++ b/t5/causal_lm/onnx/loader.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+T5 causal language modeling ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from .src.utils import T5Wrapper, pad_inputs
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ModelLoader(PyTorchModelLoader):
+    """T5 causal language modeling ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load T5 causal language modeling as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.SMALL is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        torch_model = T5Wrapper(torch_model)
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            (inputs[0], inputs[1]),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for T5 causal language modeling.
+
+        Returns:
+            torch.Tensor: Input tensor.
+        """
+        inputs = self.torch_loader.load_inputs(**kwargs)
+        input_ids = inputs["input_ids"]
+        decoder_input_ids = inputs["decoder_input_ids"]
+        padded_decoder_input_ids, _ = pad_inputs(decoder_input_ids)
+        return [input_ids, padded_decoder_input_ids]

--- a/t5/causal_lm/onnx/src/utils.py
+++ b/t5/causal_lm/onnx/src/utils.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+
+class T5Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, decoder_input_ids):
+        inputs = {"input_ids": input_ids, "decoder_input_ids": decoder_input_ids}
+        output = self.model(**inputs)
+        return output
+
+
+def pad_inputs(inputs, max_new_tokens=512):
+    batch_size, seq_len = inputs.shape
+    max_seq_len = seq_len + max_new_tokens
+    padded_inputs = torch.zeros(
+        (batch_size, max_seq_len), dtype=inputs.dtype, device=inputs.device
+    )
+    padded_inputs[:, :seq_len] = inputs
+    return padded_inputs, seq_len

--- a/vgg/image_classification/onnx/__init__.py
+++ b/vgg/image_classification/onnx/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader

--- a/vgg/image_classification/onnx/loader.py
+++ b/vgg/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+VGG ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """VGG ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load VGG as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.TV_VGG19_BN is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model()
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+        )
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities.
+
+        Args:
+            outputs: Model outputs (tensor or list/tuple with logits at index 0).
+
+        Returns:
+            str: The top 1 predicted class label.
+        """
+        print_compiled_model_results(outputs)

--- a/vgg/image_classification/onnx/src/model_utils.py
+++ b/vgg/image_classification/onnx/src/model_utils.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from torchvision import transforms
+from PIL import Image
+from third_party.tt_forge_models.tools.utils import get_file
+from loguru import logger
+
+
+def get_input_img_osmr():
+    try:
+        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
+        input_image = Image.open(file_path).convert("RGB")
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        input_tensor = preprocess(input_image)
+        input_batch = input_tensor.unsqueeze(
+            0
+        )  # create a mini-batch as expected by the model
+    except:
+        logger.warning(
+            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
+        )
+        input_batch = torch.rand(1, 3, 224, 224)
+    return input_batch


### PR DESCRIPTION
### Ticket

Fixes [#885](https://github.com/tenstorrent/tt-forge/issues/885)

### Problem description
To Port the following onnx models from tt-forge-onnx

- AlexNet
- DenseNet
- Efficientnet
- Googlenet
- MobileNetV1
- Resnet
- VGG
- Roberta for sequence classification
- Squeezebert for sequence classification
- T5 for causal_lm


### What's changed

- This PR adds loaders for above mentioned models

### Logs
[alexnet_demo.log](https://github.com/user-attachments/files/25358100/alexnet_demo.log)
[densenet_onnx_demo.log](https://github.com/user-attachments/files/25358107/densenet_onnx_demo.log)
[mobilenetv1_demo.log](https://github.com/user-attachments/files/25358118/mobilenetv1_demo.log)
[resnet_demo.log](https://github.com/user-attachments/files/25358140/resnet_demo.log)
[vgg_demo.log](https://github.com/user-attachments/files/25358143/vgg_demo.log)
[roberta_demo.log](https://github.com/user-attachments/files/25358149/roberta_demo.log)
[squeezebert_demo.log](https://github.com/user-attachments/files/25358152/squeezebert_demo.log)
[t5_demo.log](https://github.com/user-attachments/files/25358153/t5_demo.log)
