### PR TITLE
Fix TorchRuntimeError in Dense_unet_3d model

### DIFF
--- a/dense_unet_3d/pytorch/src/model.py
+++ b/dense_unet_3d/pytorch/src/model.py
@@ -10,6 +10,18 @@ from torch import nn
 from typing import Tuple
 
 
+def _aten_maxpool3d(x: torch.Tensor) -> torch.Tensor:
+    out, _ = torch.ops.aten.max_pool3d_with_indices.default(
+        x,
+        [3, 3, 3],  # kernel_size
+        [2, 2, 2],  # stride
+        [1, 1, 1],  # padding
+        [1, 1, 1],  # dilation
+        False,  # ceil_mode
+    )
+    return out
+
+
 class UpsamplingBlock(nn.Module):
     """
     Upsampling Block (upsampling layer) as specified by the paper
@@ -203,7 +215,7 @@ class DenseUNet3d(nn.Module):
         :return:   output of the forward pass
         """
         residual1 = self.relu(self.bn1(self.conv1(x)))
-        residual2 = self.dense1(self.maxpool1(residual1))
+        residual2 = self.dense1(_aten_maxpool3d(residual1))
         residual3 = self.dense2(self.transition(residual2))
         residual4 = self.dense3(self.transition(residual3))
         output = self.dense4(self.transition(residual4))


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-xla/issues/2567

### Problem description
Model was failing RuntimeError('Check failed: xtensor: Input tensor is not an XLA tensor: XLABFloat16Type')

### What's changed
his error is caused from tracing with torch.compile/Dynamo using FakeTensors on XLA. When F.max_pool3d runs during tracing, XLA’s kernel asserts that the input is a real XLATensor,  a FakeTensor hits that check and throws “Input tensor is not an XLA tensor: XLABFloat16Type.” This is an incompatibility between Dynamo’s fake-tensor tracing and the XLA registration for maxpool2d, not a model or dtype issue.Replacing with torch.ops.aten.max_pool2d doesn’t cause any tracing issues and  so Dynamo can symbolically trace it without executing a backend kernel. After these chnages, model fails with `loc("reduce-window.970"): error: failed to legalize operation 'ttir.pooling' that was explicitly marked illegal`

### Log
[dense_unet_3d.log](https://github.com/user-attachments/files/25064420/dense_unet_3d_changes.log)
