### PR TITLE
Remove return_dict=False to keep model outputs to its intended type

### DIFF
--- a/yolos_small/pytorch/loader.py
+++ b/yolos_small/pytorch/loader.py
@@ -122,8 +122,7 @@ class ModelLoader(ForgeModel):
         # Get the pretrained model name from the instance's variant config
         pretrained_model_name = self._variant_config.pretrained_model_name
 
-        model_kwargs = {"return_dict": False}
-
+        model_kwargs = {}
         # Load the model with dtype override if specified
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We see the following error in tt-xla for yolo_small model:
```
E AttributeError: 'tuple' object has no attribute 'last_hidden_state'
```
Some models have been updated in transformers to force a data type for their forward() functions. i.e. `outputs: BaseModelOutputWithPooling = self.model( ... )`. But, for the `yolo_small` models we had set return_dict=False and it is passed to Model.forward, overwriting the return type and converting the output to a tuple.

### What's changed
remove return_dict=False from yolo_small model loader

### Checklist
- [x] New/Existing tests provide coverage for changes
