### PR TITLE
Changes needed for torch 2.9.0 and transformers 4.57.1 updates

### DIFF
--- a/fuyu/pytorch/loader.py
+++ b/fuyu/pytorch/loader.py
@@ -209,7 +209,7 @@ class ModelLoader(ForgeModel):
         inputs_embeds = generate_fuyu_embedding(
             self.model,
             model_inputs["input_ids"],
-            model_inputs["image_patches"][0],
+            model_inputs["image_patches"],
             model_inputs["image_patches_indices"],
         )
         inputs_embeds = inputs_embeds.clone().detach()

--- a/gemma/codegemma/pytorch/loader.py
+++ b/gemma/codegemma/pytorch/loader.py
@@ -133,6 +133,7 @@ def calculate_age(birth_year):
             self._load_tokenizer(dtype_override=dtype_override)
 
         input_prompt = prompt or self.sample_text
+        self.tokenizer.padding_side = "right"
         inputs = self.tokenizer(
             input_prompt,
             return_tensors="pt",
@@ -147,11 +148,5 @@ def calculate_age(birth_year):
         if dtype_override is not None:
             for key in inputs:
                 inputs[key] = cast_input_to_type(inputs[key], dtype_override)
-
-        padded_input_ids, seq_len = pad_inputs(inputs["input_ids"], max_new_tokens)
-        padded_attention_mask, _ = pad_inputs(inputs["attention_mask"], max_new_tokens)
-        self.seq_len = seq_len
-        inputs["input_ids"] = padded_input_ids
-        inputs["attention_mask"] = padded_attention_mask
 
         return inputs

--- a/gemma/pytorch/loader.py
+++ b/gemma/pytorch/loader.py
@@ -151,6 +151,7 @@ class ModelLoader(ForgeModel):
         max_length = self._variant_config.max_length
         if self.tokenizer is None:
             self._load_tokenizer(dtype_override=dtype_override)
+        self.tokenizer.padding_side = "right"
         if self._variant == ModelVariant.GEMMA_2B:
             input_prompt = prompt or self.sample_text
             inputs = self.tokenizer(
@@ -183,13 +184,6 @@ class ModelLoader(ForgeModel):
             if dtype_override is not None:
                 for key in inputs:
                     inputs[key] = cast_input_to_type(inputs[key], dtype_override)
-            padded_input_ids, seq_len = pad_inputs(inputs["input_ids"], max_new_tokens)
-            padded_attention_mask, _ = pad_inputs(
-                inputs["attention_mask"], max_new_tokens
-            )
-            self.seq_len = seq_len
-            inputs["input_ids"] = padded_input_ids
-            inputs["attention_mask"] = padded_attention_mask
         return inputs
 
     def get_mesh_config(self, num_devices: int):

--- a/gpt2/pytorch/loader.py
+++ b/gpt2/pytorch/loader.py
@@ -91,7 +91,7 @@ class ModelLoader(ForgeModel):
         if self._variant == ModelVariant.GPT2_BASE:
             config = GPT2Config.from_pretrained(model_name)
             config_dict = config.to_dict()
-            config_dict["use_cache"] = False
+            config_dict["use_cache"] = True
             if dtype_override is not None:
                 config_dict["torch_dtype"] = dtype_override
             config = GPT2Config(**config_dict)

--- a/huggyllama/pytorch/loader.py
+++ b/huggyllama/pytorch/loader.py
@@ -137,6 +137,7 @@ class ModelLoader(ForgeModel):
         test_input = "This is a sample text from "
 
         # Tokenize input
+        self.tokenizer.padding_side = "right"
         inputs = self.tokenizer.encode_plus(
             test_input,
             return_tensors="pt",

--- a/minicpm_o_2_6/pytorch/loader.py
+++ b/minicpm_o_2_6/pytorch/loader.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 from transformers import AutoModel, AutoTokenizer
-from transformers.modeling_utils import ALL_PARALLEL_STYLES
+from transformers.integrations.tensor_parallel import ALL_PARALLEL_STYLES
 from PIL import Image
 import requests
 from io import BytesIO

--- a/openvla/pytorch/src/modeling_prismatic.py
+++ b/openvla/pytorch/src/modeling_prismatic.py
@@ -474,6 +474,8 @@ class PrismaticForConditionalGeneration(PrismaticPreTrainedModel):
 class OpenVLAForActionPrediction(PrismaticForConditionalGeneration):
     config_class: PretrainedConfig = OpenVLAConfig
 
+    _supports_sdpa: bool = True
+
     def __init__(self, config: OpenVLAConfig) -> None:
         super().__init__(config)
         self.norm_stats = config.norm_stats
@@ -482,3 +484,9 @@ class OpenVLAForActionPrediction(PrismaticForConditionalGeneration):
         self.vocab_size = (
             self.config.text_config.vocab_size - self.config.pad_to_multiple_of
         )
+
+    @property
+    def _supports_sdpa(self) -> bool:
+        if hasattr(self, "language_model"):
+            return self.language_model._supports_sdpa
+        return True  # Default value during initialization

--- a/whisper/audio_classification/jax/requirements.txt
+++ b/whisper/audio_classification/jax/requirements.txt
@@ -3,6 +3,5 @@ datasets
 soundfile
 librosa
 
-# Override system-wide torchcodec - version 0.5 is compatible with PyTorch 2.7
-# Note: torchcodec 0.8+ has issues with FFmpeg 4.x and PyTorch 2.7
-torchcodec==0.5
+# Override system-wide torchcodec - version 0.8 is compatible with PyTorch 2.9
+torchcodec==0.8


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1020

### Problem description
tt-xla is updating the transformers library to 4.57.1 and torch to 2.9.0, we need to make changes on how we load some of the transformers models based on the updated in the library since our last update

### What's changed
1. Transformers changed how they process text/image inputs for Fuyu models, so we don't longer need to `model_inputs["image_patches"][0]`
2. Transformers changed the location of the `ALL_PARALLEL_STYLES` global variable
3. New transformers cache logic causing SEGFAULT issues if the model uses sliding window attention, and sliding window causing recompilation of ministral decode graph on each iteration. Changed to full attention.
4. Force padding to `right` by default.
5. _supports_sdpa is not set by default before `__init__` so we need to add property for OpenVLA loader
6. whisper requirements uplifted to torchcodec==0.8 to match compatibility with torch==2.9.0
7. gemma model drops pcc when padding inputs, removing it from input loader

### Checklist
- [x] New/Existing tests provide coverage for changes