### PR TITLE
Fix Torch dynamo failure in Uniad model

### DIFF
--- a/uniad/pytorch/src/track_utils.py
+++ b/uniad/pytorch/src/track_utils.py
@@ -393,24 +393,51 @@ class PerceptionTransformer(nn.Module):
         bs = mlvl_feats[0].size(0)
         bev_queries = bev_queries.unsqueeze(1).repeat(1, bs, 1)
         bev_pos = bev_pos.flatten(2).permute(2, 0, 1)
-        delta_x = np.array([each["can_bus"][0] for each in img_metas])
-        delta_y = np.array([each["can_bus"][1] for each in img_metas])
-        ego_angle = np.array([each["can_bus"][-2] / np.pi * 180 for each in img_metas])
-        grid_length_y = grid_length[0]
-        grid_length_x = grid_length[1]
-        translation_length = np.sqrt(delta_x**2 + delta_y**2)
-        translation_angle = np.arctan2(delta_y, delta_x) / np.pi * 180
+        can_bus_list = [each["can_bus"] for each in img_metas]
+        if torch.is_tensor(can_bus_list[0]):
+            can_bus_raw = torch.stack(can_bus_list, dim=0).to(
+                device=bev_queries.device, dtype=bev_queries.dtype
+            )
+        else:
+            can_bus_raw = torch.as_tensor(
+                can_bus_list, device=bev_queries.device, dtype=bev_queries.dtype
+            )
+
+        delta_x = can_bus_raw[:, 0]
+        delta_y = can_bus_raw[:, 1]
+        ego_angle = can_bus_raw[:, -2] / torch.pi * 180.0
+
+        grid_length_y = torch.as_tensor(
+            grid_length[0], device=bev_queries.device, dtype=bev_queries.dtype
+        )
+        grid_length_x = torch.as_tensor(
+            grid_length[1], device=bev_queries.device, dtype=bev_queries.dtype
+        )
+        bev_h_t = torch.as_tensor(
+            bev_h, device=bev_queries.device, dtype=bev_queries.dtype
+        )
+        bev_w_t = torch.as_tensor(
+            bev_w, device=bev_queries.device, dtype=bev_queries.dtype
+        )
+
+        translation_length = torch.sqrt(delta_x**2 + delta_y**2)
+        translation_angle = torch.atan2(delta_y, delta_x) / torch.pi * 180.0
         bev_angle = ego_angle - translation_angle
         shift_y = (
-            translation_length * np.cos(bev_angle / 180 * np.pi) / grid_length_y / bev_h
+            translation_length
+            * torch.cos(bev_angle / 180.0 * torch.pi)
+            / grid_length_y
+            / bev_h_t
         )
         shift_x = (
-            translation_length * np.sin(bev_angle / 180 * np.pi) / grid_length_x / bev_w
+            translation_length
+            * torch.sin(bev_angle / 180.0 * torch.pi)
+            / grid_length_x
+            / bev_w_t
         )
         shift_y = shift_y * self.use_shift
         shift_x = shift_x * self.use_shift
-        shift_np = np.array([shift_x, shift_y])
-        shift = bev_queries.new_tensor(shift_np).permute(1, 0)
+        shift = torch.stack([shift_x, shift_y], dim=0).permute(1, 0)  # [bs, 2]
 
         if prev_bev is not None:
             if prev_bev.shape[1] == bev_h * bev_w:
@@ -429,9 +456,7 @@ class PerceptionTransformer(nn.Module):
                     )
                     prev_bev[:, i] = tmp_prev_bev[:, 0]
 
-        can_bus_np = np.array([each["can_bus"] for each in img_metas])
-        can_bus = bev_queries.new_tensor(can_bus_np)
-        can_bus = self.can_bus_mlp(can_bus)[None, :, :]
+        can_bus = self.can_bus_mlp(can_bus_raw)[None, :, :]
         bev_queries = bev_queries + can_bus * self.use_can_bus
 
         feat_flatten = []
@@ -1047,7 +1072,6 @@ class MSDeformableAttention3D(nn.Module):
 
 
 class BEVFormerEncoder(TransformerLayerSequence):
-
     """
     Attention with both self and cross
     Implements the decoder in DETR transformer.


### PR DESCRIPTION
### Ticket

Fixes [#2754](https://github.com/tenstorrent/tt-xla/issues/2754)

### Problem description
Uniad model fails with below error:

```
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <Wrapped method <original pow>>(*(FakeTensor(..., size=(1,)), 2), **{}): got AttributeError("'ndarray' object has no attribute 'pow'")
```

### What's changed

-  Model fails with AttributeError("'ndarray' object has no attribute 'pow'"). The root cause is mixing NumPy ops inside a TorchDynamo/XLA-traced region. Using np.sqrt(delta_x**2 + delta_y**2)  PyTorch tensors) into NumPy arrays, because NumPy functions don’t work on PyTorch tensors and force a conversion. 

- Eliminating NumPy removes the ndarray boundary that triggered the .pow attribute error and the Dynamo fake-tensor failure. Converted can_bus_list, grid_length, bev_h, and bev_w to torch tensors prevents mismatches during tracing. The computation now remains fully differentiable and traceable, resolving the runtime error and enabling compilation. 

-  Post this change model fails with out of memory error.

### Log
[uniad.log](https://github.com/user-attachments/files/24533524/uniad.log)
