### PR TITLE
Restore deit load_inputs function

### DIFF
--- a/deit/pytorch/loader.py
+++ b/deit/pytorch/loader.py
@@ -182,6 +182,22 @@ class ModelLoader(ForgeModel):
             model_for_config=model_for_config,
         )
 
+    def load_inputs(self, dtype_override=None, batch_size=1, image=None):
+        """Load and return sample inputs for the model.
+        Args:
+            dtype_override: Optional torch.dtype override.
+            batch_size: Batch size (default: 1).
+            image: Optional input image.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor.
+        """
+        return self.input_preprocess(
+            image=image,
+            dtype_override=dtype_override,
+            batch_size=batch_size,
+        )
+
     def output_postprocess(
         self,
         output=None,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
A refactor of the deit model loader for tt-inference servers removed the `load_inputs` function which is needed to instantiate the ModelLoader. Trying to run the deit model in tt-xla results in the following error:
```
E           TypeError: Can't instantiate abstract class ModelLoader with abstract method load_inputs
```

### What's changed
Added a `load_inputs` function following the format of other model loaders that have been refactored for tt-inference servers. Tested locally and deit is now passing through tt-xla.

### Checklist
- [x] New/Existing tests provide coverage for changes
