### PR TITLE
Add loaders for Olmo model in EasyDel

### DIFF
--- a/olmo/causal_lm/jax/__init__.py
+++ b/olmo/causal_lm/jax/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelVariant, ModelLoader

--- a/olmo/causal_lm/jax/loader.py
+++ b/olmo/causal_lm/jax/loader.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Olmo model loader implementation for causal language modeling.
+"""
+
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    Parallelism,
+)
+from ....tools.jax_utils import cast_hf_model_to_type
+import flax.nnx as nnx
+from jax.sharding import PartitionSpec
+import jax.numpy as jnp
+import numpy as np
+
+
+class ModelVariant(StrEnum):
+    """Available Olmo model variants."""
+
+    _7B_HF = "7b-hf"
+
+
+class ModelLoader(ForgeModel):
+    """Olmo model loader implementation for causal language modeling."""
+
+    # Dictionary of available model variants
+    _VARIANTS = {
+        ModelVariant._7B_HF: LLMModelConfig(
+            pretrained_model_name="allenai/OLMo-7B-hf",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant._7B_HF
+
+    sample_text = "Hey, are you conscious? Can you talk to me?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self._tokenizer = None
+        self._model_name = self._variant_config.pretrained_model_name
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+
+        return ModelInfo(
+            model="olmo",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.EASYDEL,
+            framework=Framework.JAX,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+
+        Args:
+            dtype_override: Optional dtype to override the tokenizer's default dtype.
+
+        Returns:
+            tokenizer: The loaded tokenizer instance
+        """
+
+        from transformers import AutoTokenizer
+
+        # Initialize tokenizer with dtype_override if provided
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["dtype"] = dtype_override
+
+        # Load the tokenizer
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            self._model_name, **tokenizer_kwargs
+        )
+
+        return self._tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the Olmo model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            model: The loaded model instance
+        """
+
+        from easydel import AutoEasyDeLModelForCausalLM
+
+        # Ensure tokenizer is loaded
+        if self._tokenizer is None:
+            self._load_tokenizer(dtype_override)
+
+        # Initialize model kwargs
+        model_kwargs = {}
+
+        # Determine the target dtype
+        if dtype_override is not None:
+            model_kwargs["dtype"] = dtype_override
+
+        partition_rules = ((r".*", PartitionSpec()),)
+
+        model = AutoEasyDeLModelForCausalLM.from_pretrained(
+            self._model_name, partition_rules=partition_rules, **model_kwargs
+        )
+
+        # Cast the model to the dtype_override if provided
+        if dtype_override is not None:
+            model = cast_hf_model_to_type(model, dtype_override)
+
+        return model
+
+    def load_inputs(self, dtype_override=None, mesh=None):
+        """Load and return sample inputs for the Olmo model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional dtype to override the model's default dtype.
+            mesh: Optional device mesh for sharding (DataParallel mode).
+        Returns:
+            inputs: Input tensors that can be fed to the model.
+        """
+
+        if mesh is not None:
+            # For multi-device, use a fixed batch size that's divisible by device count
+            # This matches the original test which used batch_size=8
+            num_devices = np.prod(list(mesh.shape.values())) if mesh.shape else 1
+            batch_size = 8  # Fixed batch size, will be sharded across devices
+            # Ensure batch size is divisible by number of devices
+            if batch_size % num_devices != 0:
+                batch_size = num_devices * (batch_size // num_devices + 1)
+        else:
+            # Default to 8 for single device too, for consistency
+            batch_size = 8
+
+        # Ensure tokenizer is initialized
+        if self._tokenizer is None:
+            self._load_tokenizer(dtype_override)
+
+        # Create tokenized inputs
+        inputs = self._tokenizer(self.sample_text, return_tensors="jax")
+
+        input_ids = jnp.repeat(inputs.input_ids, batch_size, axis=0)
+        return {"input_ids": input_ids}
+
+    def get_input_activations_partition_spec(self, mesh, parallelism, axis_name="X"):
+        """Get partition specification for input activations.
+
+        Args:
+            mesh: The device mesh for sharding.
+            parallelism: The level of parallelism for sharding.
+            axis_name: The name of the mesh axis to use for sharding.
+
+        Returns:
+            PartitionSpec for input activations (sharded on batch dimension)
+        """
+        if (
+            parallelism.name == Parallelism.TENSOR_PARALLEL.name
+            or np.prod(list(mesh.shape.values())) == 1
+        ):
+            return (PartitionSpec(),)
+
+        return (PartitionSpec(axis_name),)
+
+    def load_parameters_partition_spec(
+        self,
+        model_for_multichip,
+        parallelism,
+        axis_name="X",
+        cpu_mesh=None,
+        input_activations_partition_specs=None,
+        inputs=None,
+        dtype_override=None,
+    ):
+        # Get the model state
+        state = nnx.split(model_for_multichip)[1]
+
+        if (
+            parallelism.name == Parallelism.DATA_PARALLEL.name
+            or parallelism.name == Parallelism.SINGLE_DEVICE.name
+        ):
+            # In data parallel mode, use fully replicated partitioning
+            partition_rules = ((r".*", PartitionSpec()),)
+        else:
+            # Use EasyDel's MambaConfig to get proper partition rules
+            from easydel.modules.olmo import OlmoConfig
+
+            olmo_config = OlmoConfig()
+            partition_rules = olmo_config.get_partition_rules()
+
+        from infra.utilities import make_easydel_parameters_partition_specs
+
+        return make_easydel_parameters_partition_specs(
+            model_state=state, partition_rules=partition_rules, axis_name=axis_name
+        )

--- a/olmo/causal_lm/jax/requirements.txt
+++ b/olmo/causal_lm/jax/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
+
+eformer==0.0.62

--- a/olmo2/causal_lm/jax/__init__.py
+++ b/olmo2/causal_lm/jax/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelVariant, ModelLoader

--- a/olmo2/causal_lm/jax/loader.py
+++ b/olmo2/causal_lm/jax/loader.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Olmo2 model loader implementation for causal language modeling.
+"""
+
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    Parallelism,
+)
+from ....tools.jax_utils import cast_hf_model_to_type
+import flax.nnx as nnx
+from jax.sharding import PartitionSpec
+import jax.numpy as jnp
+import numpy as np
+
+
+class ModelVariant(StrEnum):
+    """Available Olmo2 model variants."""
+
+    _1124_7B = "1124-7b"
+
+
+class ModelLoader(ForgeModel):
+    """Olmo2 model loader implementation for causal language modeling."""
+
+    # Dictionary of available model variants
+    _VARIANTS = {
+        ModelVariant._1124_7B: LLMModelConfig(
+            pretrained_model_name="allenai/OLMo-2-1124-7B",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant._1124_7B
+
+    sample_text = "Hey, are you conscious? Can you talk to me?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self._tokenizer = None
+        self._model_name = self._variant_config.pretrained_model_name
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+
+        return ModelInfo(
+            model="olmo2",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.EASYDEL,
+            framework=Framework.JAX,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+
+        Args:
+            dtype_override: Optional dtype to override the tokenizer's default dtype.
+
+        Returns:
+            tokenizer: The loaded tokenizer instance
+        """
+
+        from transformers import AutoTokenizer
+
+        # Initialize tokenizer with dtype_override if provided
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["dtype"] = dtype_override
+
+        # Load the tokenizer
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            self._model_name, **tokenizer_kwargs
+        )
+
+        return self._tokenizer
+
+    def load_model(self, dtype_override=None):
+        """Load and return the Olmo2 model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            model: The loaded model instance
+        """
+
+        from easydel import AutoEasyDeLModelForCausalLM
+
+        # Ensure tokenizer is loaded
+        if self._tokenizer is None:
+            self._load_tokenizer(dtype_override)
+
+        # Initialize model kwargs
+        model_kwargs = {}
+
+        # Determine the target dtype
+        if dtype_override is not None:
+            model_kwargs["dtype"] = dtype_override
+
+        partition_rules = ((r".*", PartitionSpec()),)
+
+        model = AutoEasyDeLModelForCausalLM.from_pretrained(
+            self._model_name, partition_rules=partition_rules, **model_kwargs
+        )
+
+        # Cast the model to the dtype_override if provided
+        if dtype_override is not None:
+            model = cast_hf_model_to_type(model, dtype_override)
+
+        return model
+
+    def load_inputs(self, dtype_override=None, mesh=None):
+        """Load and return sample inputs for the Olmo2 model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional dtype to override the model's default dtype.
+            mesh: Optional device mesh for sharding (DataParallel mode).
+        Returns:
+            inputs: Input tensors that can be fed to the model.
+        """
+
+        if mesh is not None:
+            # For multi-device, use a fixed batch size that's divisible by device count
+            # This matches the original test which used batch_size=8
+            num_devices = np.prod(list(mesh.shape.values())) if mesh.shape else 1
+            batch_size = 8  # Fixed batch size, will be sharded across devices
+            # Ensure batch size is divisible by number of devices
+            if batch_size % num_devices != 0:
+                batch_size = num_devices * (batch_size // num_devices + 1)
+        else:
+            # Default to 8 for single device too, for consistency
+            batch_size = 8
+
+        # Ensure tokenizer is initialized
+        if self._tokenizer is None:
+            self._load_tokenizer(dtype_override)
+
+        # Create tokenized inputs
+        inputs = self._tokenizer(self.sample_text, return_tensors="jax")
+
+        input_ids = jnp.repeat(inputs.input_ids, batch_size, axis=0)
+        return {"input_ids": input_ids}
+
+    def get_input_activations_partition_spec(self, mesh, parallelism, axis_name="X"):
+        """Get partition specification for input activations.
+
+        Args:
+            mesh: The device mesh for sharding.
+            parallelism: The level of parallelism for sharding.
+            axis_name: The name of the mesh axis to use for sharding.
+
+        Returns:
+            PartitionSpec for input activations (sharded on batch dimension)
+        """
+        if (
+            parallelism.name == Parallelism.TENSOR_PARALLEL.name
+            or np.prod(list(mesh.shape.values())) == 1
+        ):
+            return (PartitionSpec(),)
+
+        return (PartitionSpec(axis_name),)
+
+    def load_parameters_partition_spec(
+        self,
+        model_for_multichip,
+        parallelism,
+        axis_name="X",
+        cpu_mesh=None,
+        input_activations_partition_specs=None,
+        inputs=None,
+        dtype_override=None,
+    ):
+        # Get the model state
+        state = nnx.split(model_for_multichip)[1]
+
+        if (
+            parallelism.name == Parallelism.DATA_PARALLEL.name
+            or parallelism.name == Parallelism.SINGLE_DEVICE.name
+        ):
+            # In data parallel mode, use fully replicated partitioning
+            partition_rules = ((r".*", PartitionSpec()),)
+        else:
+            # Use EasyDel's MambaConfig to get proper partition rules
+            from easydel.modules.olmo2 import Olmo2Config
+
+            olmo2_config = Olmo2Config()
+            partition_rules = olmo2_config.get_partition_rules()
+
+        from infra.utilities import make_easydel_parameters_partition_specs
+
+        return make_easydel_parameters_partition_specs(
+            model_state=state, partition_rules=partition_rules, axis_name=axis_name
+        )

--- a/olmo2/causal_lm/jax/requirements.txt
+++ b/olmo2/causal_lm/jax/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
+
+eformer==0.0.62


### PR DESCRIPTION
### Problem description
Add support for Olmo & Olmo2 models in JAX via EasyDel framework in tt-forge-models

### What's changed
* Created loaders for Olmo & Olmo2 models 
* This model is facing an issue like `'OlmoConfig' object has no attribute 'head_dim'`
* This error can be fixed by making a change in EasyDel repo
* Post the fix of that error, this model is facing OOM issues in single-device, tp and dp


### Checklist
- [x] New/Existing tests provide coverage for changes
Attaching the logs for these issues
Easydel issue : [olmo_jax_7b.log](https://github.com/user-attachments/files/25766486/olmo_jax_7b.log)
OOM issue : [olmo_tp.log](https://github.com/user-attachments/files/25766499/olmo_tp.log)

