### PR TITLE
Skip bfloat16 conversion in OpenPoseV2 due to Conv2d+BatchNorm2d rounding amplification

### DIFF
--- a/openpose/v2/pytorch/loader.py
+++ b/openpose/v2/pytorch/loader.py
@@ -5,6 +5,7 @@
 """
 Openpose V2 model loader implementation
 """
+
 from PIL import Image
 from pytorchcv.model_provider import get_model as ptcv_get_model
 from torchvision import transforms
@@ -60,15 +61,21 @@ class ModelLoader(ForgeModel):
 
         Args:
             dtype_override: Optional torch.dtype to override the model's default dtype.
-                            If not provided, the model will use its default dtype (typically float32).
+                            NOTE: This parameter is currently ignored (model always uses float32).
 
         Returns:
             torch.nn.Module: The Openpose V2 model instance.
 
         """
         model = ptcv_get_model(self.model_name, pretrained=True)
+
+        # Skip bfp16 conversion - Conv2d->BatchNorm2d chains amplify rounding errors in bfloat16
+        # Reference: https://github.com/tenstorrent/tt-metal/issues/36394#issuecomment-3810036978
         if dtype_override is not None:
-            model = model.to(dtype_override)
+            print(
+                "NOTE: dtype_override ignored - Conv2d+BatchNorm2d rounding amplification in bfloat16"
+            )
+        #     model = model.to(dtype_override)
 
         return model
 
@@ -77,7 +84,7 @@ class ModelLoader(ForgeModel):
 
         Args:
             dtype_override: Optional torch.dtype to override the model's default dtype.
-                            If not provided, the model will use its default dtype (typically float32).
+                            NOTE: This parameter is currently ignored (model always uses float32).
             batch_size: Optional batch size to override the default batch size of 1.
 
         Returns:
@@ -104,7 +111,13 @@ class ModelLoader(ForgeModel):
         )  # create a mini-batch as expected by the model
 
         batch_input = input_batch.repeat_interleave(batch_size, dim=0)
+
+        # Skip bfp16 conversion - Conv2d->BatchNorm2d chains amplify rounding errors in bfloat16
+        # Reference: https://github.com/tenstorrent/tt-metal/issues/36394#issuecomment-3810036978
         if dtype_override is not None:
-            batch_input = batch_input.to(dtype_override)
+            print(
+                "NOTE: dtype_override ignored - Conv2d+BatchNorm2d rounding amplification in bfloat16"
+            )
+        #     batch_input = batch_input.to(dtype_override)
 
         return batch_input


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/2938

### Problem description

- The openposev2 model shows a PCC of 0.920083787379264 when run in bfloat16.
- The PCC drop originates from BatchNorm2d when Conv2d and BatchNorm2d are executed together.
- The core issue is rounding amplification: Conv2d introduces tiny rounding differences between TT (Tenstorrent) and CPU, and BatchNorm significantly amplifies these differences when values are near the mean - [complete context](https://github.com/tenstorrent/tt-metal/issues/36394#issuecomment-3810036978)
- Since this is a precision limitation of bfloat16, Running the model in float32 improves the PCC to `0.9977604871479668`
- Received confirmation from @nvukobratTT to run this model in FP32.

### What's changed

- Skipped bfloat16 conversion for this model

### Checklist
- Verified the changes through local testing

### Logs

- [jan29_openpose_v2_bfp16.log](https://github.com/user-attachments/files/24929636/jan29_openpose_v2_bfp16.log)
- [jan29_openpose_v2_fp32.log](https://github.com/user-attachments/files/24929637/jan29_openpose_v2_fp32.log)

