### PR TITLE
Modify models hf set1

### DIFF
--- a/beit/pytorch/loader.py
+++ b/beit/pytorch/loader.py
@@ -6,8 +6,7 @@ BEiT model loader implementation for image classification
 """
 import torch
 from transformers import BeitImageProcessor, BeitForImageClassification
-from PIL import Image
-from ...tools.utils import get_file
+from datasets import load_dataset
 from typing import Optional
 
 from ...base import ForgeModel
@@ -129,8 +128,11 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor()
 
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        image = Image.open(str(image_file))
+        # Load dataset
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        image = dataset[0]["image"]
+
+        # Process the image
         inputs = self.processor(images=image, return_tensors="pt")
 
         if dtype_override is not None:

--- a/deformable_detr/pytorch/loader.py
+++ b/deformable_detr/pytorch/loader.py
@@ -6,8 +6,8 @@ Deformable DETR model loader implementation for object detection.
 """
 import torch
 from transformers import DeformableDetrForObjectDetection, DeformableDetrImageProcessor
+from datasets import load_dataset
 from typing import Optional
-from PIL import Image
 
 from ...base import ForgeModel
 from ...config import (
@@ -19,7 +19,6 @@ from ...config import (
     Framework,
     StrEnum,
 )
-from ...tools.utils import get_file
 
 
 class ModelVariant(StrEnum):
@@ -150,9 +149,11 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor()
 
-        # Get the Image
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        image = Image.open(image_file)
+        # Load dataset
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        image = dataset[0]["image"]
+
+        # Process the image
         inputs = self.processor(images=image, return_tensors="pt")
 
         # Handle batch size

--- a/detr/object_detection/pytorch/loader.py
+++ b/detr/object_detection/pytorch/loader.py
@@ -6,9 +6,8 @@ DETR model loader implementation for object detection.
 """
 import torch
 from transformers import DetrForObjectDetection, DetrImageProcessor
-from typing import Optional
-from PIL import Image
 from datasets import load_dataset
+from typing import Optional
 
 from ....base import ForgeModel
 from ....config import (
@@ -128,7 +127,6 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor()
 
-        # Load image from HuggingFace dataset
         dataset = load_dataset("huggingface/cats-image")["test"]
         image = dataset[0]["image"]
         inputs = self.processor(images=image, return_tensors="pt")

--- a/dinov2/image_classification/pytorch/loader.py
+++ b/dinov2/image_classification/pytorch/loader.py
@@ -9,8 +9,8 @@ from transformers import (
     AutoImageProcessor,
     AutoModelForImageClassification,
 )
+from datasets import load_dataset
 from typing import Optional
-from PIL import Image
 
 from ....base import ForgeModel
 from ....config import (
@@ -22,7 +22,6 @@ from ....config import (
     Framework,
     StrEnum,
 )
-from ....tools.utils import get_file
 
 
 class ModelVariant(StrEnum):
@@ -147,9 +146,9 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor()
 
-        # Get the Image
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        image = Image.open(image_file)
+        # Load dataset
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        image = dataset[0]["image"]
 
         # Process images
         inputs = self.processor(images=image, return_tensors="pt")

--- a/llava/pytorch/loader.py
+++ b/llava/pytorch/loader.py
@@ -10,7 +10,7 @@ import re
 from typing import Optional
 
 import torch
-from PIL import Image
+from datasets import load_dataset
 from transformers import LlavaForConditionalGeneration, AutoProcessor
 
 from ...base import ForgeModel
@@ -23,7 +23,6 @@ from ...config import (
     Framework,
     StrEnum,
 )
-from ...tools.utils import get_file
 from ...tools.utils import cast_input_to_type
 
 
@@ -105,11 +104,9 @@ class ModelLoader(ForgeModel):
             conversation, padding=True, add_generation_prompt=True
         )
 
-        # Load image
-
-        ## Add the get file utililty here
-        input_image = get_file("https://www.ilankelman.org/stopsigns/australia.jpg")
-        image = Image.open(str(input_image))
+        # Load dataset
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        image = dataset[0]["image"]
 
         # Preprocess
         inputs = self.processor(images=image, text=text_prompt, return_tensors="pt")

--- a/owl_vit/pytorch/loader.py
+++ b/owl_vit/pytorch/loader.py
@@ -7,8 +7,8 @@ OWL-ViT model loader implementation for object detection.
 import torch
 from transformers import OwlViTProcessor, OwlViTForObjectDetection
 from transformers.models.owlvit.modeling_owlvit import OwlViTObjectDetectionOutput
+from datasets import load_dataset
 from typing import Optional
-from PIL import Image
 
 from ...base import ForgeModel
 from ...config import (
@@ -20,7 +20,6 @@ from ...config import (
     Framework,
     StrEnum,
 )
-from ...tools.utils import get_file
 
 
 class ModelVariant(StrEnum):
@@ -128,9 +127,9 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor()
 
-        # Get the Image
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        self.image = Image.open(image_file)
+        # Load dataset
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        self.image = dataset[0]["image"]
 
         # Define text labels for object detection
         self.text_labels = [["a photo of a cat", "a photo of a dog"]]
@@ -166,11 +165,9 @@ class ModelLoader(ForgeModel):
             self._load_processor()
 
         if self.image is None:
-            # Load image if not already loaded
-            image_file = get_file(
-                "http://images.cocodataset.org/val2017/000000039769.jpg"
-            )
-            self.image = Image.open(image_file)
+            # Load dataset if not already loaded
+            dataset = load_dataset("huggingface/cats-image")["test"]
+            self.image = dataset[0]["image"]
 
         if self.text_labels is None:
             # Use text labels if not already set

--- a/rt_detr/pytorch/loader.py
+++ b/rt_detr/pytorch/loader.py
@@ -6,8 +6,8 @@ RT-DETR (Real-Time DETR) model loader implementation for object detection.
 """
 import torch
 from transformers import RTDetrForObjectDetection, RTDetrImageProcessor
+from datasets import load_dataset
 from typing import Optional
-from PIL import Image
 
 from ...base import ForgeModel
 from ...config import (
@@ -19,7 +19,6 @@ from ...config import (
     Framework,
     StrEnum,
 )
-from ...tools.utils import get_file
 
 
 class ModelVariant(StrEnum):
@@ -150,9 +149,11 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor()
 
-        # Get the Image
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        image = Image.open(image_file)
+        # Load dataset
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        image = dataset[0]["image"]
+
+        # Process the image
         inputs = self.processor(images=image, return_tensors="pt")
 
         # Handle batch size


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge-models/issues/428)

### Problem description
Currently, model inputs are handled by links from different sources.This issue aims to standardize input handling across all models by using the Hugging Face load_dataset API as the primary source of input data.

### What's changed
modified deformable_detr,detr,dinov2,fuyu,llava,owl_vit,rt_detr model to input from load_dataset from HuggingFace

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:
[test_detr_object_detection_inference.log](https://github.com/user-attachments/files/25044440/test_detr_object_detection_inference.log)
[test_detr.log](https://github.com/user-attachments/files/25044441/test_detr.log)
[test_dinov2_cpu.log](https://github.com/user-attachments/files/25044442/test_dinov2_cpu.log)
[test_dinov2_small_inference.log](https://github.com/user-attachments/files/25044444/test_dinov2_small_inference.log)
[test_fuyu_8b_inference.log](https://github.com/user-attachments/files/25044445/test_fuyu_8b_inference.log)
[test_fuyu_cpu.log](https://github.com/user-attachments/files/25044446/test_fuyu_cpu.log)
[test_llava_1_5_7b_inference.log](https://github.com/user-attachments/files/25044451/test_llava_1_5_7b_inference.log)
[test_owl_vit_base_patch32_inference.log](https://github.com/user-attachments/files/25044455/test_owl_vit_base_patch32_inference.log)


[test_set1.py](https://github.com/user-attachments/files/25736974/test_set1.py)

[test_inputs_beit.log](https://github.com/user-attachments/files/25736981/test_inputs_beit.log)
[test_inputs_deformable_detr.log](https://github.com/user-attachments/files/25736982/test_inputs_deformable_detr.log)
[test_inputs_detr.log](https://github.com/user-attachments/files/25736984/test_inputs_detr.log)
[test_inputs_dinov2.log](https://github.com/user-attachments/files/25736985/test_inputs_dinov2.log)
[test_inputs_fuyu.log](https://github.com/user-attachments/files/25736987/test_inputs_fuyu.log)
[test_inputs_llava.log](https://github.com/user-attachments/files/25736988/test_inputs_llava.log)
[test_inputs_owl_vit.log](https://github.com/user-attachments/files/25736989/test_inputs_owl_vit.log)
[test_inputs_rt_detr.log](https://github.com/user-attachments/files/25736990/test_inputs_rt_detr.log)
