### PR TITLE
refactor: remove use_cache=false from model kwargs

### DIFF
--- a/olmo3/causal_lm/pytorch/loader.py
+++ b/olmo3/causal_lm/pytorch/loader.py
@@ -137,9 +137,7 @@ class ModelLoader(ForgeModel):
             self._load_tokenizer(dtype_override=dtype_override)
 
         # Load the model with dtype override if specified
-        model_kwargs = {
-            "use_cache": False
-        }  # use_cache disabled temporarily because of runtime errors: https://github.com/tenstorrent/tt-xla/issues/3049.
+        model_kwargs = {}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
 
@@ -148,6 +146,10 @@ class ModelLoader(ForgeModel):
         model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name, **model_kwargs
         )
+        if getattr(model.config, "use_cache", True):
+            model.config.layer_types = [
+                "full_attention"
+            ] * model.config.num_hidden_layers
         model.eval()
 
         self.config = model.config


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Initially, when running the model with use_cache=True, a [runtime error](https://github.com/tenstorrent/tt-xla/issues/3049) is encountered.

### What's changed
Following Aleks’ suggestion, I replaced sliding_attention with full_attentions in the config layers.
[olm3_7b_1025.log](https://github.com/user-attachments/files/25406208/olm3_7b_1025.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
