### PR TITLE
Remove pretrained weights loading for vovnet model

### DIFF
--- a/vovnet/pytorch/loader.py
+++ b/vovnet/pytorch/loader.py
@@ -4,6 +4,7 @@
 """
 VovNet model loader implementation
 """
+
 from typing import Optional
 
 import torch
@@ -153,7 +154,8 @@ class ModelLoader(ForgeModel):
         source = cfg.source
 
         if source == ModelSource.OSMR:
-            model = ptcv_get_model(model_name, pretrained=True)
+            # Use randomly initialized weights (no pretrained download)
+            model = ptcv_get_model(model_name, pretrained=False)
         elif source == ModelSource.TIMM:
             model, _ = download_model(preprocess_timm_model, model_name)
         elif source == ModelSource.TORCH_HUB:

--- a/vovnet/pytorch/src/utils.py
+++ b/vovnet/pytorch/src/utils.py
@@ -18,7 +18,8 @@ from ....tools.utils import get_file
 
 
 def preprocess_steps(model_type):
-    model = model_type(True, True).eval()
+    # Use randomly initialized weights (no pretrained download)
+    model = model_type(False, True).eval()
     config = resolve_data_config({}, model=model)
     transform = create_transform(**config)
 
@@ -36,7 +37,8 @@ def preprocess_steps(model_type):
 
 
 def preprocess_timm_model(model_name):
-    use_pretrained_weights = True
+    # Use randomly initialized weights (no pretrained download)
+    use_pretrained_weights = False
     if model_name == "ese_vovnet99b":
         use_pretrained_weights = False
     model = timm.create_model(model_name, pretrained=use_pretrained_weights)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/2390

### Problem description

- The download repeatedly fails because the Dropbox URL returns a 403 (Forbidden), causing the model to error out after multiple retry attempts.

### What's changed

- Loading of pretrained weights has been disabled, enabling random initialization as a workaround for this issue. Post this change, model passes e2e.

### Logs
[vovnet_random_weights.log](https://github.com/user-attachments/files/24931049/vovnet_random_weights.log)
