### PR TITLE
Bringup bge-large-en-v1.5 pytorch model

### DIFF
--- a/bge_1_5/embedding_generation/pytorch/__init__.py
+++ b/bge_1_5/embedding_generation/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant

--- a/bge_1_5/embedding_generation/pytorch/loader.py
+++ b/bge_1_5/embedding_generation/pytorch/loader.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+BGE 1.5 model loader implementation for embedding generation.
+"""
+import torch
+from transformers import AutoModel, AutoTokenizer
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available BGE 1.5 model variants for embedding generation."""
+
+    BGE_LARGE_EN_V1_5 = "large_en_v1_5"
+
+
+class ModelLoader(ForgeModel):
+    """BGE 1.5 model loader implementation for embedding generation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.BGE_LARGE_EN_V1_5: ModelConfig(
+            pretrained_model_name="BAAI/bge-large-en-v1.5",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.BGE_LARGE_EN_V1_5
+
+    # Sample sentences for testing
+    sample_sentences = ["The cat sits on the mat"]
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        return ModelInfo(
+            model="bge_1_5",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_EMBED_GEN,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        # Initialize tokenizer with dtype override if specified
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        # Load the tokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+        )
+
+        return self.tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the BGE 1.5 model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The BGE 1.5 model instance for embedding generation.
+        """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        # Load the model with dtype override if specified
+        model_kwargs = {"return_dict": False}
+        if dtype_override is not None:
+            model_kwargs["dtype"] = dtype_override
+
+        model = AutoModel.from_pretrained(pretrained_model_name, **model_kwargs)
+        model.eval()
+
+        return model
+
+    def load_inputs(self, dtype_override=None):
+        """Load and return sample inputs for the BGE 1.5 model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        # Ensure tokenizer is initialized
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        # Tokenize the input texts
+        inputs = self.tokenizer(
+            self.sample_sentences,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        # Convert only float32 tensors to bfloat16, keep integer tensors unchanged
+        if dtype_override is not None:
+            for key, value in inputs.items():
+                if isinstance(value, torch.Tensor):
+                    if value.dtype == torch.float32:
+                        inputs[key] = value.to(dtype_override)
+
+        return inputs


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/2925

### Problem description

- Bringup `BAAI/bge-large-en-v1.5` pytorch model

### What's changed

- Added loader script for mentioned variant

### Checklist
- [x] Verified the changes through local testing

### Logs

- [jan21_bge_1_5_large_cpu_run.log](https://github.com/user-attachments/files/24763721/jan21_bge_cpu_bfp16_from_loader.log)
- [jan21_bge_1_5_large_xla_run.log](https://github.com/user-attachments/files/24763713/jan21_bge_1_5_large_xla.log)
- Note : `bge-large-en-v1.5` take significantly longer at runtime( more than 45 mins) than expected; therefore, intermediate log is attached.
- Will check the results on experimental nightly and add config later accordingly

