### PR TITLE
Bringup olmo3 pytorch model

### DIFF
--- a/Olmo3/causal_lm/pytorch/__init__.py
+++ b/Olmo3/causal_lm/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Olmo3 causal language modeling implementation for Tenstorrent projects.
+"""
+# Import from the loader module
+from .loader import ModelLoader

--- a/Olmo3/causal_lm/pytorch/loader.py
+++ b/Olmo3/causal_lm/pytorch/loader.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Olmo3 Causal LM model loader implementation
+"""
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Olmo3 model variants for causal language modeling."""
+
+    Olmo_3_7B_Think = "3_7b_think"
+    Olmo_3_7B_Instruct = "3_7b_instruct"
+    Olmo_3_1025_7B = "3_1025_7b"
+    Olmo_3_32B_Think = "3_32b_think"
+    Olmo_3_1125_32B = "3_1125_32b"
+
+
+class ModelLoader(ForgeModel):
+    """Olmo3 model loader implementation for causal language modeling tasks."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.Olmo_3_7B_Think: LLMModelConfig(
+            pretrained_model_name="allenai/Olmo-3-7B-Think",
+            max_length=256,
+        ),
+        ModelVariant.Olmo_3_7B_Instruct: LLMModelConfig(
+            pretrained_model_name="allenai/Olmo-3-7B-Instruct",
+            max_length=256,
+        ),
+        ModelVariant.Olmo_3_1025_7B: LLMModelConfig(
+            pretrained_model_name="allenai/Olmo-3-1025-7B",
+            max_length=256,
+        ),
+        ModelVariant.Olmo_3_1125_32B: LLMModelConfig(
+            pretrained_model_name="allenai/Olmo-3-1125-32B",
+            max_length=256,
+        ),
+        ModelVariant.Olmo_3_32B_Think: LLMModelConfig(
+            pretrained_model_name="allenai/Olmo-3-32B-Think",
+            max_length=256,
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.Olmo_3_7B_Think
+
+    # Shared configuration parameters
+    sample_text = "Who would win in a fight - a dinosaur or a cow named Moo Moo?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.model = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+
+        group = ModelGroup.RED
+        return ModelInfo(
+            model="olmo_3",
+            variant=variant,
+            group=group,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        # Initialize tokenizer with dtype override if specified
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        # Load the tokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+        )
+
+        return self.tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the Olmo 3 model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Olmo 3 model instance for causal language modeling.
+        """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        # Ensure tokenizer is loaded
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        # Load the model with dtype override if specified
+        model_kwargs = {
+            "use_cache": False
+        }  # use_cache disabled temporarily because of runtime errors: https://github.com/tenstorrent/tt-xla/issues/3049.
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+        model.eval()
+
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the Olmo 3 model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+            batch_size: Batch size for the inputs.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        # Ensure tokenizer is initialized
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        # Get max_length from the variant config
+        max_length = self._variant_config.max_length
+
+        prompts = [self.sample_text]
+
+        inputs = self.tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        # Add batch dimension
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+
+        return inputs
+
+    def get_mesh_config(self, num_devices: int):
+
+        # Prefer (1, N) when heads divide N, otherwise try (2, N/2)
+        if self.config.num_attention_heads % num_devices == 0:
+            mesh_shape = (1, num_devices)
+        elif (
+            self.config.num_attention_heads % (num_devices // 2) == 0
+            and num_devices % 2 == 0
+        ):
+            mesh_shape = (2, num_devices // 2)
+        else:
+            raise ValueError(
+                f"Cannot evenly distribute {self.config.num_attention_heads} heads across {num_devices} devices"
+            )
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+        for layer in model.model.layers:
+            shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
+
+            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+        shard_specs[model.lm_head.weight] = ("model", "batch")
+
+        return shard_specs
+
+    def load_config(self):
+        """Load and return the configuration for the Olmo 3 model variant.
+
+        Returns:
+            The configuration object for the Olmo 3 model.
+        """
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+
+        return self.config


### PR DESCRIPTION
### Ticket
[2289](https://github.com/tenstorrent/tt-xla/issues/2899)

### Problem description
Bringup OLMO3 model

### What's changed
The reference link includes five variants:

- Olmo-3-1125-32B

- Olmo-3-32B-Think

- Olmo-3-1025-7B

- Olmo-3-7B-Think

- Olmo-3-7B-Instruct

All five variants were successfully brought up.

**Observations:**
In the configuration files for allenai/OLMo-3-7B-Think, allenai/OLMo-3-7B-Instruct, and allenai/OLMo-3-32B-Think, **use_cache** is set to **False**.
In contrast, for allenai/OLMo-3-1025-7B and allenai/OLMo-3-1125-32B, **use_cache** is set to **True**.

When use_cache=True, past_key_values are initialized using the dynamic cache and then set for subsequent layers:

> `pask_key_values = DynamicCache(layers=[DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicSlidingWindowLayer, DynamicLayer])
`

While executing the DynamicSlidingWindowLayer, the following error was encountered:
```
self = <OpOverload(op='aten.slice', overload='Tensor')>
args = (tensor([[[[-1.1250e+00, -1.1523e+00, -2.5049e-01,  ...,  1.1641e+00,
            9.2334e-01,  1.3867e+00],
          ...2.0752e-01,  ...,  1.3892e-01,
            2.6172e-01, -1.4570e+00]]]], device='xla:0'), 2, -4095, 9223372036854775807)
kwargs = {}

    def __call__(self, /, *args: _P.args, **kwargs: _P.kwargs) -> _T:
>       return self._op(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
E       RuntimeError: Value out of range (expected to be in range of [-16, 15], but got -4095)

```
raise the issue ticket in [tt-xla](https://github.com/tenstorrent/tt-xla/issues/3049)

Testing Summary:

N150:

Tested the 7B variants with bfp8 weights — tests passed successfully.

P150:

Tested the 7B variants with bf16 weights — tests passed successfully.

N300-LLMBox:

While testing the 32B variants, encountered an out-of-memory (OOM) issue.

### Checklist
- [ ] New/Existing tests provide coverage for changes
