### PR TITLE
Adjust galaxy mesh_configs to be DP=4 TP=8

### DIFF
--- a/gpt_oss/pytorch/loader.py
+++ b/gpt_oss/pytorch/loader.py
@@ -198,7 +198,7 @@ class ModelLoader(ForgeModel):
         """
         # Support different mesh configurations based on number of devices
         if num_devices == 32:  # Galaxy
-            mesh_shape = (8, 4)
+            mesh_shape = (4, 8)
         elif num_devices == 8:  # llmbox
             mesh_shape = (2, 4)
         else:

--- a/llama/causal_lm/pytorch/loader.py
+++ b/llama/causal_lm/pytorch/loader.py
@@ -411,7 +411,7 @@ class ModelLoader(ForgeModel):
             ModelVariant.LLAMA_3_1_405B_INSTRUCT,
         ]:
             if num_devices == 32:  # Galaxy
-                mesh_shape = (8, 4)
+                mesh_shape = (4, 8)
             else:  # wh/bh llmbox
                 mesh_shape = (2, num_devices // 2)
         else:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Llama and gpt-oss galaxy tests should be sharded so that DP=4 TP=8. 

### What's changed
Adjusted the mesh shapes to be `(4, 8)`  instead of `(8, 4)` since a mesh shape of `(4, 8)` is now supported.

### Checklist
- [x] New/Existing tests provide coverage for changes
