### PR TITLE
Decouple Post-Processing from SSD300_VGG16 model

### DIFF
--- a/ssd300_vgg16/pytorch/loader.py
+++ b/ssd300_vgg16/pytorch/loader.py
@@ -8,6 +8,7 @@ import torch
 from typing import Optional
 from torchvision import models
 from torchvision.models.detection.anchor_utils import DefaultBoxGenerator
+from torchvision.models.detection.ssd import SSD
 from PIL import Image
 
 from ...base import ForgeModel
@@ -21,8 +22,7 @@ from ...config import (
     StrEnum,
 )
 from datasets import load_dataset
-from ...tools.utils import print_compiled_model_results
-from .src.utils import SSDPostprocessor, patched_grid_default_boxes, patched_forward
+from .src.utils import patched_grid_default_boxes, patched_forward, patched_SSD_forward
 
 
 class ModelVariant(StrEnum):
@@ -55,6 +55,7 @@ class ModelLoader(ForgeModel):
                      If None, DEFAULT_VARIANT is used.
         """
         super().__init__(variant)
+        self.image_sizes = (300, 300)
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -93,18 +94,23 @@ class ModelLoader(ForgeModel):
         DefaultBoxGenerator._grid_default_boxes = patched_grid_default_boxes
         DefaultBoxGenerator.forward = patched_forward
 
+        # Workaround: Decouple post-processing from SSD.forward to avoid PCC drop
+        # in softmax -> slice -> greater_than op chain on device.
+        # Revert once https://github.com/tenstorrent/tt-metal/issues/39171 is fixed.
+        SSD.forward = patched_SSD_forward
+
         # Load model from torchvision
         weights = models.detection.SSD300_VGG16_Weights.DEFAULT
-        model = models.detection.ssd300_vgg16(weights=weights)
-        model.eval()
+        self.model = models.detection.ssd300_vgg16(weights=weights)
+        self.model.eval()
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
-            # model = model.to(dtype_override)
+            # self.model = self.model.to(dtype_override)
             # TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
             print("NOTE: dtype_override ignored - batched_nms lacks BFloat16 support")
 
-        return model
+        return self.model
 
     def load_inputs(self, dtype_override=None, batch_size=1):
         """Load and return sample inputs for the SSD300 VGG16 model with this instance's variant settings.
@@ -125,6 +131,7 @@ class ModelLoader(ForgeModel):
         weights = models.detection.SSD300_VGG16_Weights.DEFAULT
         preprocess = weights.transforms()
         img_t = preprocess(image)
+        self.original_image_sizes = (img_t.shape[-2], img_t.shape[-1])
         batch_t = torch.unsqueeze(img_t, 0)
         batch_t = batch_t.contiguous()
 
@@ -139,16 +146,30 @@ class ModelLoader(ForgeModel):
 
         return batch_t
 
-    def postprocess_results(self, model, fw_out, co_out, inputs):
-        """Postprocess detection results from framework and compiled model outputs and Print classification results
+    def postprocess_detections(self, fw_out, co_out):
+        """Run post-processing on raw model outputs (head_outputs, anchors) on CPU.
 
         Args:
-            model: The SSD model instance (typically the wrapped model)
-            fw_out: Framework model outputs
-            co_out: Compiled model outputs
-            inputs: Input tensors used for inference
+            fw_out: Framework model outputs (head_outputs, anchors) tuple.
+            co_out: Compiled model outputs (head_outputs, anchors) tuple.
 
+        Returns:
+            Tuple of (framework model detections, compiled model detections).
         """
-        postprocessor = SSDPostprocessor(model)
-        _, detection_co = postprocessor.process(fw_out, co_out, inputs)
-        print_compiled_model_results(detection_co)
+        fw_head_outputs, fw_anchors = fw_out
+        detections_fw = self.model.postprocess_detections(
+            fw_head_outputs, fw_anchors, [self.image_sizes]
+        )
+        detections_fw = self.model.transform.postprocess(
+            detections_fw, [self.image_sizes], [self.original_image_sizes]
+        )
+
+        co_head_outputs, co_anchors = co_out
+        detections_co = self.model.postprocess_detections(
+            co_head_outputs, co_anchors, [self.image_sizes]
+        )
+        detections_co = self.model.transform.postprocess(
+            detections_co, [self.image_sizes], [self.original_image_sizes]
+        )
+
+        return detections_fw, detections_co

--- a/ssd300_vgg16/pytorch/src/utils.py
+++ b/ssd300_vgg16/pytorch/src/utils.py
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from collections import OrderedDict
+from typing import Optional
+
 import torch
 from torch import Tensor
-import torch.nn.functional as F
-from torchvision.models.detection import _utils as det_utils
-from torchvision.ops import boxes as box_ops
-from torchvision.models.detection.anchor_utils import DefaultBoxGenerator
-from torchvision.models.detection.transform import GeneralizedRCNNTransform
 
 
 # Patched versions of DefaultBoxGenerator methods that propagate device into
@@ -80,127 +78,59 @@ def patched_forward(self, image_list, feature_maps: list[Tensor]) -> list[Tensor
     return dboxes
 
 
-# SSD300 VGG16 post-processing utilities
-def postprocess_detections_ssd(
-    head_outputs: dict[str, torch.Tensor],
-    image_anchors: list[torch.Tensor],
-    image_shapes: list[tuple[int, int]],
-) -> list[dict[str, torch.Tensor]]:
-    """Post-process SSD detection outputs."""
+# See https://github.com/tenstorrent/tt-metal/issues/39171
+def patched_SSD_forward(
+    self, images: list[Tensor], targets: Optional[list[dict[str, Tensor]]] = None
+) -> tuple[dict[str, Tensor], list[dict[str, Tensor]]]:
+    if self.training:
+        if targets is None:
+            torch._assert(False, "targets should not be none when in training mode")
+        else:
+            for target in targets:
+                boxes = target["boxes"]
+                if isinstance(boxes, torch.Tensor):
+                    torch._assert(
+                        len(boxes.shape) == 2 and boxes.shape[-1] == 4,
+                        f"Expected target boxes to be a tensor of shape [N, 4], got {boxes.shape}.",
+                    )
+                else:
+                    torch._assert(
+                        False,
+                        f"Expected target boxes to be of type Tensor, got {type(boxes)}.",
+                    )
 
-    bbox_regression = head_outputs["bbox_regression"]
-    pred_scores = F.softmax(head_outputs["cls_logits"], dim=-1)
+    original_image_sizes: list[tuple[int, int]] = []
+    for img in images:
+        val = img.shape[-2:]
+        torch._assert(
+            len(val) == 2,
+            f"expecting the last two dimensions of the Tensor to be H and W instead got {img.shape[-2:]}",
+        )
+        original_image_sizes.append((val[0], val[1]))
 
-    num_classes = pred_scores.size(-1)
-    device = pred_scores.device
+    images, targets = self.transform(images, targets)
 
-    detections: list[dict[str, torch.Tensor]] = []
-
-    for boxes, scores, anchors, image_shape in zip(
-        bbox_regression, pred_scores, image_anchors, image_shapes
-    ):
-        box_coder = det_utils.BoxCoder(weights=(10.0, 10.0, 5.0, 5.0))
-        boxes = box_coder.decode_single(boxes, anchors)
-        boxes = box_ops.clip_boxes_to_image(boxes, image_shape)
-
-        image_boxes = []
-        image_scores = []
-        image_labels = []
-        for label in range(1, num_classes):
-            score = scores[:, label]
-
-            keep_idxs = score > 0.01
-            score = score[keep_idxs]
-            box = boxes[keep_idxs]
-
-            # keep only topk scoring predictions
-            num_topk = det_utils._topk_min(score, 400, 0)
-            score, idxs = score.topk(num_topk)
-            box = box[idxs]
-
-            image_boxes.append(box)
-            image_scores.append(score)
-            image_labels.append(
-                torch.full_like(
-                    score, fill_value=label, dtype=torch.int64, device=device
+    if targets is not None:
+        for target_idx, target in enumerate(targets):
+            boxes = target["boxes"]
+            degenerate_boxes = boxes[:, 2:] <= boxes[:, :2]
+            if degenerate_boxes.any():
+                bb_idx = torch.where(degenerate_boxes.any(dim=1))[0][0]
+                degen_bb: list[float] = boxes[bb_idx].tolist()
+                torch._assert(
+                    False,
+                    "All bounding boxes should have positive height and width."
+                    f" Found invalid box {degen_bb} for target at index {target_idx}.",
                 )
-            )
 
-        image_boxes = torch.cat(image_boxes, dim=0)
-        image_scores = torch.cat(image_scores, dim=0)
-        image_labels = torch.cat(image_labels, dim=0)
+    features = self.backbone(images.tensors)
+    if isinstance(features, torch.Tensor):
+        features = OrderedDict([("0", features)])
 
-        # non-maximum suppression
-        keep = box_ops.batched_nms(image_boxes, image_scores, image_labels, 0.45)
-        keep = keep[:200]
+    features = list(features.values())
 
-        detections.append(
-            {
-                "boxes": image_boxes[keep],
-                "scores": image_scores[keep],
-                "labels": image_labels[keep],
-            }
-        )
-    return detections
+    head_outputs = self.head(features)
 
+    anchors = self.anchor_generator(images, features)
 
-class SSDPostprocessor:
-    """Post-processor for SSD300 VGG16 detection results."""
-
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
-
-    def process(self, x, y, images):
-        """Process framework and compiled model outputs."""
-
-        fw_head_outputs = {
-            "bbox_regression": x[0],
-            "cls_logits": x[1],
-        }
-        anchors_fw = x[2]
-        anchors_co = y[2]
-        co_head_outputs = {
-            "bbox_regression": y[0],
-            "cls_logits": y[1],
-        }
-        anchor_generator = DefaultBoxGenerator(
-            [[2], [2, 3], [2, 3], [2, 3], [2], [2]],
-            scales=[0.07, 0.15, 0.33, 0.51, 0.69, 0.87, 1.05],
-            steps=[8, 16, 32, 64, 100, 300],
-        )
-
-        image_mean = [0.48235, 0.45882, 0.40784]
-        image_std = [1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0]
-
-        transform = GeneralizedRCNNTransform(
-            min((300, 300)),
-            max(300, 300),
-            image_mean,
-            image_std,
-            size_divisible=1,
-            fixed_size=(300, 300),
-        )
-        images, targets = transform(images)
-        anchors_fw = anchor_generator(images, [x[2]])
-        anchors_co = anchor_generator(images, [y[2]])
-
-        original_image_sizes: list[tuple[int, int]] = []
-        for img in images:
-            val = img.shape[-2:]
-            original_image_sizes.append((val[0], val[1]))
-        detections_fw = postprocess_detections_ssd(
-            fw_head_outputs, anchors_fw, images.image_size
-        )
-        detections_fw = self.model.transform.postprocess(
-            detections_fw, images.image_size, original_image_sizes
-        )
-
-        detections_co = postprocess_detections_ssd(
-            co_head_outputs, anchors_co, images.image_size
-        )
-        detections_co = self.model.transform.postprocess(
-            detections_fw, images.image_size, original_image_sizes
-        )
-
-        return detections_fw, detections_co
+    return (head_outputs, anchors)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/3570

### Problem description

- `ssd300_vgg16` fails with `PCC=0.13025588869684107`. 
- The drop originates from the chain of [softmax](https://github.com/pytorch/vision/blob/d801a34632023859a0a274803d6abaf0a45d77a5/torchvision/models/detection/ssd.py#L418C23-L418C32) -> [slice](https://github.com/pytorch/vision/blob/d801a34632023859a0a274803d6abaf0a45d77a5/torchvision/models/detection/ssd.py#L433C25-L433C41) -> [greater than](https://github.com/pytorch/vision/blob/d801a34632023859a0a274803d6abaf0a45d77a5/torchvision/models/detection/ssd.py#L435C35-L435C36) ops.
- The tt-metal team confirmed that a minor drop in softmax gets amplified at the [greater_than op](https://github.com/tenstorrent/tt-metal/issues/39171#issuecomment-4002314117) and 0.98 is the [best accuracy](https://github.com/tenstorrent/tt-metal/issues/39171#issuecomment-4006038259) achieved for the problematic sanity for now. For complete context, pls checkout these tickets - [#3570](https://github.com/tenstorrent/tt-xla/issues/3570) , [#39171](https://github.com/tenstorrent/tt-metal/issues/39171)
- Since the problematic ops are present in the post-processing part, we can decouple it as a workaround and couple it back later when PCC for the attached sanity exceeds 0.99.

### What's changed

- Patched SSD.forward to return raw (head_outputs, anchors) instead of running post-processing on tt-device
- Removed existing hardcoded post-processing code (SSDPostprocessor, postprocess_detections_ssd) and replaced it with direct calls to torchvision's built-in model.postprocess_detections and model.transform.postprocess
- Post-processing now runs on CPU after inference, avoiding the PCC-sensitive op chain on tt device

### Checklist
- [x] verified the changes through local testing 

### Logs

Before Fix

- [mar9_ssd300vgg16_cpu_before_fix.log](https://github.com/user-attachments/files/25839280/mar9_ssd300vgg16_cpu_bf.log)
- [mar9_ssd300vgg16_xla_before_fix.log](https://github.com/user-attachments/files/25839314/mar9_ssd300vgg16_xla_bf.log)

After Fix

- [mar9_ssd300vgg16_cpu_after_fix.log](https://github.com/user-attachments/files/25839278/mar9_ssd300vgg16_cpu_af.log)
- [mar9_ssd300vgg16_xla_after_fix.log](https://github.com/user-attachments/files/25839313/mar9_ssd300vgg16_xla_af.log)





