### PR TITLE
Align BEVFormerV2 variant_str names with ModelVariant enum

### DIFF
--- a/bevformer/pytorch/src/model.py
+++ b/bevformer/pytorch/src/model.py
@@ -82,13 +82,13 @@ def get_bevformer_v2_model(variant_str):
         },
     }
 
-    if variant_str == "bevformerv2-r50-t1-base":
+    if variant_str == "v2_R50_T1_Base":
         frames = base_config["frames"]
         group_detr = None
         pts_bbox_head_type = "BEVFormerHead"
         self_attn_type = "MultiheadAttention"
 
-    elif variant_str == "bevformerv2-r50-t1":
+    elif variant_str == "v2_R50_T1":
         base_config["frames"] = (0,)
         base_config["group_detr"] = 11
         base_config["ida_aug_conf"] = {
@@ -103,7 +103,7 @@ def get_bevformer_v2_model(variant_str):
         pts_bbox_head_type = "BEVFormerHead_GroupDETR"
         self_attn_type = "GroupMultiheadAttention"
 
-    elif variant_str == "bevformerv2-r50-t2":
+    elif variant_str == "v2_R50_T2":
         base_config["frames"] = (
             -1,
             0,
@@ -121,7 +121,7 @@ def get_bevformer_v2_model(variant_str):
         pts_bbox_head_type = "BEVFormerHead_GroupDETR"
         self_attn_type = "GroupMultiheadAttention"
 
-    elif variant_str == "bevformerv2-r50-t8":
+    elif variant_str == "v2_R50_T8":
         base_config["frames"] = (-7, -6, -5, -4, -3, -2, -1, 0)
         base_config["group_detr"] = 11
         base_config["ida_aug_conf"] = {


### PR DESCRIPTION
### Ticket
Fixes [#3598](https://github.com/tenstorrent/tt-xla/issues/3598)

### Problem description
Model fails with `UnboundLocalError: cannot access local variable 'pts_bbox_head_type'` since model names has been changed in accordance with new naming convention. 

### What's changed

-  The code checked variant_str against old pretrained model name strings like "bevformerv2-r50-t1-base". It now checks variant_str against enum-style names used by the loader like "v2_R50_T1_Base". Variant checks has been changed to use the same naming format as the loader, so the correct configuration branch runs and the model initializes properly.

### Logs
[bev_v2_before.log](https://github.com/user-attachments/files/25842701/bev_v2_error.log)
[bev_v2_after.log](https://github.com/user-attachments/files/25842711/bev_v2.log)
