### PR TITLE
Updated the loader.py file for the Qwen2 model

### DIFF
--- a/qwen_2/causal_lm/pytorch/loader.py
+++ b/qwen_2/causal_lm/pytorch/loader.py
@@ -130,6 +130,7 @@ class ModelLoader(ForgeModel):
             pretrained_model_name, **model_kwargs
         )
         model.eval()
+        self.config = model.config
 
         return model
 
@@ -171,3 +172,46 @@ class ModelLoader(ForgeModel):
                 inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
         return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        """Return mesh shape and axis names for tensor parallel."""
+        if self.config.num_attention_heads % num_devices == 0:
+            mesh_shape = (1, num_devices)
+        elif (
+            self.config.num_attention_heads % (num_devices // 2) == 0
+            and num_devices % 2 == 0
+        ):
+            mesh_shape = (2, num_devices // 2)
+        else:
+            raise ValueError(
+                f"Cannot evenly distribute {self.config.num_attention_heads} heads "
+                f"across {num_devices} devices"
+            )
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+        for layer in model.model.layers:
+            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+
+            shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
+        shard_specs[model.lm_head.weight] = ("model", "batch")
+
+        return shard_specs
+
+    def load_config(self):
+        """Load and return the configuration for the Qwen2 model variant.
+
+        Returns:
+            The configuration object for the Qwen2 model.
+        """
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+
+        return self.config


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
While running qwen_2/causal_lm/pytorch-Qwq_32B-tensor_parallel-inference, I encountered the following error.
```
_ test_all_models_torch[qwen_2/causal_lm/pytorch-Qwq_32B-tensor_parallel-inference] _
tests/runner/test_models.py:294: in test_all_models_torch
    _run_model_test_impl(
tests/runner/test_models.py:116: in _run_model_test_impl
    tester = DynamicTorchModelTester(
tests/runner/testers/torch/dynamic_torch_model_tester.py:59: in __init__
    super().__init__(
tests/infra/testers/single_chip/model/torch_model_tester.py:86: in __init__
    super().__init__(
tests/infra/testers/single_chip/model/model_tester.py:61: in __init__
    self._initialize_components()
tests/infra/testers/single_chip/model/model_tester.py:68: in _initialize_components
    self._initialize_workload()
tests/infra/testers/single_chip/model/torch_model_tester.py:154: in _initialize_workload
    self._workload.mesh and len(self._workload.mesh.device_ids) > 1
E   AssertionError: Tensor parallel requires multi-chip mesh
```

### What's changed
Updated loader.py by adding the functions get_mesh_config, load_shard_spec, and load_config.
After this change, we are not encountering any runtime errors.

I have attached the logs for reference.
[before_fix.log](https://github.com/user-attachments/files/25897860/error.log)
[after_fix.log](https://github.com/user-attachments/files/25898061/after_fix.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
