### PR TITLE
Fix Torch Dynamo Failure in VADv2 and SSR Model

### DIFF
--- a/ssr/pytorch/loader.py
+++ b/ssr/pytorch/loader.py
@@ -62,8 +62,6 @@ class ModelLoader(ForgeModel):
 
     def load_inputs(self, **kwargs):
         """Return sample inputs for the SSR model with default settings."""
-        torch.manual_seed(42)
-        np.random.seed(42)
 
         img_norm_cfg = {
             "mean": np.array([123.675, 116.28, 103.53], dtype=np.float32),

--- a/vadv2/pytorch/src/transformer.py
+++ b/vadv2/pytorch/src/transformer.py
@@ -95,7 +95,7 @@ class VADPerceptionTransformer(nn.Module):
         if self.can_bus_norm:
             self.can_bus_mlp.add_module("norm", nn.LayerNorm(self.embed_dims))
 
-    # TODO apply fp16 to this module cause grad_norm NAN
+    # # TODO apply fp16 to this module cause grad_norm NAN
     def get_bev_features(
         self,
         mlvl_feats,
@@ -115,57 +115,80 @@ class VADPerceptionTransformer(nn.Module):
         bev_queries = bev_queries.unsqueeze(1).repeat(1, bs, 1)
         bev_pos = bev_pos.flatten(2).permute(2, 0, 1)
 
-        # obtain rotation angle and shift with ego motion
-        delta_x = np.array([each["can_bus"][0] for each in kwargs["img_metas"]])
-        delta_y = np.array([each["can_bus"][1] for each in kwargs["img_metas"]])
-        ego_angle = np.array(
-            [each["can_bus"][-2] / np.pi * 180 for each in kwargs["img_metas"]]
+        device = bev_queries.device
+        dtype = bev_queries.dtype
+
+        delta_x = torch.tensor(
+            [each["can_bus"][0] for each in kwargs["img_metas"]],
+            device=device,
+            dtype=dtype,
         )
+
+        delta_y = torch.tensor(
+            [each["can_bus"][1] for each in kwargs["img_metas"]],
+            device=device,
+            dtype=dtype,
+        )
+
+        ego_angle = (
+            torch.tensor(
+                [each["can_bus"][-2] for each in kwargs["img_metas"]],
+                device=device,
+                dtype=dtype,
+            )
+            * 180.0
+            / torch.pi
+        )
+
         grid_length_y = grid_length[0]
         grid_length_x = grid_length[1]
-        translation_length = np.sqrt(delta_x**2 + delta_y**2)
-        translation_angle = np.arctan2(delta_y, delta_x) / np.pi * 180
+
+        translation_length = torch.sqrt(delta_x**2 + delta_y**2)
+        translation_angle = torch.atan2(delta_y, delta_x) * 180.0 / torch.pi
         bev_angle = ego_angle - translation_angle
+
         shift_y = (
-            translation_length * np.cos(bev_angle / 180 * np.pi) / grid_length_y / bev_h
+            translation_length
+            * torch.cos(bev_angle * torch.pi / 180.0)
+            / grid_length_y
+            / bev_h
         )
+
         shift_x = (
-            translation_length * np.sin(bev_angle / 180 * np.pi) / grid_length_x / bev_w
+            translation_length
+            * torch.sin(bev_angle * torch.pi / 180.0)
+            / grid_length_x
+            / bev_w
         )
+
         shift_y = shift_y * self.use_shift
         shift_x = shift_x * self.use_shift
-        # shift = bev_queries.new_tensor([shift_x, shift_y]).permute(
-        #     1, 0
-        # )  # xy, bs -> bs, xy
-        shift_x = torch.as_tensor(shift_x, dtype=bev_queries.dtype)
-        shift_y = torch.as_tensor(shift_y, dtype=bev_queries.dtype)
+
         shift = torch.stack([shift_x, shift_y], dim=0).permute(1, 0)
 
         if prev_bev is not None:
             if prev_bev.shape[1] == bev_h * bev_w:
                 prev_bev = prev_bev.permute(1, 0, 2)
+
             if self.rotate_prev_bev:
                 for i in range(bs):
-                    # num_prev_bev = prev_bev.size(1)
                     rotation_angle = kwargs["img_metas"][i]["can_bus"][-1]
                     tmp_prev_bev = (
                         prev_bev[:, i].reshape(bev_h, bev_w, -1).permute(2, 0, 1)
                     )
                     tmp_prev_bev = rotate(
-                        tmp_prev_bev, rotation_angle, center=self.rotate_center
+                        tmp_prev_bev,
+                        rotation_angle,
+                        center=self.rotate_center,
                     )
                     tmp_prev_bev = tmp_prev_bev.permute(1, 2, 0).reshape(
                         bev_h * bev_w, 1, -1
                     )
                     prev_bev[:, i] = tmp_prev_bev[:, 0]
 
-        # add can bus signals
-        # can_bus = bev_queries.new_tensor(
-        #     [each["can_bus"] for each in kwargs["img_metas"]]
-        # )  # [:, :]
         can_bus = torch.stack(
             [
-                torch.as_tensor(each["can_bus"], dtype=bev_queries.dtype)
+                torch.as_tensor(each["can_bus"], device=device, dtype=dtype)
                 for each in kwargs["img_metas"]
             ],
             dim=0,
@@ -175,26 +198,35 @@ class VADPerceptionTransformer(nn.Module):
 
         feat_flatten = []
         spatial_shapes = []
+
         for lvl, feat in enumerate(mlvl_feats):
             bs, num_cam, c, h, w = feat.shape
             spatial_shape = (h, w)
             feat = feat.flatten(3).permute(1, 0, 3, 2)
+
             if self.use_cams_embeds:
                 feat = feat + self.cams_embeds[:, None, None, :]
+
             feat = feat + self.level_embeds[None, None, lvl : lvl + 1, :]
             spatial_shapes.append(spatial_shape)
             feat_flatten.append(feat)
 
         feat_flatten = torch.cat(feat_flatten, 2)
-        spatial_shapes = torch.as_tensor(spatial_shapes)
+        spatial_shapes = torch.as_tensor(spatial_shapes, device=device)
         level_start_index = torch.cat(
-            (spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1])
+            (
+                spatial_shapes.new_zeros((1,)),
+                spatial_shapes.prod(1).cumsum(0)[:-1],
+            )
         )
 
         feat_flatten = feat_flatten.permute(
             0, 2, 1, 3
         )  # (num_cam, H*W, bs, embed_dims)
 
+        # ------------------------------------------------------------
+        # BEV encoder
+        # ------------------------------------------------------------
         bev_embed = self.encoder(
             bev_queries,
             feat_flatten,


### PR DESCRIPTION
### Ticket

Fixes[ #2755](https://github.com/tenstorrent/tt-xla/issues/2755) and [#2756](https://github.com/tenstorrent/tt-xla/issues/2756)

### Problem description
VADv2 model fails with below error:

```
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <Wrapped method <original pow>>(*(FakeTensor(..., size=(1,)), 2), **{}): got AttributeError("'ndarray' object has no attribute 'pow'")
```
and SSR Model fails with 

```
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <Wrapped method <original div>>(*(FakeTensor(..., size=(), dtype=torch.float64), 3.141592653589793), **{}): got AttributeError("'ndarray' object has no attribute 'div'")
```

### What's changed

-  Made modifications in get_bev_features function to replace all numpy ops with torch ops with right device and dtype. All numpy math has been converted to torch math to get rid of the attribute error.  Following this, model failed with numpy related attribute errors from various parts of models, all these parts were converted to equivalent torch ops. After all changes, model was tested to verify that there is no deviation in final results from original results. Post these changes, model was failing with out of memory error. SSR Model was fixed by converting problematic areas causing attribute errors to entirely torch ops which was failing with out of memory as well finally.

### Log
[vadv2.log](https://github.com/user-attachments/files/24580209/vadv2_eval_single_col_final_oom.log)
[ssr.log](https://github.com/user-attachments/files/24580213/ssr_oom.log)
