### PR TITLE
Update gpt-oss for tt-forge

### DIFF
--- a/gpt_oss/pytorch/loader.py
+++ b/gpt_oss/pytorch/loader.py
@@ -180,6 +180,7 @@ class ModelLoader(ForgeModel):
         ):
             # if the model uses sliding window attention, match sliding window value to input size so it
             # does not go out of bounds when updating the cache
+            # Issue: https://github.com/tenstorrent/tt-xla/issues/3186
             self.model.config.sliding_window = inputs["input_ids"].shape[1]
 
         return inputs


### PR DESCRIPTION
### Ticket
None

### Problem description
tt-forge doesn't use `load_tokenizer` explicitly and expects the tokenizer to be loaded when model is loaded.
sliding window attention is disabled to avoid recompilation.

### What's changed
tokenizer and sliding window changes for gpt-oss

### Checklist
- https://github.com/tenstorrent/tt-xla/actions/runs/21758336539
