### PR TITLE
Bringup Qwen3_VL Pytorch model

### DIFF
--- a/config.py
+++ b/config.py
@@ -41,6 +41,7 @@ class ModelTask(StrEnum):
     NLP_TRANSLATION = "nlp_translation"
     NLP_SUMMARIZATION = "nlp_summarization"
     NLP_MULTI_CHOICE = "nlp_multi_choice"
+    NLP_IMAGE_TO_TEXT = "nlp_image_to_text"
     AUDIO_CLS = "audio_cls"
     AUDIO_ASR = "audio_asr"
     CV_IMAGE_CLS = "cv_image_cls"

--- a/qwen_3_vl/image_to_text/pytorch/__init__.py
+++ b/qwen_3_vl/image_to_text/pytorch/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/qwen_3_vl/image_to_text/pytorch/loader.py
+++ b/qwen_3_vl/image_to_text/pytorch/loader.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3 model loader implementation for image to text.
+"""
+
+from transformers import Qwen3VLForConditionalGeneration, AutoProcessor
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Qwen 3 model variants for image to text."""
+
+    QWEN_3_VL_2B_INSTRUCT = "2b_instruct"
+    QWEN_3_VL_2B_THINKING = "2b_thinking"
+    QWEN_3_VL_4B_INSTRUCT = "4b_instruct"
+    QWEN_3_VL_4B_THINKING = "4b_thinking"
+
+
+class ModelLoader(ForgeModel):
+    """Qwen 3 model loader implementation for image to text tasks."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.QWEN_3_VL_2B_INSTRUCT: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3-VL-2B-Instruct",
+            max_length=128,
+        ),
+        ModelVariant.QWEN_3_VL_2B_THINKING: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3-VL-2B-Thinking",
+            max_length=128,
+        ),
+        ModelVariant.QWEN_3_VL_4B_INSTRUCT: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3-VL-4B-Instruct",
+            max_length=128,
+        ),
+        ModelVariant.QWEN_3_VL_4B_THINKING: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3-VL-4B-Thinking",
+            max_length=128,
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.QWEN_3_VL_2B_INSTRUCT
+
+    # Shared configuration parameters
+    sample_image = (
+        "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"
+    )
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.processor = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        return ModelInfo(
+            model="qwen_v3",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.NLP_IMAGE_TO_TEXT,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, dtype_override=None):
+        """Load and return the Qwen 3 model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The Qwen 3 model instance for image to text.
+        """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        # Load the model with dtype override if specified
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+
+        self.processor = AutoProcessor.from_pretrained(pretrained_model_name)
+
+        model = Qwen3VLForConditionalGeneration.from_pretrained(
+            pretrained_model_name, dtype="auto", device_map="auto", **model_kwargs
+        )
+        model.eval()
+
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the Qwen 3 model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+            batch_size: Batch size for the inputs.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+                    },
+                    {"type": "text", "text": "Describe this image."},
+                ],
+            }
+        ]
+
+        inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        return inputs


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/2931

### Problem description

- Bringup Qwen3_VL pytorch variants

### What's changed

- Added loader script for below mentioned variants:
    1. Qwen/Qwen3-VL-2B-Instruct
    2. Qwen/Qwen3-VL-2B-Thinking
    3. Qwen/Qwen3-VL-4B-Instruct
    4. Qwen/Qwen3-VL-4B-Thinking

### Logs
[qwenv3_vl_2b_instruct_xla.log](https://github.com/user-attachments/files/24773101/qwenv3_vl_2b_instruct_xla.log)
[qwenv3_vl_2b_thinking_xla.log](https://github.com/user-attachments/files/24773106/qwenv3_vl_2b_thinking_xla.log)
[qwenv3_vl_4b_instruct_xla.log](https://github.com/user-attachments/files/24773110/qwenv3_vl_4b_instruct_xla.log)
[qwenv3_vl_4b_thinking_xla.log](https://github.com/user-attachments/files/24773112/qwenv3_vl_4b_thinking_xla.log)
