### PR TITLE
Fix tensor device mismatch error in SSD300_VGG16 & SSDLITE320_MOBILENET_V3_LARGE

### DIFF
--- a/ssdlite320_mobilenetv3/pytorch/loader.py
+++ b/ssdlite320_mobilenetv3/pytorch/loader.py
@@ -22,6 +22,11 @@ from PIL import Image
 from ...tools.utils import get_file
 from torchvision import transforms
 import torchvision.models as models
+from torchvision.models.detection.anchor_utils import DefaultBoxGenerator
+from ...ssd300_vgg16.pytorch.src.utils import (
+    patched_grid_default_boxes,
+    patched_forward,
+)
 
 
 class ModelVariant(StrEnum):
@@ -83,6 +88,12 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.nn.Module: The SSDLite320 MobileNetV3 model instance.
         """
+        # Monkey-patch DefaultBoxGenerator to propagate device into _grid_default_boxes,
+        # so tensors created during forward are on the same device (XLA) as the feature maps
+        # instead of defaulting to CPU - https://github.com/tenstorrent/tt-xla/issues/3335
+        DefaultBoxGenerator._grid_default_boxes = patched_grid_default_boxes
+        DefaultBoxGenerator.forward = patched_forward
+
         # Get the pretrained model name from the instance's variant config
         model_name = self._variant_config.pretrained_model_name
 


### PR DESCRIPTION
### Ticket

- Closes https://github.com/tenstorrent/tt-xla/issues/3335

### Problem description

- `ssd300_vgg16` facing `RuntimeError: Check failed: xtensor: Input tensor is not an XLA tensor: CPUFloatType` - [feb18_ssd300_vgg16.log](https://github.com/user-attachments/files/25387039/feb18_ssd300_vgg16.log)
- Inside [_grid_default_boxes](https://github.com/pytorch/vision/blob/7a9db90e9aadea3e3e1fec35969601167e9efd4f/torchvision/models/detection/anchor_utils.py#L209), shifts is built from [torch.arange](https://github.com/pytorch/vision/blob/7a9db90e9aadea3e3e1fec35969601167e9efd4f/torchvision/models/detection/anchor_utils.py#L221C26-L221C38)(0, f_k[1]) which creates CPU tensors because no device is specified.
- During compilation on the TT device, self._wh_pairs[k] is already on the TT device (XLA tensor), but shifts is freshly created on CPU by torch.arange() inside _grid_default_boxes. When torch.cat((shifts, wh_pairs), dim=1) executes, this CPU vs XLA mismatch causes the crash.
- The root cause is that _grid_default_boxes doesn't accept or use a device argument. the forward method [extracts device from feature_maps[0]](https://github.com/pytorch/vision/blob/7a9db90e9aadea3e3e1fec35969601167e9efd4f/torchvision/models/detection/anchor_utils.py#L252C9-L252C70) but only applies it after _grid_default_boxes returns (via default_boxes.to(device)), which is too late.
- Observed similar behaviour in `ssdlite320_mobilenet_v3_large` too. [feb18_ssd_lite320_mobv3_bf.log](https://github.com/user-attachments/files/25389213/feb18_ssd_lite320_mobv3_bf.log)


### What's changed

- Monkey-patched DefaultBoxGenerator to propagate device into _grid_default_boxes, so tensors created during forward are on the same device (XLA) instead of defaulting to CPU.
- Both **ssd300_vgg16** and **ssdlite320_mobilenetv3** use the same DefaultBoxGenerator class from the same `torchvision/models/detection/anchor_utils.py` file.
- So reused the same patched functions in the `ssdlite320_mobilenet_v3_large` loader script.
- Post this change `ssd300_vgg16` facing  `Can't convert shape rank` issue at runtime and `ssdlite320_mobilenet_v3_large` facing `error: 'ttir.arange' op Invalid range: start=0, end=0, step=1`

### Checklist
- [x] Verified the changes through local testing

### Logs



**CPU run** 

- [feb18_ssd300vgg16_cpu_before_fix.log](https://github.com/user-attachments/files/25387693/feb18_ssd300vgg16_cpu_bf.log)
- [feb18_ssd300vgg16_cpu_after_fix.log](https://github.com/user-attachments/files/25387692/feb18_ssd300vgg16_cpu_af.log)
- [feb18_ssdlite320_mobv3_cpu_before_fix.log](https://github.com/user-attachments/files/25389312/feb18_ssdlite320_mobv3_cpu_bf.log)
- [feb18_ssdlite320_mobv3_cpu_after_fix.log](https://github.com/user-attachments/files/25389311/feb18_ssdlite320_mobv3_cpu_af.log)
- Cpu results matches exactly - https://www.diffchecker.com/26BdIwq7/ , https://www.diffchecker.com/gLWdQTuC/


**TT run**

- [feb18_ssd300_vgg16_before_fix.log](https://github.com/user-attachments/files/25387691/feb18_ssd300_vgg16.log)
-  [feb18_ssd300_vgg16_after_fix.log](https://github.com/user-attachments/files/25387690/feb18_ssd300_vgg16_after_fix_f.log)
- [feb18_ssdlite320_mobv3_before_fix.log](https://github.com/user-attachments/files/25389321/feb18_ssd_lite320_mobv3_bf.log)
- [feb18_ssdlite320_mobv3_after_fix.log](https://github.com/user-attachments/files/25389320/feb18_ssd_lite320_mobv3_af.log)





