### PR TITLE
Add bfloat16 support for panoptic segmentation variants

### DIFF
--- a/panoptic_segmentation/pytorch/loader.py
+++ b/panoptic_segmentation/pytorch/loader.py
@@ -248,8 +248,12 @@ class ModelLoader(ForgeModel):
             else ModelGroup.GENERALITY,
         )
 
-    def load_model(self, **kwargs):
+    def load_model(self, *, dtype_override=None, **kwargs):
         """Load and return the Panoptic FPN model with DefaultPredictor.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
 
         Returns:
             DefaultPredictor: The predictor instance ready for inference
@@ -291,6 +295,11 @@ class ModelLoader(ForgeModel):
 
         # Keep reference to the underlying torch.nn.Module for tester expectations
         self._model = self.predictor.model
+
+        # Only convert dtype if explicitly requested
+        if dtype_override is not None:
+            self._model = self._model.to(dtype_override)
+            self.predictor.model = self._model
 
         # Setup metadata for downstream decoding/support tooling
         self._setup_metadata(cfg)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/3202
- https://github.com/tenstorrent/tt-xla/issues/3089

### Problem description

- On the current tt-xla main, panoptic segmentation variants (`resnet50_1x, resnet50_3x,resnet101_3x`) failing due to `TT_FATAL: Input tensor data type must be BFLOAT16 or UINT16, got DataType::FLOAT32`, triggered by a newly added assert for sort op in tt-metal([#36467](https://github.com/tenstorrent/tt-metal/pull/36467))
- The input to the topk operation (which decomposes to ttnn.sort + ttnn.slice) is float32 dtype in this model. float32 is not a supported input dtype for ttnn.sort - ([docs](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.sort.html#ttnn.sort))
- The model is currently running in FP32, so BFP16 support needs to be enabled

### What's changed

- **Loader updates:** Modified the `load_model()` to accept `dtype_override` parameter and apply it to the model. `load_inputs()` already handles `dtype_override`.
- **Removed hardcoded conversions:** Eliminated hardcoded fp32 conversions in model code to prevent dtype mismatch issues. 
- **Note :** `nms_kernel , roi_align_forward_kernel` not implemented for `BFloat16`. Inputs are converted to float32 before these operations. Outputs are converted back to original dtype if floating-point.
- **Device placement fixes:** Propagated device information where needed and removed hardcoded .cpu() conversions to avoid device mismatch errors. 
- After this change, variants currently failing due to an error: `Can't convert shape rank` (original error before the new assertion was added)

### Checklist
- [x] Verified the changes through local testing

### Logs

**CPU runs**

- FP32 (Before vs. After Fix): Results remain unchanged after introducing this PR changes - https://www.diffchecker.com/cXAqajKq/
  - [feb6_ps_cpu_fp32_bf.log](https://github.com/user-attachments/files/25131851/feb6_ps_cpu_fp32_bf.log)
  - [feb6_ps_cpu_fp32_af.log](https://github.com/user-attachments/files/25131849/feb6_ps_cpu_fp32_af.log)
- BFP16 - [feb6_ps_cpu_bfp16.log](https://github.com/user-attachments/files/25131912/feb6_ps_cpu_bfp16.log)

**TT-XLA runs**

**Before fix** 
- [feb6_ps_res50_1x_fp32_xla_bf.log](https://github.com/user-attachments/files/25131706/feb6_ps_res50_1x_fp32_xla_bf.log)
- [feb6_ps_res50_3x_fp32_xla_bf.log](https://github.com/user-attachments/files/25131708/feb6_ps_res50_3x_fp32_xla_bf.log)
- [feb6_ps_res101_3x_fp32_xla_bf.log](https://github.com/user-attachments/files/25131709/feb6_ps_res101_3x_fp32_xla_bf.log)

**After fix**
- [feb6_ps_xla_after_fix.log](https://github.com/user-attachments/files/25131777/feb6_ps_xla_after_fix.log)


