### PR TITLE
Update code to run the Phi-4 model with tensor parallel.

### DIFF
--- a/phi4/causal_lm/pytorch/loader.py
+++ b/phi4/causal_lm/pytorch/loader.py
@@ -128,6 +128,7 @@ class ModelLoader(ForgeModel):
         )
         model.eval()
 
+        self.config = model.config
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):
@@ -187,3 +188,37 @@ class ModelLoader(ForgeModel):
             decoded_output = self.tokenizer.decode(next_token_id)
 
         return decoded_output
+
+    def get_mesh_config(self, num_devices: int):
+        """Return mesh shape and axis names for tensor parallel."""
+        if self.config.num_attention_heads % num_devices == 0:
+            mesh_shape = (1, num_devices)
+        elif (
+            self.config.num_attention_heads % (num_devices // 2) == 0
+            and num_devices % 2 == 0
+        ):
+            mesh_shape = (2, num_devices // 2)
+        else:
+            raise ValueError(
+                f"Cannot evenly distribute {self.config.num_attention_heads} heads "
+                f"across {num_devices} devices"
+            )
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+        for layer in model.model.layers:
+            shard_specs[layer.self_attn.o_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.qkv_proj.weight] = ("model", "batch")
+
+            shard_specs[layer.mlp.gate_up_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.down_proj.weight] = ("model", "batch")
+        shard_specs[model.lm_head.weight] = ("model", "batch")
+        return shard_specs
+
+    def load_config(self):
+        """Load and return the configuration for the model variant."""
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.config


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Resolve the runtime errors encountered when running the Phi-4 model with tensor parallelism.

### What's changed
Initially, while running the model with tensor parallelism, the following runtime error was encountered:
```
_ test_all_models_torch[phi4/causal_lm/pytorch-Phi_4-tensor_parallel-inference] _
tests/runner/test_models.py:288: in test_all_models_torch
    _run_model_test_impl(
tests/runner/test_models.py:111: in _run_model_test_impl
    tester = DynamicTorchModelTester(
tests/runner/testers/torch/dynamic_torch_model_tester.py:59: in __init__
    super().__init__(
tests/infra/testers/single_chip/model/torch_model_tester.py:86: in __init__
    super().__init__(
tests/infra/testers/single_chip/model/model_tester.py:61: in __init__
    self._initialize_components()
tests/infra/testers/single_chip/model/model_tester.py:68: in _initialize_components
    self._initialize_workload()
tests/infra/testers/single_chip/model/torch_model_tester.py:154: in _initialize_workload
    self._workload.mesh and len(self._workload.mesh.device_ids) > 1
E   AssertionError: Tensor parallel requires multi-chip mesh
```

To resolve the above-mentioned error, the following functions—**get_mesh_config** and **load_shard_spec**—were added to loader.py.

After these changes, the model now passes with a PCC of 0.9996130444915992.

The logs are attached for reference:
[phi4:causal_lm:pytorch-Phi_4-tensor_parallel-inference.log](https://github.com/user-attachments/files/25706233/phi4.causal_lm.pytorch-Phi_4-tensor_parallel-inference.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
