### PR TITLE
Add missing num_layer configs and normalize names

### DIFF
--- a/gemma/pytorch/loader.py
+++ b/gemma/pytorch/loader.py
@@ -66,11 +66,21 @@ class ModelLoader(ForgeModel):
 
     sample_text = "What is your favorite city?"
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
+        """
         super().__init__(variant)
         self.tokenizer = None
         self.seq_len = None
         self.config = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -125,11 +135,17 @@ class ModelLoader(ForgeModel):
         pretrained_model_name = self._variant_config.pretrained_model_name
         if self.tokenizer is None:
             self._load_tokenizer(dtype_override=dtype_override)
-        model_kwargs = {"use_cache": False}
+        model_kwargs = {}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
+
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
         model = AutoModelForCausalLM.from_pretrained(
-            pretrained_model_name, **model_kwargs
+            pretrained_model_name, config=config, **model_kwargs
         )
         model.eval()
         self.model = model

--- a/gpt_neo/causal_lm/pytorch/loader.py
+++ b/gpt_neo/causal_lm/pytorch/loader.py
@@ -50,7 +50,9 @@ class ModelLoader(ForgeModel):
     # Default variant to use
     DEFAULT_VARIANT = ModelVariant.GPT_NEO_125M
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -111,7 +113,9 @@ class ModelLoader(ForgeModel):
         if self.num_layers is not None:
             config.num_hidden_layers = self.num_layers
 
-        model = GPTNeoForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
+        model = GPTNeoForCausalLM.from_pretrained(
+            pretrained_model_name, config=config, **model_kwargs
+        )
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):

--- a/llama/causal_lm/pytorch/loader.py
+++ b/llama/causal_lm/pytorch/loader.py
@@ -136,17 +136,19 @@ class ModelLoader(ForgeModel):
     # Sample text for causal LM
     sample_text = "Hey how are you doing today?"
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
         self.seq_len = None
         self.config = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -239,8 +241,13 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
         model = AutoModelForCausalLM.from_pretrained(
-            pretrained_model_name, **model_kwargs
+            pretrained_model_name, config=config, **model_kwargs
         )
 
         model.eval()

--- a/llama/causal_lm/pytorch/loader.py
+++ b/llama/causal_lm/pytorch/loader.py
@@ -136,7 +136,9 @@ class ModelLoader(ForgeModel):
     # Sample text for causal LM
     sample_text = "Hey how are you doing today?"
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:

--- a/opt/causal_lm/pytorch/loader.py
+++ b/opt/causal_lm/pytorch/loader.py
@@ -52,7 +52,9 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "My name is Thomas and my main"
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -133,7 +135,9 @@ class ModelLoader(ForgeModel):
         if self.num_layers is not None:
             config.num_hidden_layers = self.num_layers
 
-        model = OPTForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
+        model = OPTForCausalLM.from_pretrained(
+            pretrained_model_name, config=config, **model_kwargs
+        )
 
         model.eval()
 

--- a/phi1/causal_lm/pytorch/loader.py
+++ b/phi1/causal_lm/pytorch/loader.py
@@ -23,7 +23,7 @@ from ....config import (
 class ModelVariant(StrEnum):
     """Available PHI1 model variants."""
 
-    PHI1 = "microsoft/phi-1"
+    PHI_1 = "microsoft/phi-1"
 
 
 class ModelLoader(ForgeModel):
@@ -31,14 +31,14 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        ModelVariant.PHI1: LLMModelConfig(
+        ModelVariant.PHI_1: LLMModelConfig(
             pretrained_model_name="microsoft/phi-1",
             max_length=256,
         ),
     }
 
     # Default variant to use
-    DEFAULT_VARIANT = ModelVariant.PHI1
+    DEFAULT_VARIANT = ModelVariant.PHI_1
 
     # Shared configuration parameters
     sample_text = "Africa is an emerging economy because"

--- a/phi1/causal_lm/pytorch/loader.py
+++ b/phi1/causal_lm/pytorch/loader.py
@@ -43,7 +43,9 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Africa is an emerging economy because"
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -125,7 +127,9 @@ class ModelLoader(ForgeModel):
         if self.num_layers is not None:
             config.num_hidden_layers = self.num_layers
 
-        model = PhiForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
+        model = PhiForCausalLM.from_pretrained(
+            pretrained_model_name, config=config, **model_kwargs
+        )
 
         return model
 

--- a/phi1/causal_lm/pytorch/loader.py
+++ b/phi1/causal_lm/pytorch/loader.py
@@ -5,7 +5,7 @@
 PHI1 model loader implementation for causal language modeling.
 """
 import torch
-from transformers import PhiForCausalLM, AutoTokenizer
+from transformers import PhiForCausalLM, AutoTokenizer, AutoConfig
 from typing import Optional
 
 from ....base import ForgeModel
@@ -43,15 +43,17 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Africa is an emerging economy because"
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -118,7 +120,12 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
-        model = PhiForCausalLM.from_pretrained(pretrained_model_name, **model_kwargs)
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
+        model = PhiForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
 
         return model
 

--- a/phi1_5/causal_lm/pytorch/loader.py
+++ b/phi1_5/causal_lm/pytorch/loader.py
@@ -23,7 +23,7 @@ from ....config import (
 class ModelVariant(StrEnum):
     """Available PHI1_5 model variants."""
 
-    PHI1_5 = "microsoft/phi-1_5"
+    PHI_1_5 = "microsoft/phi-1_5"
 
 
 class ModelLoader(ForgeModel):
@@ -31,14 +31,14 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        ModelVariant.PHI1_5: LLMModelConfig(
+        ModelVariant.PHI_1_5: LLMModelConfig(
             pretrained_model_name="microsoft/phi-1_5",
             max_length=256,
         ),
     }
 
     # Default variant to use
-    DEFAULT_VARIANT = ModelVariant.PHI1_5
+    DEFAULT_VARIANT = ModelVariant.PHI_1_5
 
     # Shared configuration parameters
     sample_text = "Africa is an emerging economy because"

--- a/phi1_5/causal_lm/pytorch/loader.py
+++ b/phi1_5/causal_lm/pytorch/loader.py
@@ -5,7 +5,7 @@
 PHI1_5 model loader implementation for causal language modeling.
 """
 import torch
-from transformers import PhiForCausalLM, AutoTokenizer
+from transformers import PhiForCausalLM, AutoTokenizer, AutoConfig
 from typing import Optional
 
 from ....base import ForgeModel
@@ -43,15 +43,17 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Africa is an emerging economy because"
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -118,7 +120,12 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
-        model = PhiForCausalLM.from_pretrained(pretrained_model_name, **model_kwargs)
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
+        model = PhiForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
 
         return model
 

--- a/phi1_5/causal_lm/pytorch/loader.py
+++ b/phi1_5/causal_lm/pytorch/loader.py
@@ -43,7 +43,9 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Africa is an emerging economy because"
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -125,7 +127,9 @@ class ModelLoader(ForgeModel):
         if self.num_layers is not None:
             config.num_hidden_layers = self.num_layers
 
-        model = PhiForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
+        model = PhiForCausalLM.from_pretrained(
+            pretrained_model_name, config=config, **model_kwargs
+        )
 
         return model
 

--- a/phi2/causal_lm/pytorch/loader.py
+++ b/phi2/causal_lm/pytorch/loader.py
@@ -5,7 +5,7 @@
 PHI2 model loader implementation for causal language modeling.
 """
 import torch
-from transformers import PhiForCausalLM, AutoTokenizer
+from transformers import PhiForCausalLM, AutoTokenizer, AutoConfig
 from typing import Optional
 
 from ....base import ForgeModel
@@ -46,15 +46,17 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Write a detailed analogy between mathematics and a lighthouse."
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -128,7 +130,12 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
-        model = PhiForCausalLM.from_pretrained(pretrained_model_name, **model_kwargs)
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name, trust_remote_code=True)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
+        model = PhiForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
 
         return model
 

--- a/phi2/causal_lm/pytorch/loader.py
+++ b/phi2/causal_lm/pytorch/loader.py
@@ -46,7 +46,9 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Write a detailed analogy between mathematics and a lighthouse."
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -131,11 +133,15 @@ class ModelLoader(ForgeModel):
             model_kwargs["torch_dtype"] = dtype_override
 
         # Load config and optionally limit number of hidden layers
-        config = AutoConfig.from_pretrained(pretrained_model_name, trust_remote_code=True)
+        config = AutoConfig.from_pretrained(
+            pretrained_model_name, trust_remote_code=True
+        )
         if self.num_layers is not None:
             config.num_hidden_layers = self.num_layers
 
-        model = PhiForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
+        model = PhiForCausalLM.from_pretrained(
+            pretrained_model_name, config=config, **model_kwargs
+        )
 
         return model
 

--- a/phi2/causal_lm/pytorch/loader.py
+++ b/phi2/causal_lm/pytorch/loader.py
@@ -23,8 +23,8 @@ from ....config import (
 class ModelVariant(StrEnum):
     """Available PHI2 model variants."""
 
-    PHI2 = "microsoft/phi-2"
-    PHI2_PYTDML = "microsoft/phi-2-pytdml"
+    PHI_2 = "microsoft/phi-2"
+    PHI_2_PYTDML = "microsoft/phi-2-pytdml"
 
 
 class ModelLoader(ForgeModel):
@@ -32,16 +32,16 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
-        ModelVariant.PHI2: LLMModelConfig(
+        ModelVariant.PHI_2: LLMModelConfig(
             pretrained_model_name="microsoft/phi-2",
         ),
-        ModelVariant.PHI2_PYTDML: LLMModelConfig(
+        ModelVariant.PHI_2_PYTDML: LLMModelConfig(
             pretrained_model_name="microsoft/phi-2-pytdml",
         ),
     }
 
     # Default variant to use
-    DEFAULT_VARIANT = ModelVariant.PHI2
+    DEFAULT_VARIANT = ModelVariant.PHI_2
 
     # Shared configuration parameters
     sample_text = "Write a detailed analogy between mathematics and a lighthouse."
@@ -72,7 +72,7 @@ class ModelLoader(ForgeModel):
             ModelInfo: Information about the model and variant
         """
         # Determine group and priority based on variant
-        if variant == ModelVariant.PHI2:
+        if variant == ModelVariant.PHI_2:
             group = ModelGroup.RED
         else:
             group = ModelGroup.GENERALITY

--- a/phi3/causal_lm/pytorch/loader.py
+++ b/phi3/causal_lm/pytorch/loader.py
@@ -38,7 +38,9 @@ class ModelLoader(ForgeModel):
 
     DEFAULT_VARIANT = ModelVariant.MINI_128K
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:

--- a/phi3/causal_lm/pytorch/loader.py
+++ b/phi3/causal_lm/pytorch/loader.py
@@ -6,7 +6,7 @@ Phi-3 causal language modeling loader
 """
 from typing import Optional
 
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
 
 from ....config import (
     ModelConfig,
@@ -38,9 +38,17 @@ class ModelLoader(ForgeModel):
 
     DEFAULT_VARIANT = ModelVariant.MINI_128K
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
+        """
         super().__init__(variant)
         self.tokenizer = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -65,8 +73,17 @@ class ModelLoader(ForgeModel):
 
     def load_model(self, dtype_override=None):
         self._ensure_tokenizer()
+
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name, trust_remote_code=True
+        )
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
         model = AutoModelForCausalLM.from_pretrained(
             self._variant_config.pretrained_model_name,
+            config=config,
             trust_remote_code=True,
             use_cache=False,
         )

--- a/phi4/causal_lm/pytorch/loader.py
+++ b/phi4/causal_lm/pytorch/loader.py
@@ -5,7 +5,7 @@
 Phi 4 model loader implementation for causal language modeling
 """
 import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
 from typing import Optional
 
 from ....base import ForgeModel
@@ -39,15 +39,17 @@ class ModelLoader(ForgeModel):
     # Default variant to use
     DEFAULT_VARIANT = ModelVariant.PHI_4
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -112,8 +114,13 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
         model = AutoModelForCausalLM.from_pretrained(
-            pretrained_model_name, use_cache=False, **model_kwargs
+            pretrained_model_name, config=config, use_cache=False, **model_kwargs
         )
         model.eval()
 

--- a/phi4/causal_lm/pytorch/loader.py
+++ b/phi4/causal_lm/pytorch/loader.py
@@ -39,7 +39,9 @@ class ModelLoader(ForgeModel):
     # Default variant to use
     DEFAULT_VARIANT = ModelVariant.PHI_4
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:

--- a/qwen_1_5/causal_lm/pytorch/loader.py
+++ b/qwen_1_5/causal_lm/pytorch/loader.py
@@ -5,7 +5,7 @@
 Qwen 1.5 model loader implementation for causal language modeling.
 """
 import torch
-from transformers import Qwen2ForCausalLM, Qwen2Tokenizer
+from transformers import Qwen2ForCausalLM, Qwen2Tokenizer, AutoConfig
 from typing import Optional
 
 from ....base import ForgeModel
@@ -52,15 +52,17 @@ class ModelLoader(ForgeModel):
         {"role": "user", "content": "Introduce yourself please!"},
     ]
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -130,7 +132,12 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
-        model = Qwen2ForCausalLM.from_pretrained(pretrained_model_name, **model_kwargs)
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
+        model = Qwen2ForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
 
         # Disable DynamicCache
         model._supports_cache_class = False

--- a/qwen_1_5/causal_lm/pytorch/loader.py
+++ b/qwen_1_5/causal_lm/pytorch/loader.py
@@ -52,7 +52,9 @@ class ModelLoader(ForgeModel):
         {"role": "user", "content": "Introduce yourself please!"},
     ]
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -137,7 +139,9 @@ class ModelLoader(ForgeModel):
         if self.num_layers is not None:
             config.num_hidden_layers = self.num_layers
 
-        model = Qwen2ForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
+        model = Qwen2ForCausalLM.from_pretrained(
+            pretrained_model_name, config=config, **model_kwargs
+        )
 
         # Disable DynamicCache
         model._supports_cache_class = False

--- a/qwen_2/causal_lm/pytorch/loader.py
+++ b/qwen_2/causal_lm/pytorch/loader.py
@@ -43,7 +43,9 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Give me a short introduction to large language model."
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:

--- a/qwen_2/causal_lm/pytorch/loader.py
+++ b/qwen_2/causal_lm/pytorch/loader.py
@@ -5,7 +5,7 @@
 Qwen 2 model loader implementation for causal language modeling.
 """
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
 from typing import Optional
 
 from ....base import ForgeModel
@@ -43,15 +43,17 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Give me a short introduction to large language model."
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -116,8 +118,13 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
         model = AutoModelForCausalLM.from_pretrained(
-            pretrained_model_name, **model_kwargs
+            pretrained_model_name, config=config, **model_kwargs
         )
         model.eval()
 

--- a/qwen_2_5/causal_lm/pytorch/loader.py
+++ b/qwen_2_5/causal_lm/pytorch/loader.py
@@ -116,7 +116,9 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Give me a short introduction to large language models."
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -210,7 +212,9 @@ class ModelLoader(ForgeModel):
         if self.num_layers is not None:
             config.num_hidden_layers = self.num_layers
 
-        model = Qwen2ForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
+        model = Qwen2ForCausalLM.from_pretrained(
+            pretrained_model_name, config=config, **model_kwargs
+        )
         model.eval()
 
         self.config = model.config

--- a/qwen_2_5/causal_lm/pytorch/loader.py
+++ b/qwen_2_5/causal_lm/pytorch/loader.py
@@ -116,15 +116,17 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Give me a short introduction to large language models."
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
+        self.num_layers = num_layers
         self.config = None
 
     @classmethod
@@ -203,7 +205,12 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
-        model = Qwen2ForCausalLM.from_pretrained(pretrained_model_name, **model_kwargs)
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
+        model = Qwen2ForCausalLM.from_pretrained(pretrained_model_name, config=config, **model_kwargs)
         model.eval()
 
         self.config = model.config

--- a/qwen_3/causal_lm/pytorch/loader.py
+++ b/qwen_3/causal_lm/pytorch/loader.py
@@ -74,16 +74,18 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Give me a short introduction to large language model."
 
-    def __init__(self, variant: Optional[ModelVariant] = None):
+    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
                      If None, DEFAULT_VARIANT is used.
+            num_layers: Optional number of hidden layers to use. If None, uses the model's default.
         """
         super().__init__(variant)
         self.tokenizer = None
         self.config = None
+        self.num_layers = num_layers
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -148,8 +150,13 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
+        # Load config and optionally limit number of hidden layers
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if self.num_layers is not None:
+            config.num_hidden_layers = self.num_layers
+
         model = AutoModelForCausalLM.from_pretrained(
-            pretrained_model_name, **model_kwargs
+            pretrained_model_name, config=config, **model_kwargs
         ).eval()
 
         self.config = model.config

--- a/qwen_3/causal_lm/pytorch/loader.py
+++ b/qwen_3/causal_lm/pytorch/loader.py
@@ -74,7 +74,9 @@ class ModelLoader(ForgeModel):
     # Shared configuration parameters
     sample_text = "Give me a short introduction to large language model."
 
-    def __init__(self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None):
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
         """Initialize ModelLoader with specified variant.
 
         Args:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-mlir/issues/6222)

### Problem description
To make single block and single layer tests, it would be faster if we load only one-layer models. 

### What's changed
Added missing one-layer loaders and normalizing enums to have format `model_variant_size`

### Checklist
- [ ] Waiting for [this PR](https://github.com/tenstorrent/tt-forge-models/pull/329) to be merged first 
