### PR TITLE
Remove requirements.nodeps.txt from MapTR as mmcv and mmdet dependencies are already removed

### DIFF
--- a/maptr/pytorch/requirements.nodeps.txt
+++ b/maptr/pytorch/requirements.nodeps.txt
@@ -1,3 +1,0 @@
-mmcv-full==1.7.2
-mmdet==2.28.2
-yapf==0.43.0   # required for mmcv


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-models/issues/172

### Problem description

- This [PR](https://github.com/tenstorrent/tt-forge-models/issues/172) removed mmcv & mmdet dependency by adding required code locally from the those packages but missed to remove `requirements.nodeps.txt` file.

### What's changed

- Removed  `requirements.nodeps.txt` from MapTR

### Checklist
- [x] All required checks were already performed in the original PR. This change is only a cleanup PR
