### PR TITLE
Test HF model loading with cache-first logic

### DIFF
--- a/custom_hf_model/__init__.py
+++ b/custom_hf_model/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/custom_hf_model/causal_lm/__init__.py
+++ b/custom_hf_model/causal_lm/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/custom_hf_model/causal_lm/pytorch/__init__.py
+++ b/custom_hf_model/causal_lm/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+

--- a/custom_hf_model/causal_lm/pytorch/loader.py
+++ b/custom_hf_model/causal_lm/pytorch/loader.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Custom HuggingFace model loader for loading models from your personal HuggingFace Hub.
+
+This loader demonstrates how to:
+1. Load a model from YOUR personal HuggingFace repository
+2. Use cache-first logic (second run uses cached weights)
+3. Support private repositories with HF_TOKEN
+
+Setup:
+    1. Upload a model to your HuggingFace Hub (see hf_upload_example.py)
+    2. Set environment variable with your repo ID:
+       export CUSTOM_HF_REPO_ID="your-username/your-model-name"
+    3. For private repos, set your token:
+       export HF_TOKEN="hf_your_token_here"
+
+Usage:
+    export CUSTOM_HF_REPO_ID="your-username/my-gpt2"
+    pytest -svv tests/runner/test_models.py::test_all_models_torch[custom_hf_model/causal_lm/pytorch-custom-single_device-inference]
+"""
+import os
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....tools.utils import load_huggingface_model, load_huggingface_tokenizer
+
+
+def get_custom_repo_id() -> str:
+    """Get the custom HuggingFace repo ID from environment variable.
+    
+    Returns:
+        str: The repo ID (e.g., "your-username/my-model")
+    
+    Raises:
+        ValueError: If CUSTOM_HF_REPO_ID is not set
+    """
+    repo_id = os.environ.get("CUSTOM_HF_REPO_ID")
+    if not repo_id:
+        raise ValueError(
+            "CUSTOM_HF_REPO_ID environment variable is not set.\n"
+            "Please set it to your HuggingFace repository ID:\n"
+            '  export CUSTOM_HF_REPO_ID="your-username/your-model-name"\n'
+            "\nTo upload a model first, use:\n"
+            "  python third_party/tt_forge_models/tools/hf_upload_example.py --upload --repo-id your-username/my-model"
+        )
+    return repo_id
+
+
+class ModelVariant(StrEnum):
+    """Available model variants."""
+    
+    # The custom variant loads from CUSTOM_HF_REPO_ID environment variable
+    CUSTOM = "custom"
+
+
+class ModelLoader(ForgeModel):
+    """Custom HuggingFace model loader for personal Hub repositories.
+    
+    This loader reads the model repository from the CUSTOM_HF_REPO_ID 
+    environment variable and uses cache-first loading logic.
+    
+    First run: Downloads from your HuggingFace Hub
+    Second run: Uses cached weights (no download needed)
+    """
+
+    # Dictionary of available model variants - required for test discovery
+    # The actual repo ID comes from CUSTOM_HF_REPO_ID environment variable
+    _VARIANTS = {
+        ModelVariant.CUSTOM: LLMModelConfig(
+            pretrained_model_name="custom",  # Placeholder, actual value from env var
+            max_length=128,
+        ),
+    }
+
+    # Default variant
+    DEFAULT_VARIANT = ModelVariant.CUSTOM
+
+    # Sample text for testing
+    sample_text = "The quick brown fox jumps over the lazy"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader.
+
+        Args:
+            variant: Optional ModelVariant (only CUSTOM is supported)
+        """
+        super().__init__(variant)
+        self._repo_id = None
+        self.tokenizer = None
+
+    def _get_repo_id(self) -> str:
+        """Get and cache the repo ID."""
+        if self._repo_id is None:
+            self._repo_id = get_custom_repo_id()
+        return self._repo_id
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Get model info.
+
+        Returns:
+            ModelInfo: Information about the model
+        """
+        return ModelInfo(
+            model="custom_hf_model",
+            variant=variant or cls.DEFAULT_VARIANT,
+            group=ModelGroup.RED,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer from your HuggingFace Hub with cache-first logic."""
+        repo_id = self._get_repo_id()
+        
+        # Get HF token for private repos
+        hf_token = os.environ.get("HF_TOKEN")
+
+        # Use cache-first loading
+        self.tokenizer = load_huggingface_tokenizer(
+            AutoTokenizer,
+            repo_id,
+            token=hf_token,  # Pass token for private repos
+        )
+        
+        # Set pad token if not set
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        return self.tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load model from your HuggingFace Hub with cache-first logic.
+
+        First run: Downloads from HuggingFace Hub
+        Second run: Uses cached weights
+
+        Args:
+            dtype_override: Optional torch.dtype to override model dtype
+
+        Returns:
+            torch.nn.Module: The loaded model
+        """
+        repo_id = self._get_repo_id()
+        
+        # Ensure tokenizer is loaded
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        # Get HF token for private repos
+        hf_token = os.environ.get("HF_TOKEN")
+
+        # Prepare model kwargs
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        if hf_token:
+            model_kwargs["token"] = hf_token
+
+        # Use cache-first loading
+        model = load_huggingface_model(
+            AutoModelForCausalLM,
+            repo_id,
+            **model_kwargs,
+        )
+
+        model.eval()
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Load sample inputs for the model."""
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        inputs = self.tokenizer(
+            self.sample_text,
+            return_tensors="pt",
+            max_length=self._variant_config.max_length,
+            padding="max_length",
+            truncation=True,
+        )
+
+        return inputs
+
+    def decode_output(self, outputs, inputs=None):
+        """Decode model outputs to text."""
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        if inputs is None:
+            inputs = self.load_inputs()
+
+        logits = outputs.logits if hasattr(outputs, "logits") else outputs[0]
+        predicted_token_ids = logits.argmax(dim=-1)
+        predicted_text = self.tokenizer.decode(
+            predicted_token_ids[0], skip_special_tokens=True
+        )
+
+        return predicted_text
+

--- a/sample_hf_model/__init__.py
+++ b/sample_hf_model/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/sample_hf_model/causal_lm/__init__.py
+++ b/sample_hf_model/causal_lm/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+

--- a/sample_hf_model/causal_lm/pytorch/__init__.py
+++ b/sample_hf_model/causal_lm/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+

--- a/sample_hf_model/causal_lm/pytorch/loader.py
+++ b/sample_hf_model/causal_lm/pytorch/loader.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Sample HuggingFace model loader implementation for causal language modeling.
+
+This is a sample model that demonstrates how to load HuggingFace models with
+cache-first logic. The model will:
+1. Check if the model is already cached locally
+2. If cached, load from cache (no network required)
+3. If not cached, download from HuggingFace Hub and cache for future use
+
+Usage:
+    pytest -svv tests/runner/test_models.py::test_all_models_torch[sample_hf_model/causal_lm/pytorch-gpt2-single_device-inference] 2>&1 | tee test_sample_hf.log
+"""
+import torch
+from transformers import GPT2LMHeadModel, AutoTokenizer
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....tools.utils import load_huggingface_model, load_huggingface_tokenizer
+
+
+class ModelVariant(StrEnum):
+    """Available sample model variants."""
+
+    # Using GPT2 as a sample - it's small and fast to download
+    GPT2 = "gpt2"
+    GPT2_MEDIUM = "gpt2-medium"
+
+
+class ModelLoader(ForgeModel):
+    """Sample HuggingFace model loader with cache-first logic.
+    
+    This demonstrates loading a HuggingFace model (GPT2) with automatic caching.
+    On the first run, the model will be downloaded from HuggingFace Hub.
+    On subsequent runs, the cached model will be used automatically.
+    """
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.GPT2: LLMModelConfig(
+            pretrained_model_name="gpt2",
+            max_length=128,
+        ),
+        ModelVariant.GPT2_MEDIUM: LLMModelConfig(
+            pretrained_model_name="gpt2-medium",
+            max_length=128,
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.GPT2
+
+    # Shared configuration parameters
+    sample_text = "The quick brown fox jumps over the lazy"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        return ModelInfo(
+            model="sample_hf_model",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant using cache-first logic.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        # Use the cache-first loading utility
+        self.tokenizer = load_huggingface_tokenizer(
+            AutoTokenizer,
+            pretrained_model_name,
+        )
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        return self.tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the model instance using cache-first logic.
+
+        This method will:
+        1. Check if the model is cached in HuggingFace cache directory
+        2. If cached, load from local cache (no network required)
+        3. If not cached, download from HuggingFace Hub
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The GPT2 model instance for causal language modeling.
+        """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        # Ensure tokenizer is loaded
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        # Prepare model kwargs
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        # Use the cache-first loading utility
+        # This will automatically use cached model if available
+        model = load_huggingface_model(
+            GPT2LMHeadModel,
+            pretrained_model_name,
+            **model_kwargs,
+        )
+
+        model.eval()
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Load and return sample inputs for the model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        # Ensure tokenizer is initialized
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        # Create tokenized inputs for the causal language modeling task
+        inputs = self.tokenizer(
+            self.sample_text,
+            return_tensors="pt",
+            max_length=self._variant_config.max_length,
+            padding="max_length",
+            truncation=True,
+        )
+
+        return inputs
+
+    def decode_output(self, outputs, inputs=None):
+        """Helper method to decode model outputs into human-readable text.
+
+        Args:
+            outputs: Model output from a forward pass
+            inputs: Optional input tensors used to generate the outputs
+
+        Returns:
+            str: Decoded prediction for the next tokens
+        """
+        # Ensure tokenizer is initialized
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        if inputs is None:
+            inputs = self.load_inputs()
+
+        # Get the logits from the outputs
+        logits = outputs.logits if hasattr(outputs, "logits") else outputs[0]
+
+        # Get the predicted token IDs
+        predicted_token_ids = logits.argmax(dim=-1)
+
+        # Decode the predicted tokens
+        predicted_text = self.tokenizer.decode(
+            predicted_token_ids[0], skip_special_tokens=True
+        )
+
+        return predicted_text
+

--- a/tools/hf_upload_example.py
+++ b/tools/hf_upload_example.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Example script demonstrating how to:
+1. Download a model from HuggingFace
+2. Upload it to your personal HuggingFace Hub
+3. Load it from your personal Hub with caching
+
+Requirements:
+    pip install huggingface_hub transformers torch
+
+Setup:
+    1. Create a HuggingFace account at https://huggingface.co
+    2. Create an access token at https://huggingface.co/settings/tokens (with write access)
+    3. Login via: huggingface-cli login
+       OR set: export HF_TOKEN="hf_your_token_here"
+    4. Create a new model repo at https://huggingface.co/new
+
+Usage:
+    # Step 1: Upload model to your hub (one-time)
+    python hf_upload_example.py --upload --repo-id "your-username/my-gpt2"
+
+    # Step 2: Use your uploaded model (first run downloads, second run uses cache)
+    python hf_upload_example.py --use --repo-id "your-username/my-gpt2"
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+
+def upload_model_to_hub(
+    source_model: str,
+    repo_id: str,
+    private: bool = False,
+):
+    """Download a model and upload it to your HuggingFace Hub.
+
+    Args:
+        source_model: Source model to download (e.g., "gpt2", "microsoft/phi-1")
+        repo_id: Your HuggingFace repo ID (e.g., "your-username/my-model")
+        private: Whether to make the repo private
+    """
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    from huggingface_hub import HfApi, create_repo
+
+    print(f"[Step 1] Downloading model '{source_model}'...", flush=True)
+
+    # Download model and tokenizer
+    model = AutoModelForCausalLM.from_pretrained(source_model)
+    tokenizer = AutoTokenizer.from_pretrained(source_model)
+
+    print(f"[Step 2] Creating repository '{repo_id}' on HuggingFace Hub...", flush=True)
+
+    # Create repo if it doesn't exist
+    try:
+        create_repo(repo_id, private=private, exist_ok=True)
+        print(f"Repository '{repo_id}' ready.", flush=True)
+    except Exception as e:
+        print(f"Note: {e}", flush=True)
+
+    print(f"[Step 3] Uploading model to '{repo_id}'...", flush=True)
+
+    # Push model and tokenizer to Hub
+    model.push_to_hub(repo_id)
+    tokenizer.push_to_hub(repo_id)
+
+    print(f"[Success] Model uploaded to: https://huggingface.co/{repo_id}", flush=True)
+    print(f"\nYou can now use this model with:", flush=True)
+    print(f'  python hf_upload_example.py --use --repo-id "{repo_id}"', flush=True)
+
+
+def use_model_from_hub(repo_id: str):
+    """Load a model from your HuggingFace Hub with cache-first logic.
+
+    First run: Downloads from HuggingFace Hub
+    Second run: Uses cached version (no download needed)
+
+    Args:
+        repo_id: Your HuggingFace repo ID (e.g., "your-username/my-model")
+    """
+    from utils import load_huggingface_model, load_huggingface_tokenizer, is_huggingface_model_cached
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    # Check cache status
+    is_cached = is_huggingface_model_cached(repo_id)
+    print(f"\n{'='*60}", flush=True)
+    print(f"Model: {repo_id}", flush=True)
+    print(f"Cache status: {'CACHED ✓' if is_cached else 'NOT CACHED - will download'}", flush=True)
+    print(f"{'='*60}\n", flush=True)
+
+    # Load tokenizer with cache-first logic
+    tokenizer = load_huggingface_tokenizer(
+        AutoTokenizer,
+        repo_id,
+    )
+
+    # Load model with cache-first logic
+    model = load_huggingface_model(
+        AutoModelForCausalLM,
+        repo_id,
+    )
+
+    # Test the model
+    print("\n[Testing model]", flush=True)
+    tokenizer.pad_token = tokenizer.eos_token
+    inputs = tokenizer("Hello, I am a language model", return_tensors="pt")
+
+    # Generate some text
+    model.eval()
+    with __import__('torch').no_grad():
+        outputs = model(**inputs)
+
+    print(f"Model output shape: {outputs.logits.shape}", flush=True)
+    print(f"\n[Success] Model loaded and tested!", flush=True)
+
+    return model, tokenizer
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Upload and use models from your personal HuggingFace Hub"
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload a model to your HuggingFace Hub",
+    )
+    parser.add_argument(
+        "--use",
+        action="store_true",
+        help="Use a model from your HuggingFace Hub (with caching)",
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        required=True,
+        help="Your HuggingFace repo ID (e.g., 'your-username/my-model')",
+    )
+    parser.add_argument(
+        "--source-model",
+        type=str,
+        default="gpt2",
+        help="Source model to download and upload (default: gpt2)",
+    )
+    parser.add_argument(
+        "--private",
+        action="store_true",
+        help="Make the repository private",
+    )
+
+    args = parser.parse_args()
+
+    if not args.upload and not args.use:
+        parser.error("Please specify --upload or --use")
+
+    if args.upload:
+        upload_model_to_hub(
+            source_model=args.source_model,
+            repo_id=args.repo_id,
+            private=args.private,
+        )
+
+    if args.use:
+        use_model_from_hub(repo_id=args.repo_id)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-forge-models/issues/417

### Problem description
The current get_file implementation supports both URLs and local paths, but its behavior is tightly coupled to environment-specific variables such as DOCKER_CACHE_ROOT and IRD_LF_CACHE. This makes demos and end-user execution brittle, non-portable, and dependent on internal infrastructure.

At the same time, we already follow a more robust and user-friendly approach for Hugging Face models using an offline-first cache detection strategy. This logic avoids environment dependencies and relies on standard local caches.

This issue proposes refactoring get_file to follow a similar design philosophy.

### What's changed

Current Behavior

### The existing get_file logic:
Input Handling

- Accepts either:
  - A URL
  - A local file path

- If input is a URL:
  - Generates a unique hashed filename to avoid collisions
  - Downloads the file
  - Stores it in a local cache
  - Uses environment variables (DOCKER_CACHE_ROOT, LOCAL_LF_CACHE) if available

-If input is a local path:
  - Tries to resolve it from predefined cache directories
  - Falls back to downloading from a remote cache using IRD_LF_CACHE
  - Reuses cached files if already present


Problems

- Depends on internal infra-specific environment variables:
 - DOCKER_CACHE_ROOT
 - IRD_LF_CACHE


### Hugging Face Model Loading

We already use a better approach for Hugging Face models:

a) Cache Detection
Before downloading, we check if the model is already present locally using:
`is_huggingface_model_cached(model_name)`


This verifies:
- Snapshot directory exists
- Config file exists
- Model weights exist (.bin, .safetensors, etc.)

b) Offline-First Strategy

If cached:
Load using local_files_only=True

If not cached:
Download from Hugging Face Hub

Automatically cache for future use
### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_custom_ru21.log](https://github.com/user-attachments/files/24756659/test_custom_ru21.log)
[test_custom_run1.log](https://github.com/user-attachments/files/24756665/test_custom_run1.log)
[test_run1.log](https://github.com/user-attachments/files/24756666/test_run1.log)
[test_run2.log](https://github.com/user-attachments/files/24756667/test_run2.log)

