### PR TITLE
Refactor and update the shared specification for the OLMo3 model.

### DIFF
--- a/olmo3/causal_lm/pytorch/loader.py
+++ b/olmo3/causal_lm/pytorch/loader.py
@@ -215,7 +215,7 @@ class ModelLoader(ForgeModel):
             shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
             shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
             shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
-        shard_specs[model.lm_head.weight] = ("model", "batch")
+        shard_specs[model.lm_head.weight] = ("batch", "model")
 
         return shard_specs
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
While running tensor-parallel inference on n300-llmbox, I encountered the following error:
`ValueError: bad optional access
`
### What's changed
After reviewing other loader.py implementations to understand load_shard_spec, changing `shard_specs[model.lm_head.weight] `from `("model", "batch")` to `("batch", "model")` resolves the issue and works successfully for OLMO3 series models.

| model_vareint | pcc |
|--------|--------|
| allenai/Olmo-3-1125-32B | 0.999842419511947 |
| allenai/Olmo-3-32B-Think | 0.9909116597742709 |

I have attached the logs for reference.

[olmo3_1125_32b-tensor_parallel-inference](https://github.com/user-attachments/files/25358659/olmo3_1125_32b_torch.log)
[olmo3_32b_think-tensor_parallel-inference](https://github.com/user-attachments/files/25358663/olmo3_think_32b_torch.log)
### Checklist
- [ ] New/Existing tests provide coverage for changes
