### PR TITLE
Update TorchCodec requirement for pi_0 model

### DIFF
--- a/pi_0/pytorch/requirements.txt
+++ b/pi_0/pytorch/requirements.txt
@@ -2,7 +2,7 @@ transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_o
 tokenizers==0.21.1
 draccus==0.10.0
 gymnasium==1.2.3
-torchcodec==0.9.1
+torchcodec==0.10.0
 pyserial==3.5
 deepdiff==8.6.1
 av==15.0.0


### PR DESCRIPTION
### Ticket
closes #531 

### Problem description
PyTorch is uplifted to v2.10 in tt-xla and it is not compatible with torchcode 0.9.1.

### What's changed
Update requirements for Pi_0 models

**Note:** This PR will be merged once we uplift PyTorch in tt-xla