### PR TITLE
Skip BFloat16 conversion in mgp-str-base

### DIFF
--- a/mgp_str_base/pytorch/loader.py
+++ b/mgp_str_base/pytorch/loader.py
@@ -61,7 +61,10 @@ class ModelLoader(ForgeModel):
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
-            model = model.to(dtype_override)
+            # Temporary FP32 workaround: BF16 can trigger a known WH matmul/fp32-dest-acc accuracy issue
+            # Remove once https://github.com/tenstorrent/tt-metal/issues/39518 is resolved.
+            print("NOTE: dtype_override ignored")
+            # model = model.to(dtype_override)
 
         return model
 
@@ -81,7 +84,10 @@ class ModelLoader(ForgeModel):
 
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
-            inputs = inputs.to(dtype_override)
+            # Temporary FP32 workaround: BF16 can trigger a known WH matmul/fp32-dest-acc accuracy issue
+            # Remove once https://github.com/tenstorrent/tt-metal/issues/39518 is resolved.
+            print("NOTE: dtype_override ignored")
+            # inputs = inputs.to(dtype_override)
 
         # Add batch dimension
         inputs = inputs.repeat_interleave(batch_size, dim=0)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/3640

### Problem description

- `mgp-str-base` is failing with a PCC of `0.6037964039577881`.
- The Metal team confirmed that this is caused by a known [WH matmul/fp32-dest-acc accuracy issue](https://github.com/tenstorrent/tt-metal/issues/39518#issuecomment-4033398261).
- Switching the model from BFP16 to FP32 improved PCC to `0.9972705412497568`.
- For Additional context, pls checkout [#3640](https://github.com/tenstorrent/tt-xla/issues/3640) , [#39518](https://github.com/tenstorrent/tt-metal/issues/39518)
- As a temporary workaround, we can skip BFP16 conversion and run the model in FP32 until the issue is resolved.

### What's changed

- Skipped Bfloat16 conversion for this model

### Checklist
- [x] Verified the changes through local testing

### Logs

- [mar11_mgp_str_base_bfp16.log](https://github.com/user-attachments/files/25913135/mar11_mgp_str_base_bfp16.log)
- [mar11_mgp_str_base_fp32.log](https://github.com/user-attachments/files/25913138/mar11_mgp_str_base_fp32.log)

