### PR TITLE
Refactor and reformat falcon_loader.py

### DIFF
--- a/falcon/pytorch/loader.py
+++ b/falcon/pytorch/loader.py
@@ -95,7 +95,7 @@ class ModelLoader(ForgeModel):
         super().__init__(variant)
 
         # Configuration parameters
-        self.input_text_1 = "Write a function to calculate the factorial of a number"
+        self.input_text_1 = "In a shocking discovery, scientists stumbled upon a herd of unicorns living in a remote, unexplored valley in the Andes Mountains. To their astonishment, these unicorns could speak perfect English. Describe the scientists’ reactions, the unicorns’ personalities, and the conversations that unfold between them. Include vivid details of the valley, the unicorns’ appearance, and any surprising or magical behaviors they display."
         self.max_length = 512
         self.tokenizer = None
         self.config = None
@@ -143,7 +143,7 @@ class ModelLoader(ForgeModel):
         if self._variant == ModelVariant.FALCON_7B_INSTRUCT:
             inputs = self.tokenizer(self.input_text_2, return_tensors="pt")
         else:
-            inputs = self.tokenizer.encode(
+            inputs = self.tokenizer(
                 self.input_text_1,
                 add_special_tokens=True,
                 return_tensors="pt",


### PR DESCRIPTION
### Ticket
[1789](https://github.com/tenstorrent/tt-xla/issues/1789)

### Problem description
Debug PCC Drop in **falcon/pytorch-tiiuae/Falcon3-7B-Base** Model

### What's changed
Upon inspecting the [load_inputs](https://github.com/tenstorrent/tt-forge-models/blob/main/falcon/pytorch/loader.py#L146) function, it returns tensor.

While running the model from [Hugging Face](https://huggingface.co/docs/transformers/main/en/model_doc/falcon?usage=transformers+CLI#transformers.FalconModel) in [Google Colab](https://colab.research.google.com/drive/14JhzDBZ1UzEvgo7ZHfQHIbZbd8g1Bpvo?usp=sharing), I observed a difference in the input keys being passed to the model.

The following keys are being sent to the model: ['input_ids', 'token_type_ids', 'attention_mask']

Edited the load_inputs function to use self.tokenizer instead of self.tokenizer.encode, ensuring the correct input keys are produced.
Updated the function with a larger prompt based on @kmabeeTT  suggestion.
After updating the prompt, the results are as follows:

| Varient_name | Pcc |
|--------|--------|
| Falcon3-1B-Base | 0.9992534538010508 |
| Falcon3-3B-Base | 0.9993098802664383 |
| Falcon3-7B-Base | 0.9983628578962351 | 
| Falcon3-10B-Base | 0.9986492302786513 | 

Logs:
[falcon3_1b.log](https://github.com/user-attachments/files/24559399/falcon3_1b.log)
[falcon3_3b.log](https://github.com/user-attachments/files/24559401/falcon3_3b.log)
[falcon3_7b.log](https://github.com/user-attachments/files/24559402/falcon3_7b.log)
[falcon3_10b.log](https://github.com/user-attachments/files/24559403/falcon3_10b.log)



### Checklist
- [ ] New/Existing tests provide coverage for changes
