### PR TITLE
Modify models hf set8

### DIFF
--- a/blip/vision_language/paddlepaddle/loader.py
+++ b/blip/vision_language/paddlepaddle/loader.py
@@ -26,7 +26,7 @@ from ....config import (
     StrEnum,
 )
 from ....base import ForgeModel
-from ....tools.utils import get_file
+from datasets import load_dataset
 
 
 @dataclass
@@ -134,8 +134,8 @@ class ModelLoader(ForgeModel):
         task = self._variant_config.task
         processor = BlipProcessor.from_pretrained(model_name)
 
-        image_path = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        image = Image.open(str(image_path))
+        ds = load_dataset("huggingface/cats-image", split="test")
+        image = ds[0]["image"]
 
         if task == BlipTask.TEXT:
             text = "a photo of cats in bed"

--- a/monodepth2/pytorch/src/utils.py
+++ b/monodepth2/pytorch/src/utils.py
@@ -4,11 +4,11 @@
 import os
 import torch
 from torchvision import transforms
-import requests
 from PIL import Image
 import PIL.Image as pil
 from .resnet_encoder import ResnetEncoder
 from .depth_decoder import DepthDecoder
+from datasets import load_dataset
 from ....tools.utils import get_file
 
 
@@ -51,10 +51,8 @@ def load_model(variant):
 
 def load_input(feed_height, feed_width):
 
-    image_file = get_file(
-        "https://raw.githubusercontent.com/nianticlabs/monodepth2/master/assets/test_image.jpg"
-    )
-    input_image = Image.open(image_file).convert("RGB")
+    dataset = load_dataset("huggingface/cats-image", split="test")
+    input_image = dataset[0]["image"].convert("RGB")
     original_width, original_height = input_image.size
     input_image_resized = input_image.resize((feed_width, feed_height), pil.LANCZOS)
     input_tensor = transforms.ToTensor()(input_image_resized).unsqueeze(0)

--- a/mplug_owl2/pytorch/loader.py
+++ b/mplug_owl2/pytorch/loader.py
@@ -11,6 +11,7 @@ from PIL import Image
 from transformers import AutoTokenizer
 from transformers.models.clip.image_processing_clip import CLIPImageProcessor
 
+from datasets import load_dataset
 from ...tools.utils import get_file
 from ...base import ForgeModel
 from ...config import (
@@ -155,8 +156,8 @@ class ModelLoader(ForgeModel):
             self._load_processors()
 
         # Image
-        image_file = get_file(self.default_image_url)
-        image = Image.open(image_file).convert("RGB")
+        dataset = load_dataset("huggingface/cats-image", split="test")
+        image = dataset[0]["image"].convert("RGB")
 
         image_tensor = process_images([image], self.image_processor)  # (B, C, H, W)
         if batch_size > 1:

--- a/olm_ocr/image_text_generation/pytorch/loader.py
+++ b/olm_ocr/image_text_generation/pytorch/loader.py
@@ -7,6 +7,7 @@
 import torch
 from transformers import AutoProcessor, AutoModelForImageTextToText, AutoConfig
 from typing import Optional
+from datasets import load_dataset
 
 from ....base import ForgeModel
 from ....config import (
@@ -149,6 +150,10 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor(dtype_override=dtype_override)
 
+        # Load image from HuggingFace dataset
+        ds = load_dataset("huggingface/cats-image", split="test")
+        image = ds[0]["image"].convert("RGB")
+
         # Use chat template for input text
         messages = [
             {
@@ -156,7 +161,7 @@ class ModelLoader(ForgeModel):
                 "content": [
                     {
                         "type": "image",
-                        "image": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/pipeline-cat-chonk.jpeg",
+                        "image": image,
                     },
                     {"type": "text", "text": "Describe the image."},
                 ],

--- a/rcnn/pytorch/loader.py
+++ b/rcnn/pytorch/loader.py
@@ -23,10 +23,7 @@ from ...config import (
     Framework,
     StrEnum,
 )
-from ...tools.utils import get_file
-
-# Default image for testing
-DEFAULT_IMAGE_PATH = "forge/test/models/files/samples/images/car.jpg"
+from datasets import load_dataset
 
 
 class ModelVariant(StrEnum):
@@ -138,23 +135,23 @@ class ModelLoader(ForgeModel):
         Args:
             batch_size: Number of samples in the batch
             dtype_override: Optional torch.dtype to override input dtype
-            image_path: Optional path to input image. If None, uses default test image.
+            image_path: Optional path to input image. If None, uses HuggingFace dataset image.
             use_selective_search: Whether to use selective search for region proposals
 
         Returns:
             List of input tensors matching the expected RCNN input format
         """
         if image_path is None:
-            image_path = DEFAULT_IMAGE_PATH
-
-        # Load image
-        try:
-            img = cv2.imread(image_path)
-            if img is None:
-                raise FileNotFoundError(f"Could not load image from {image_path}")
-        except Exception:
-            # Create a dummy image if file not found
-            img = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+            dataset = load_dataset("huggingface/cats-image", split="test")
+            pil_image = dataset[0]["image"].convert("RGB")
+            img = cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
+        else:
+            try:
+                img = cv2.imread(image_path)
+                if img is None:
+                    raise FileNotFoundError(f"Could not load image from {image_path}")
+            except Exception:
+                img = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
 
         # Define transforms
         transform = transforms.Compose(
@@ -218,15 +215,16 @@ class ModelLoader(ForgeModel):
             Tuple of (index, [input_tensor]) for each region proposal
         """
         if image_path is None:
-            image_path = DEFAULT_IMAGE_PATH
-
-        try:
-            img = cv2.imread(image_path)
-            if img is None:
-                raise FileNotFoundError(f"Could not load image from {image_path}")
-        except Exception:
-            # Create a dummy image if file not found
-            img = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
+            dataset = load_dataset("huggingface/cats-image", split="test")
+            pil_image = dataset[0]["image"].convert("RGB")
+            img = cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
+        else:
+            try:
+                img = cv2.imread(image_path)
+                if img is None:
+                    raise FileNotFoundError(f"Could not load image from {image_path}")
+            except Exception:
+                img = np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
 
         # Define transforms
         transform = transforms.Compose(
@@ -286,13 +284,15 @@ class ModelLoader(ForgeModel):
             List of region proposals as [xmin, ymin, xmax, ymax] coordinates
         """
         if image_path is None:
-            image_path = DEFAULT_IMAGE_PATH
-
-        try:
+            dataset = load_dataset("huggingface/cats-image", split="test")
+            pil_image = dataset[0]["image"].convert("RGB")
+            img = cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
+        else:
             img = cv2.imread(image_path)
             if img is None:
                 raise FileNotFoundError(f"Could not load image from {image_path}")
 
+        try:
             # Selective search for region proposals
             gs = cv2.ximgproc.segmentation.createSelectiveSearchSegmentation()
             gs.setBaseImage(img)

--- a/ssd512/object_detection/pytorch/src/model_utils.py
+++ b/ssd512/object_detection/pytorch/src/model_utils.py
@@ -3,15 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 import cv2
 import numpy as np
-from .....tools.utils import get_file
 import torch
 import torch.nn.functional as F
+from datasets import load_dataset
 from ..src.model import decode, nms
 
 
 def load_ssd512_inputs():
-    image_path = get_file("test_images/ssd512_input.jpg")
-    img = cv2.imread(image_path, cv2.IMREAD_COLOR)
+    dataset = load_dataset("huggingface/cats-image", split="test")
+    image = dataset[0]["image"].convert("RGB")
+    img = cv2.cvtColor(np.array(image), cv2.COLOR_RGB2BGR)
     dataset_mean = (104, 117, 123)
     transform = BaseTransform(300, dataset_mean)
     img_t, _, _ = transform(img)

--- a/ultra_fast_lane_detection/pytorch/loader.py
+++ b/ultra_fast_lane_detection/pytorch/loader.py
@@ -25,6 +25,7 @@ from ...config import (
 )
 from ...base import ForgeModel
 from ...tools.utils import get_file
+from datasets import load_dataset
 
 from .src.utils import (
     load_lane_detection_model,
@@ -201,22 +202,11 @@ class ModelLoader(ForgeModel):
 
         return self.model
 
-    def _get_sample_image_path(self) -> Optional[str]:
-        """Get sample image path for the dataset using get_file."""
-        dataset = self.config.dataset
-        sample_image_key = self.SAMPLE_IMAGE_PATHS.get(dataset)
-
-        if not sample_image_key:
-            return None
-
-        try:
-            sample_image_path = str(get_file(sample_image_key))
-            if os.path.exists(sample_image_path):
-                return sample_image_path
-        except Exception as e:
-            print(f"Warning: Could not get sample image: {e}")
-
-        return None
+    def _get_sample_image(self):
+        """Load sample image from HuggingFace dataset."""
+        ds = load_dataset("huggingface/cats-image", split="test")
+        pil_image = ds[0]["image"].convert("RGB")
+        return cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
 
     def input_preprocess(self, dtype_override=None, batch_size=1, image=None):
         """Preprocess input image(s) and return model-ready input tensor.
@@ -229,22 +219,9 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.Tensor: Preprocessed input tensor [batch_size, 3, H, W].
         """
-        # If no image provided, use default sample image for the dataset
+        # If no image provided, load sample image from HuggingFace dataset
         if image is None:
-            dataset = self.config.dataset
-            sample_image_path = self._get_sample_image_path()
-
-            if sample_image_path and os.path.exists(sample_image_path):
-                print(
-                    f"Using predefined sample image for {dataset} dataset: {sample_image_path}"
-                )
-                image = cv2.imread(sample_image_path)
-            else:
-                expected_image = self.SAMPLE_IMAGE_PATHS.get(dataset)
-                raise FileNotFoundError(
-                    f"Sample image not found for {dataset} dataset. "
-                    f"Expected: {expected_image}"
-                )
+            image = self._get_sample_image()
 
         # Convert image to numpy array (BGR format) if needed
         if isinstance(image, Image.Image):

--- a/vgg/image_classification/onnx/src/model_utils.py
+++ b/vgg/image_classification/onnx/src/model_utils.py
@@ -3,32 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
 from torchvision import transforms
-from PIL import Image
-from third_party.tt_forge_models.tools.utils import get_file
-from loguru import logger
+from datasets import load_dataset
 
 
 def get_input_img_osmr():
-    try:
-        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
-        input_image = Image.open(file_path).convert("RGB")
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        input_tensor = preprocess(input_image)
-        input_batch = input_tensor.unsqueeze(
-            0
-        )  # create a mini-batch as expected by the model
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        input_batch = torch.rand(1, 3, 224, 224)
+    dataset = load_dataset("huggingface/cats-image", split="test")
+    input_image = dataset[0]["image"].convert("RGB")
+    preprocess = transforms.Compose(
+        [
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(
+                mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+            ),
+        ]
+    )
+    input_tensor = preprocess(input_image)
+    input_batch = input_tensor.unsqueeze(0)
     return input_batch

--- a/vovnet/pytorch/src/utils.py
+++ b/vovnet/pytorch/src/utils.py
@@ -14,30 +14,22 @@ from timm.data.transforms_factory import create_transform
 import requests
 import shutil
 import time
-from ....tools.utils import get_file
+from datasets import load_dataset
 
 
 def preprocess_steps(model_type):
-    # Use randomly initialized weights (no pretrained download)
     model = model_type(False, True).eval()
     config = resolve_data_config({}, model=model)
     transform = create_transform(**config)
 
-    try:
-        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
-        img = Image.open(file_path).convert("RGB")
-        img_tensor = transform(img).unsqueeze(0)  # transform and add batch dimension
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        img_tensor = torch.rand(1, 3, 224, 224)
+    dataset = load_dataset("huggingface/cats-image", split="test")
+    img = dataset[0]["image"].convert("RGB")
+    img_tensor = transform(img).unsqueeze(0)
 
     return model, img_tensor
 
 
 def preprocess_timm_model(model_name):
-    # Use randomly initialized weights (no pretrained download)
     use_pretrained_weights = False
     if model_name == "ese_vovnet99b":
         use_pretrained_weights = False
@@ -46,15 +38,9 @@ def preprocess_timm_model(model_name):
     config = resolve_data_config({}, model=model)
     transform = create_transform(**config)
 
-    try:
-        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
-        img = Image.open(file_path).convert("RGB")
-        img_tensor = transform(img).unsqueeze(0)  # transform and add batch dimension
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        img_tensor = torch.rand(1, 3, 224, 224)
+    dataset = load_dataset("huggingface/cats-image", split="test")
+    img = dataset[0]["image"].convert("RGB")
+    img_tensor = transform(img).unsqueeze(0)
 
     return model, img_tensor
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge-models/issues/428)

### Problem description
Currently, model inputs are handled by links from different sources.This issue aims to standardize input handling across all models by using the Hugging Face load_dataset API as the primary source of input data

### What's changed
Modified monodepth2, mplug_owl2, ssd512, blip/paddlepaddle,minicpm_o_2_6, rcnn, ultra_fast_lane_detection, vovnet,vgg/onnx, and olm_ocr models to use load_dataset from HuggingFace instead of get_file for image inputs

### Checklist
- [x] New/Existing tests provide coverage for changes

I have attached the logs for your reference:

[test_inputs_set8.py](https://github.com/user-attachments/files/26021954/test_inputs_set8.py)

[test_monodepth2.log](https://github.com/user-attachments/files/26021903/test_monodepth2.log)
[test_mplug_owl2.log](https://github.com/user-attachments/files/26021905/test_mplug_owl2.log)
[test_olm_ocr.log](https://github.com/user-attachments/files/26021906/test_olm_ocr.log)
[test_rcnn.log](https://github.com/user-attachments/files/26021907/test_rcnn.log)
[test_ssd512.log](https://github.com/user-attachments/files/26021909/test_ssd512.log)
[test_ultra_fast_lane_detection.log](https://github.com/user-attachments/files/26021911/test_ultra_fast_lane_detection.log)
[test_vgg_onnx.log](https://github.com/user-attachments/files/26021912/test_vgg_onnx.log)
[test_vovnet.log](https://github.com/user-attachments/files/26021913/test_vovnet.log)
