### PR TITLE
gpt-oss dequantization

### DIFF
--- a/gpt_oss/pytorch/loader.py
+++ b/gpt_oss/pytorch/loader.py
@@ -6,6 +6,7 @@ gpt-oss model loader implementation for causal language modeling tasks.
 """
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers.utils.quantization_config import Mxfp4Config
 from typing import Optional
 
 from ...base import ForgeModel
@@ -107,11 +108,13 @@ class ModelLoader(ForgeModel):
             torch.nn.Module: The gpt-oss model instance for causal language modeling.
         """
         # Load config with modifications
+        quantization_config = Mxfp4Config(dequantize=True)
         self.load_config()
 
         # Prepare model kwargs
         model_kwargs = {
             "config": self.config,
+            "quantization_config": quantization_config,
             "low_cpu_mem_usage": True,
             "trust_remote_code": True,
             "attn_implementation": "eager",
@@ -224,6 +227,4 @@ class ModelLoader(ForgeModel):
         if self.num_layers is not None:
             self.config.num_hidden_layers = self.num_layers
 
-        self.config.quantization_config["quant_method"] = "none"
-        self.config.use_cache = False
         return self.config


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently, gpt-oss assigns random weights to mlp expert weights when loaded with bfloat16 and no quantization config. Instead, weights could be dequantized using Mxfp4Config.


### What's changed
Loading model with `quantization_config = Mxfp4Config(dequantize=True)`

### Checklist
- [x] Single test run in tt-xla: https://github.com/tenstorrent/tt-xla/actions/runs/21458311717 