### PR TITLE
Fix for PCC drop in test_llms_torch models

### DIFF
--- a/falcon/pytorch/loader.py
+++ b/falcon/pytorch/loader.py
@@ -293,6 +293,7 @@ class ModelLoader(ForgeModel):
         return get_static_cache_decode_inputs(
             tokenizer=self.tokenizer,
             config=self.config,
+            model=self.model,
             batch_size=batch_size,
             max_cache_len=max_cache_len,
             dtype=dtype_override,

--- a/gemma/pytorch/loader.py
+++ b/gemma/pytorch/loader.py
@@ -263,6 +263,7 @@ class ModelLoader(ForgeModel):
         return get_static_cache_decode_inputs(
             tokenizer=self.tokenizer,
             config=self.config,
+            model=self.model,
             batch_size=batch_size,
             max_cache_len=max_cache_len,
             dtype=dtype_override,

--- a/llama/causal_lm/pytorch/loader.py
+++ b/llama/causal_lm/pytorch/loader.py
@@ -325,6 +325,7 @@ class ModelLoader(ForgeModel):
         return get_static_cache_decode_inputs(
             tokenizer=self.tokenizer,
             config=self.config,
+            model=self.model,
             batch_size=batch_size,
             max_cache_len=max_cache_len,
             dtype=dtype_override,

--- a/qwen_2_5/causal_lm/pytorch/loader.py
+++ b/qwen_2_5/causal_lm/pytorch/loader.py
@@ -223,7 +223,7 @@ class ModelLoader(ForgeModel):
         model.eval()
 
         self.config = model.config
-
+        self.model = model
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):
@@ -327,6 +327,7 @@ class ModelLoader(ForgeModel):
         return get_static_cache_decode_inputs(
             tokenizer=self.tokenizer,
             config=self.config,
+            model=self.model,
             batch_size=batch_size,
             max_cache_len=max_cache_len,
             dtype=dtype_override,

--- a/qwen_3/causal_lm/pytorch/loader.py
+++ b/qwen_3/causal_lm/pytorch/loader.py
@@ -163,7 +163,7 @@ class ModelLoader(ForgeModel):
         ).eval()
 
         self.config = model.config
-
+        self.model = model
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):
@@ -258,6 +258,7 @@ class ModelLoader(ForgeModel):
         return get_static_cache_decode_inputs(
             tokenizer=self.tokenizer,
             config=self.config,
+            model=self.model,
             batch_size=batch_size,
             max_cache_len=max_cache_len,
             dtype=dtype_override,

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -312,6 +312,7 @@ def get_static_cache_decode_inputs(
     *,
     tokenizer,
     config,
+    model,
     batch_size: int = 1,
     max_cache_len: int = 128,
     dtype: Optional[torch.dtype] = None,
@@ -338,13 +339,28 @@ def get_static_cache_decode_inputs(
 
     token_id = get_simple_decode_token_id(tokenizer, config)
     input_ids = torch.full((batch_size, 1), fill_value=token_id, dtype=torch.long)
+    prefill_len = max_cache_len - 1
+    prefill_input_ids = torch.full(
+        (batch_size, prefill_len),
+        token_id,
+        dtype=torch.long,
+        device=device,
+    )
+
+    with torch.no_grad():
+        outputs = model(
+            input_ids=prefill_input_ids,
+            past_key_values=static_cache,
+            use_cache=True,
+        )
+    past_key_values = outputs.past_key_values
 
     pos = (max_cache_len - 1) if cache_position is None else int(cache_position)
     cache_position_t = torch.tensor([pos], dtype=torch.long)
 
     inputs = {
         "input_ids": input_ids,
-        "past_key_values": static_cache,
+        "past_key_values": past_key_values,
         "cache_position": cache_position_t,
         "use_cache": True,
     }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/2845)

### Problem description
During decode testing with StaticCache, the KV cache was initialized but not populated with real key/value tensors.
The previous implementation simply created a StaticCache and passed it to the decode step.
Since the cache contained uninitialized / empty KV values, the attention layers were operating on invalid context, which resulted in low PCC during model validation.

### What's changed
The decode input preparation has been updated to prefill the KV cache with real key/value tensors before performing the decode step.

This is done by:
1. Allocating a StaticCache with max_cache_len.
2. Running a prefill forward pass using max_cache_len - 1 tokens.
3. Allowing the model to populate the KV cache during the prefill forward pass.
4. Using the filled cache for the final single-token decode step.

### Checklist
- [ ] New/Existing tests provide coverage for changes

### Logs
[test_llms_torch_after_fix.log](https://github.com/user-attachments/files/25905030/test_llms_torch_after_fix.log)
[test_llms_torch_before_fix.log](https://github.com/user-attachments/files/25905032/test_llms_torch_before_fix.log)
