### PR TITLE
Fix model loading issue in GPT OSS

### DIFF
--- a/gpt_oss/pytorch/loader.py
+++ b/gpt_oss/pytorch/loader.py
@@ -148,6 +148,8 @@ class ModelLoader(ForgeModel):
         )
         model.eval()
 
+        self.model = model
+
         return model
 
     def load_inputs(self, dtype_override=None):


### PR DESCRIPTION
### Ticket
Ref : [Nightly failure](https://github.com/tenstorrent/tt-xla/actions/runs/21846180532/job/63042520253#step:17:2547)

### Problem description
All GPT_OSS model tests are failing with an error as  
```
hasattr(self.model.config, "sliding_window")
            ^^^^^^^^^^
E   AttributeError: 'ModelLoader' object has no attribute 'model'
```

The below tests are failed 
```
tests/torch/graphs/test_attention.py::test_gpt_oss_attention[single_device-gpt_oss_20b]
tests/torch/graphs/test_attention.py::test_gpt_oss_attention[single_device-gpt_oss_120b] 
tests/torch/graphs/test_mlp.py::test_gpt_oss_mlp[gpt_oss_20b-single_device] 
tests/torch/graphs/test_mlp.py::test_gpt_oss_mlp[gpt_oss_120b-single_device]
tests/torch/graphs/test_attention.py::test_gpt_oss_attention[llmbox-gpt_oss_20b] 
tests/torch/graphs/test_attention.py::test_gpt_oss_attention[llmbox-gpt_oss_120b]  
tests/torch/graphs/test_mlp.py::test_gpt_oss_mlp[gpt_oss_20b-llmbox]
tests/torch/graphs/test_mlp.py::test_gpt_oss_mlp[gpt_oss_120b-llmbox]
```
### What's changed
* saved the model in a class variable to use in further places

### Checklist
- [x] New/Existing tests provide coverage for changes

Tested in local with these changes
[gpt_oss_attention.log](https://github.com/user-attachments/files/25201499/gpt_oss_attention.log)
[gpt_oss_Test_fix.log](https://github.com/user-attachments/files/25201501/gpt_oss_Test_fix.log)
[graph_gpt_oss_Test.log](https://github.com/user-attachments/files/25201502/graph_gpt_oss_Test.log)

