### PR TITLE
refactor uniad and vadv2 model to support tt-inference server

### DIFF
--- a/uniad/pytorch/loader.py
+++ b/uniad/pytorch/loader.py
@@ -4,11 +4,32 @@
 """
 UniAD model loader implementation
 """
-import torch
+
 from typing import Optional
+from dataclasses import dataclass
+import torch
+
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
 from ...base import ForgeModel
-from ...config import ModelGroup, ModelTask, ModelSource, Framework, StrEnum, ModelInfo
 from ...tools.utils import get_file
+
+
+@dataclass
+class UniadConfig(ModelConfig):
+    """Configuration specific to UniAD models"""
+
+    checkpoint_file: str
+    img_shape: tuple = (928, 1600)  # (height, width)
+    num_cameras: int = 6
+    num_channels: int = 3
 
 
 class ModelVariant(StrEnum):
@@ -20,10 +41,21 @@ class ModelVariant(StrEnum):
 class ModelLoader(ForgeModel):
     """UniAD model loader implementation for autonomous driving tasks."""
 
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.UNIAD_E2E: UniadConfig(
+            pretrained_model_name="uniad_e2e",
+            checkpoint_file="test_files/pytorch/uniad/uniad_e2e.pth",
+            img_shape=(928, 1600),
+            num_cameras=6,
+            num_channels=3,
+        ),
+    }
+
     # Default variant to use
     DEFAULT_VARIANT = ModelVariant.UNIAD_E2E
 
-    def __init__(self, variant=None):
+    def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -31,12 +63,11 @@ class ModelLoader(ForgeModel):
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
-        # Configuration parameters
-        self.processor = None
+        self.model = None
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
-        """Implementation method for getting model info with validated variant.
+        """Get model information for dashboard and metrics reporting.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
@@ -45,6 +76,8 @@ class ModelLoader(ForgeModel):
         Returns:
             ModelInfo: Information about the model and variant
         """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
 
         return ModelInfo(
             model="uniad",
@@ -55,56 +88,87 @@ class ModelLoader(ForgeModel):
             framework=Framework.TORCH,
         )
 
-    def load_model(self, **kwargs):
-        """Load and return the UniAD model instance with default settings.
+    def load_model(self, dtype_override=None):
+        """Load and return the UniAD model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
 
         Returns:
-            Torch model: The UniAD model instance.
+            torch.nn.Module: The UniAD model instance.
         """
-        # Load model with defaults
+        # Import model class
         from third_party.tt_forge_models.uniad.pytorch.src.uniad_e2e import UniAD
 
+        # Get checkpoint file from the instance's variant config
+        checkpoint_file = self._variant_config.checkpoint_file
+
+        # Load model
         model = UniAD()
-        checkpoint_path = get_file("test_files/pytorch/uniad/uniad_e2e.pth")
+        checkpoint_path = get_file(checkpoint_file)
         checkpoint = torch.load(checkpoint_path, map_location="cpu")
         model.load_state_dict(
             checkpoint["state_dict"] if "state_dict" in checkpoint else checkpoint,
             strict=False,
         )
+        model.eval()
+
+        # Store model for potential use in input preprocessing
+        self.model = model
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
         return model
 
-    def load_inputs(self, **kwargs):
-        """Return sample inputs for the UniAD model with default settings.
+    def input_preprocess(self, dtype_override=None, **kwargs):
+        """Preprocess inputs and return model-ready input dictionary.
+
+        Args:
+            dtype_override: Optional torch.dtype override (default: float32).
+            **kwargs: Additional keyword arguments (unused, for compatibility).
 
         Returns:
-            dict: A dictionary of input tensors and metadata suitable for the model.
+            dict: A dictionary of preprocessed input tensors and metadata suitable for the model.
         """
         from third_party.tt_forge_models.uniad.pytorch.src.track_utils import (
             LiDARInstance3DBoxes,
         )
 
-        img_tensor = img_tensor = [
-            torch.randn(1, 6, 3, 928, 1600, dtype=torch.float32) * 50
+        # Get configuration from variant config
+        img_h, img_w = self._variant_config.img_shape
+        num_cameras = self._variant_config.num_cameras
+        num_channels = self._variant_config.num_channels
+
+        # Determine dtype
+        dtype = dtype_override if dtype_override is not None else torch.float32
+
+        # Create input tensors
+        img_tensor = [
+            torch.randn(1, num_cameras, num_channels, img_h, img_w, dtype=dtype) * 50
         ]
         img_metas = [
             [
                 {
-                    "ori_shape": [(900, 1600, 3)] * 6,
-                    "img_shape": [(928, 1600, 3)] * 6,
+                    "ori_shape": [(900, img_w, num_channels)] * num_cameras,
+                    "img_shape": [(img_h, img_w, num_channels)] * num_cameras,
                     "lidar2img": [
-                        torch.randn(4, 4, dtype=torch.float32) * 500 for _ in range(6)
+                        torch.randn(4, 4, dtype=dtype) * 500
+                        for _ in range(num_cameras)
                     ],
                     "box_type_3d": LiDARInstance3DBoxes,
                     "sample_idx": "3e8750f331d7499e9b5123e9eb70f2e2",
                     "scene_token": "fcbccedd61424f1b85dcbf8f897f9754",
-                    "can_bus": torch.randn(18, dtype=torch.float32) * 300,
+                    "can_bus": torch.randn(18, dtype=dtype) * 300,
                 }
             ]
         ]
 
-        timestamp = [torch.tensor([1533151603.5476])]
-        l2g_r_mat = torch.randn(1, 3, 3)
-        l2g_t = torch.randn(1, 3) * 800
+        timestamp = [torch.tensor([1533151603.5476], dtype=dtype)]
+        l2g_r_mat = torch.randn(1, 3, 3, dtype=dtype)
+        l2g_t = torch.randn(1, 3, dtype=dtype) * 800
 
         gt_lane_labels = [torch.randint(0, 4, (1, 12))]
         gt_lane_bboxes = [torch.randint(0, 200, (1, 12, 4))]
@@ -119,11 +183,11 @@ class ModelLoader(ForgeModel):
         gt_occ_has_invalid_frame = [torch.ones((1,), dtype=torch.long)]
         gt_occ_img_is_valid = [torch.randint(0, 2, (1, 9))]
 
-        sdc_planning = [torch.rand(1, 1, 6, 3) * 25]
-        sdc_planning_mask = [torch.ones(1, 1, 6, 2)]
+        sdc_planning = [torch.rand(1, 1, 6, 3, dtype=dtype) * 25]
+        sdc_planning_mask = [torch.ones(1, 1, 6, 2, dtype=dtype)]
         command = [torch.tensor([0])]
 
-        kwargs = {
+        inputs = {
             "command": command,
             "gt_backward_flow": gt_backward_flow,
             "gt_centerness": gt_centerness,
@@ -146,4 +210,19 @@ class ModelLoader(ForgeModel):
             "timestamp": timestamp,
         }
 
-        return kwargs
+        return inputs
+
+    def load_inputs(self, dtype_override=None, **kwargs):
+        """Load and return sample inputs for the model.
+
+        Args:
+            dtype_override: Optional torch.dtype override.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            dict: A dictionary of input tensors and metadata suitable for the model.
+        """
+        return self.input_preprocess(dtype_override=dtype_override, **kwargs)
+
+    def output_postprocess(self, output):
+        return output

--- a/vadv2/pytorch/loader.py
+++ b/vadv2/pytorch/loader.py
@@ -4,14 +4,36 @@
 """
 Vadv2 model loader implementation
 """
+
+from typing import Optional
+from dataclasses import dataclass
 import torch
 import numpy as np
-from typing import Optional
+
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
 from ...base import ForgeModel
-from ...config import ModelGroup, ModelTask, ModelSource, Framework, StrEnum, ModelInfo
 from ...tools.utils import get_file
-from third_party.tt_forge_models.vadv2.pytorch.src.vad import VAD
-from third_party.tt_forge_models.vadv2.pytorch.src.dataset import LiDARInstance3DBoxes
+
+
+@dataclass
+class Vadv2Config(ModelConfig):
+    """Configuration specific to Vadv2 models"""
+
+    checkpoint_file: str
+    img_shape: tuple = (384, 640)  # (height, width)
+    ori_shape: tuple = (360, 640)  # Original shape before padding
+    num_cameras: int = 6
+    num_channels: int = 3
+    num_boxes: int = 11
+    box_dim: int = 9
 
 
 class ModelVariant(StrEnum):
@@ -23,10 +45,24 @@ class ModelVariant(StrEnum):
 class ModelLoader(ForgeModel):
     """Vadv2 model loader implementation for autonomous driving tasks."""
 
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.VADV2_TINY: Vadv2Config(
+            pretrained_model_name="vadv2_tiny",
+            checkpoint_file="test_files/pytorch/vadv2/vadv2_tiny.pth",
+            img_shape=(384, 640),
+            ori_shape=(360, 640),
+            num_cameras=6,
+            num_channels=3,
+            num_boxes=11,
+            box_dim=9,
+        ),
+    }
+
     # Default variant to use
     DEFAULT_VARIANT = ModelVariant.VADV2_TINY
 
-    def __init__(self, variant=None):
+    def __init__(self, variant: Optional[ModelVariant] = None):
         """Initialize ModelLoader with specified variant.
 
         Args:
@@ -34,12 +70,11 @@ class ModelLoader(ForgeModel):
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
-        # Configuration parameters
-        self.processor = None
+        self.model = None
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
-        """Implementation method for getting model info with validated variant.
+        """Get model information for dashboard and metrics reporting.
 
         Args:
             variant: Optional ModelVariant specifying which variant to use.
@@ -48,6 +83,8 @@ class ModelLoader(ForgeModel):
         Returns:
             ModelInfo: Information about the model and variant
         """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
 
         return ModelInfo(
             model="vadv2",
@@ -58,39 +95,78 @@ class ModelLoader(ForgeModel):
             framework=Framework.TORCH,
         )
 
-    def load_model(self, **kwargs):
-        """Load and return the Vadv2 model instance with default settings.
+    def load_model(self, dtype_override=None):
+        """Load and return the Vadv2 model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
 
         Returns:
-            Torch model: The Vadv2 model instance.
+            torch.nn.Module: The Vadv2 model instance.
         """
-        # Load model with defaults
+        # Import model class
+        from third_party.tt_forge_models.vadv2.pytorch.src.vad import VAD
+
+        # Get checkpoint file from the instance's variant config
+        checkpoint_file = self._variant_config.checkpoint_file
+
+        # Load model
         model = VAD()
-        checkpoint_path = get_file("test_files/pytorch/vadv2/vadv2_tiny.pth")
+        checkpoint_path = get_file(checkpoint_file)
         checkpoint = torch.load(checkpoint_path, map_location="cpu")
         model.load_state_dict(
             checkpoint["state_dict"] if "state_dict" in checkpoint else checkpoint,
             strict=False,
         )
+        model.eval()
+
+        # Store model for potential use in input preprocessing
+        self.model = model
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
         return model
 
-    def load_inputs(self, **kwargs):
-        """Return sample inputs for the Vadv2 model with default settings.
+    def input_preprocess(self, dtype_override=None, **kwargs):
+        """Preprocess inputs and return model-ready input dictionary.
+
+        Args:
+            dtype_override: Optional torch.dtype override (default: float32).
+            **kwargs: Additional keyword arguments (unused, for compatibility).
 
         Returns:
-            dict: A dictionary of input tensors and metadata suitable for the model.
+            dict: A dictionary of preprocessed input tensors and metadata suitable for the model.
         """
+        from third_party.tt_forge_models.vadv2.pytorch.src.dataset import (
+            LiDARInstance3DBoxes,
+        )
+
+        # Get configuration from variant config
+        img_h, img_w = self._variant_config.img_shape
+        ori_h, ori_w = self._variant_config.ori_shape
+        num_cameras = self._variant_config.num_cameras
+        num_channels = self._variant_config.num_channels
+        num_boxes = self._variant_config.num_boxes
+        box_dim = self._variant_config.box_dim
+
+        # Determine dtype
+        dtype = dtype_override if dtype_override is not None else torch.float32
+
+        # Create input dictionary
         input_dict = {
             "img_metas": [
                 [
                     [
                         {
-                            "ori_shape": [(360, 640, 3)] * 6,
-                            "img_shape": [(384, 640, 3)] * 6,
+                            "ori_shape": [(ori_h, ori_w, num_channels)] * num_cameras,
+                            "img_shape": [(img_h, img_w, num_channels)] * num_cameras,
                             "lidar2img": [
-                                torch.rand(4, 4) * 6,
+                                torch.rand(4, 4, dtype=dtype) * 6,
                             ],
-                            "pad_shape": [(384, 640, 3)] * 6,
+                            "pad_shape": [(img_h, img_w, num_channels)] * num_cameras,
                             "scale_factor": 1.0,
                             "flip": False,
                             "pcd_horizontal_flip": False,
@@ -111,7 +187,7 @@ class ModelLoader(ForgeModel):
                             "pcd_scale_factor": 1.0,
                             "pts_filename": "data/pcd.bin",
                             "scene_token": "fcbccedd61424f1b85dcbf8f897f9754",
-                            "can_bus": torch.rand(18),
+                            "can_bus": torch.rand(18, dtype=dtype),
                         }
                     ]
                 ]
@@ -120,28 +196,33 @@ class ModelLoader(ForgeModel):
                 [
                     [
                         LiDARInstance3DBoxes(
-                            torch.rand(11, 9),
-                            box_dim=9,
+                            torch.rand(num_boxes, box_dim, dtype=dtype),
+                            box_dim=box_dim,
                         )
                     ]
                 ]
             ],
             "gt_labels_3d": [[[torch.tensor([8, 8, 8, 8, 8, 8, 0, 8, 8, 0, 8])]]],
             "fut_valid_flag": [torch.tensor([True])],
-            "ego_his_trajs": [[torch.tensor([[[[0.0757, 4.2529], [0.0757, 4.2529]]]])]],
-            "ego_fut_trajs": [[torch.zeros((1, 1, 6, 2))]],
-            "ego_fut_masks": [[torch.ones((1, 1, 6))]],
-            "ego_fut_cmd": [[torch.tensor([[[[1.0, 0.0, 0.0]]]])]],
-            "ego_lcf_feat": [[torch.zeros((1, 1, 1, 9))]],
-            "gt_attr_labels": [[[torch.rand(11, 34)]]],
-            "map_gt_labels_3d": [[torch.zeros((7,))]],
+            "ego_his_trajs": [
+                [torch.tensor([[[[0.0757, 4.2529], [0.0757, 4.2529]]]], dtype=dtype)]
+            ],
+            "ego_fut_trajs": [[torch.zeros((1, 1, 6, 2), dtype=dtype)]],
+            "ego_fut_masks": [[torch.ones((1, 1, 6), dtype=dtype)]],
+            "ego_fut_cmd": [[torch.tensor([[[[1.0, 0.0, 0.0]]]], dtype=dtype)]],
+            "ego_lcf_feat": [[torch.zeros((1, 1, 1, 9), dtype=dtype)]],
+            "gt_attr_labels": [[[torch.rand(num_boxes, 34, dtype=dtype)]]],
+            "map_gt_labels_3d": [[torch.zeros((7,), dtype=dtype)]],
             "map_gt_bboxes_3d": [[None]],
         }
-        tensor = torch.randn(1, 6, 3, 384, 640)
-        img1 = []
-        img1.append(tensor)
-        kwargs = {
-            "img": img1,
+
+        # Create image tensor
+        tensor = torch.randn(1, num_cameras, num_channels, img_h, img_w, dtype=dtype)
+        img = [tensor]
+
+        # Build inputs dictionary
+        inputs = {
+            "img": img,
             "img_metas": input_dict["img_metas"],
             "gt_bboxes_3d": input_dict["gt_bboxes_3d"],
             "gt_labels_3d": input_dict["gt_labels_3d"],
@@ -153,4 +234,19 @@ class ModelLoader(ForgeModel):
             "gt_attr_labels": input_dict["gt_attr_labels"],
         }
 
-        return kwargs
+        return inputs
+
+    def load_inputs(self, dtype_override=None, **kwargs):
+        """Load and return sample inputs for the model.
+
+        Args:
+            dtype_override: Optional torch.dtype override.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            dict: A dictionary of input tensors and metadata suitable for the model.
+        """
+        return self.input_preprocess(dtype_override=dtype_override, **kwargs)
+
+    def output_postprocess(self, output):
+        return output


### PR DESCRIPTION
### Ticket
[Github Issue](https://github.com/tenstorrent/tt-xla/issues/2062)

### Problem description
Added a common preprocessor and postprocessor for Uniad and VadV2 model

### What's changed
Modified  Deit models to support inference server

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_uniad_single_device_inference.log](https://github.com/user-attachments/files/24578506/test_uniad_single_device_inference.log)
[test_vadv2_single_device_inference.log](https://github.com/user-attachments/files/24578507/test_vadv2_single_device_inference.log)
