### PR TITLE
Add bfloat16 support for transfuser model

### DIFF
--- a/transfuser/pytorch/loader.py
+++ b/transfuser/pytorch/loader.py
@@ -54,8 +54,12 @@ class ModelLoader(ForgeModel):
             framework=Framework.TORCH,
         )
 
-    def load_model(self, **kwargs):
+    def load_model(self, *, dtype_override=None, **kwargs):
         """Load and return the Transfuser model instance with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
 
         Returns:
             Torch model: The Transfuser model instance.
@@ -79,10 +83,18 @@ class ModelLoader(ForgeModel):
         model.load_state_dict(new_state_dict, strict=False)
         model.eval()
 
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+
         return model
 
-    def load_inputs(self, **kwargs):
+    def load_inputs(self, dtype_override=None, **kwargs):
         """Return sample inputs for the Transfuser model with default settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the inputs' default dtype.
+                           If not provided, inputs will use the default dtype (typically float32).
 
         Returns:
             dict: A dictionary of input tensors and metadata suitable for the model.
@@ -101,6 +113,10 @@ class ModelLoader(ForgeModel):
             "target_point_image": target_point_image,
             "ego_vel": ego_vel,
         }
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            kwargs = {k: v.to(dtype_override) for k, v in kwargs.items()}
 
         return kwargs
 


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/3196
- https://github.com/tenstorrent/tt-xla/issues/3089

### Problem description

- On the current tt-xla main, the Transfuser model fails with `TT_FATAL: Input tensor data type must be BFLOAT16 or UINT16, got DataType::FLOAT32`, triggered by a newly added assert for sort op in tt-metal(https://github.com/tenstorrent/tt-metal/pull/36467) - [feb5_transfuser_xla_fp32.log](https://github.com/user-attachments/files/25105782/feb5_transfuser_xla_fp32.log)
- The input to the topk operation (which decomposes to ttnn.sort + ttnn.slice) is float32 dtype in this model. float32 is not a supported input dtype for ttnn.sort - ([docs](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.sort.html#ttnn.sort))
- The model is currently running in FP32, so BFP16 support needs to be enabled

### What's changed

- **Loader updates**: Modified the loader to accept dtype_override parameter and apply it to both the model and inputs
- **Removed hardcoded conversions**: Eliminated hardcoded fp32 conversions in model code to prevent dtype mismatch issues. 
- **Device placement fixes**: Propagated device information where needed and removed hardcoded .cpu() conversions to avoid device mismatch errors like this. [feb5_transfuser_xla_bfp16_err1.log](https://github.com/user-attachments/files/25123637/feb5_transfuser_xla_bfp16_err1.log), [feb6_transfuser_bfp16_err2.log](https://github.com/user-attachments/files/25123640/feb6_transfuser_bfp16_err2.log)
- After this change, model currently failing due to `error: Shardy propagation doesn't support tuples: 'tuple<tensor<3x3xf32>, tensor<3xf32>>'`

### Checklist
- [x] Verified the changes through local testing


### Logs

**CPU runs** 

- FP32 (Before vs. After Fix): Results remain unchanged after introducing this PR changes - https://www.diffchecker.com/PUjR2SnY/
  - [feb5_transfuser_cpu_fp32_before_fix.log](https://github.com/user-attachments/files/25123672/feb5_transfuser_cpu_fp32_before_hc_removals.log)
  - [feb6_transfuser_cpu_fp32_after_fix.log](https://github.com/user-attachments/files/25123674/feb6_transfuser_cpu_fp32_after_hc_removals.log)
- BFP16 - [feb6_transfuser_cpu_bfp16.log](https://github.com/user-attachments/files/25123700/feb6_transfuser_cpu_bfp16.log)

**TT-XLA runs**

- [feb6_transfuser_bfp16_1.log.zip](https://github.com/user-attachments/files/25123730/feb6_transfuser_bfp16_1.log.zip)


