### PR TITLE
Decouple Post-Processing from ssdlite320_mobilenetv3 Model

### DIFF
--- a/ssdlite320_mobilenetv3/pytorch/loader.py
+++ b/ssdlite320_mobilenetv3/pytorch/loader.py
@@ -22,9 +22,13 @@ from datasets import load_dataset
 from torchvision import transforms
 import torchvision.models as models
 from torchvision.models.detection.anchor_utils import DefaultBoxGenerator
+from torchvision.models.detection.ssd import SSD
 from ...ssd300_vgg16.pytorch.src.utils import (
     patched_grid_default_boxes,
     patched_forward,
+)
+from ...ssdlite320_mobilenetv3.pytorch.src.utils import (
+    patched_SSD_forward,
 )
 
 
@@ -54,6 +58,8 @@ class ModelLoader(ForgeModel):
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
+        self.image_sizes = (320, 320)
+        self.original_image_sizes = (320, 320)
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -92,6 +98,7 @@ class ModelLoader(ForgeModel):
         # instead of defaulting to CPU - https://github.com/tenstorrent/tt-xla/issues/3335
         DefaultBoxGenerator._grid_default_boxes = patched_grid_default_boxes
         DefaultBoxGenerator.forward = patched_forward
+        SSD.forward = patched_SSD_forward
 
         # Get the pretrained model name from the instance's variant config
         model_name = self._variant_config.pretrained_model_name
@@ -100,16 +107,17 @@ class ModelLoader(ForgeModel):
         if model_name == "ssdlite320_mobilenet_v3_large":
             weights = models.detection.SSDLite320_MobileNet_V3_Large_Weights.DEFAULT
             model = models.detection.ssdlite320_mobilenet_v3_large(weights=weights)
+            self.model = model
         else:
             raise ValueError(f"Unsupported model variant: {model_name}")
 
-        model.eval()
+        self.model.eval()
 
         if dtype_override is not None:
             print("NOTE: dtype_override ignored - batched_nms lacks BFloat16 support")
         #     model = model.to(dtype_override)
 
-        return model
+        return self.model
 
     def load_inputs(self, dtype_override=None, batch_size=1):
         """Load and return sample inputs for the SSDLite320 MobileNetV3 model with this instance's variant settings.
@@ -146,3 +154,13 @@ class ModelLoader(ForgeModel):
             # inputs = inputs.to(dtype_override)
 
         return inputs
+
+    def postprocess_detections(self, outputs):
+        head_outputs, anchors = outputs
+        detections = self.model.postprocess_detections(
+            head_outputs, anchors, [self.image_sizes]
+        )
+        detections = self.model.transform.postprocess(
+            detections, [self.image_sizes], [self.original_image_sizes]
+        )
+        return detections

--- a/ssdlite320_mobilenetv3/pytorch/src/utils.py
+++ b/ssdlite320_mobilenetv3/pytorch/src/utils.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+import torch
+from torch import Tensor
+from collections import OrderedDict
+
+
+def patched_SSD_forward(
+    self, images: list[Tensor], targets: Optional[list[dict[str, Tensor]]] = None
+) -> tuple[dict[str, Tensor], list[dict[str, Tensor]]]:
+    if self.training:
+        if targets is None:
+            torch._assert(False, "targets should not be none when in training mode")
+        else:
+            for target in targets:
+                boxes = target["boxes"]
+                if isinstance(boxes, torch.Tensor):
+                    torch._assert(
+                        len(boxes.shape) == 2 and boxes.shape[-1] == 4,
+                        f"Expected target boxes to be a tensor of shape [N, 4], got {boxes.shape}.",
+                    )
+                else:
+                    torch._assert(
+                        False,
+                        f"Expected target boxes to be of type Tensor, got {type(boxes)}.",
+                    )
+
+    # get the original image sizes
+    original_image_sizes: list[tuple[int, int]] = []
+    for img in images:
+        val = img.shape[-2:]
+        torch._assert(
+            len(val) == 2,
+            f"expecting the last two dimensions of the Tensor to be H and W instead got {img.shape[-2:]}",
+        )
+        original_image_sizes.append((val[0], val[1]))
+
+    # transform the input
+    images, targets = self.transform(images, targets)
+
+    # Check for degenerate boxes
+    if targets is not None:
+        for target_idx, target in enumerate(targets):
+            boxes = target["boxes"]
+            degenerate_boxes = boxes[:, 2:] <= boxes[:, :2]
+            if degenerate_boxes.any():
+                bb_idx = torch.where(degenerate_boxes.any(dim=1))[0][0]
+                degen_bb: list[float] = boxes[bb_idx].tolist()
+                torch._assert(
+                    False,
+                    "All bounding boxes should have positive height and width."
+                    f" Found invalid box {degen_bb} for target at index {target_idx}.",
+                )
+
+    # get the features from the backbone
+    features = self.backbone(images.tensors)
+    if isinstance(features, torch.Tensor):
+        features = OrderedDict([("0", features)])
+
+    features = list(features.values())
+
+    # compute the ssd heads outputs using the features
+    head_outputs = self.head(features)
+
+    # create the set of anchors
+    anchors = self.anchor_generator(images, features)
+
+    return (head_outputs, anchors)


### PR DESCRIPTION
### Ticket
Fixes [#3380](https://github.com/tenstorrent/tt-xla/issues/3380)

### Problem description
SSDlite320_mobilenetv3 fails with 'ttir.arange' op fails with invalid range (start=0, end=0, step=1)

### What's changed

-  In SSD.postprocess_detections, the model checks predictions separately for each object category. For an image that contains only one type of object, most other categories receive extremely low confidence scores across all candidate boxes. When the code filters out low-confidence scores, those categories end up with nothing left that is the filtered result is an empty tensor.

- To bypass this, inference has been split into two explicit phases core forward and postprocess since original inference pipeline included the post-processing steps as well.

-  SSD.forward has been patched to return raw outputs needed for post-processing

- New post-processing method has been added which unpacks the tuple from the patched forward and further runs the exact torchvision post-processing explicitly

- The final CPU inference outputs were compared before and after the changes, and the results are identical and xla run passes e2e after this change.

### Logs
[ssdlite320.log](https://github.com/user-attachments/files/25765426/ssdlite320.log)

