### PR TITLE
Handle list outputs in BERT output postprocessing

### DIFF
--- a/bert/sentence_embedding_generation/pytorch/loader.py
+++ b/bert/sentence_embedding_generation/pytorch/loader.py
@@ -183,7 +183,7 @@ class ModelLoader(ForgeModel):
         attention_mask = inputs["attention_mask"]
 
         # Extract token embeddings from outputs
-        if isinstance(output, tuple):
+        if isinstance(output, (tuple, list)):
             token_embeddings = output[0]  # Last hidden state
         elif hasattr(output, "last_hidden_state"):
             # Handle BaseModelOutput or similar


### PR DESCRIPTION
## Summary

This PR fixes a bug in the BERT sentence embedding generation loader where the `output_postprocess` function failed to properly handle list-type model outputs, causing the bert demo test cases to fail in CI pipelines - https://github.com/tenstorrent/tt-forge/actions/runs/20908146782/job/60065697967.

## Problem

The bert demo test case for `sentence_embedding_generation` (specifically `EMRECAN_BERT_BASE_TURKISH_CASED_MEAN_NLI_STSB_TR` variant) was failing in the CI pipeline with the following error:

```
AttributeError: 'list' object has no attribute 'size'
```

**Error Trace:**
```
File "/__w/tt-forge/tt-forge/demos/tt-forge-fe/nlp/bert_demo.py", line 51, in run_bert_demo_case
    loader.decode_output(output)
File "/__w/tt-forge/tt-forge/third_party/tt_forge_models/bert/sentence_embedding_generation/pytorch/loader.py", line 215, in decode_output
    return self.output_postprocess(outputs, inputs=inputs)
File "/__w/tt-forge/tt-forge/third_party/tt_forge_models/bert/sentence_embedding_generation/pytorch/loader.py", line 197, in output_postprocess
    attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
AttributeError: 'list' object has no attribute 'size'
```

## Solution

Updated the `output_postprocess` function in `third_party/tt_forge_models/bert/sentence_embedding_generation/pytorch/loader.py` to properly handle both list and tuple outputs when extracting token embeddings. 