### PR TITLE
Modify models hf set9

### DIFF
--- a/deepseek/deepseek_ocr/pytorch/loader.py
+++ b/deepseek/deepseek_ocr/pytorch/loader.py
@@ -18,7 +18,7 @@ from ....config import (
     Framework,
     StrEnum,
 )
-from ....tools.utils import get_file
+from datasets import load_dataset
 from .src.modeling_deepseekocr import DeepseekOCRForCausalLM
 from .src.model_utils import preprocess
 from huggingface_hub import snapshot_download
@@ -159,8 +159,13 @@ class ModelLoader(ForgeModel):
         if self.tokenizer is None:
             self._load_tokenizer()
 
-        # Load the sample image
-        image_file = get_file("test_images/doc.png")
+        # Load image from HuggingFace dataset
+        import tempfile
+        ds = load_dataset("huggingface/cats-image", split="test")
+        image = ds[0]["image"].convert("RGB")
+        tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+        image.save(tmp.name)
+        image_file = tmp.name
 
         # Process the image and prompt using the preprocess function
         inputs = preprocess(

--- a/mnist/image_classification/pytorch/loader.py
+++ b/mnist/image_classification/pytorch/loader.py
@@ -19,8 +19,8 @@ from third_party.tt_forge_models.config import (
     ModelConfig,
 )
 from third_party.tt_forge_models.base import ForgeModel
-from torch.utils.data import DataLoader
-from torchvision import datasets, transforms
+from torchvision import transforms
+from datasets import load_dataset
 
 
 class MNISTCNNDropoutModel(torch.nn.Module):
@@ -190,11 +190,8 @@ class ModelLoader(ForgeModel):
             torch.Tensor: Input tensor that can be fed to the model.
         """
         transform = transforms.Compose([transforms.ToTensor()])
-        test_dataset = datasets.MNIST(
-            root="./data", train=False, transform=transform, download=True
-        )
-        dataloader = DataLoader(test_dataset, batch_size=2)
-        test_input, _ = next(iter(dataloader))
+        ds = load_dataset("ylecun/mnist", split="test")
+        test_input = torch.stack([transform(ds[i]["image"]) for i in range(2)])
 
         if dtype_override is not None:
             test_input = test_input.to(dtype=dtype_override)

--- a/panoptic_segmentation/pytorch/loader.py
+++ b/panoptic_segmentation/pytorch/loader.py
@@ -360,33 +360,29 @@ class ModelLoader(ForgeModel):
         """Run inference on an image using the loaded predictor.
 
         Args:
-            image_path: Optional path to image file. If None, uses sample image URL.
+            image_path: Optional path to image file. If None, uses HuggingFace dataset image.
 
         Returns:
             Dict containing panoptic segmentation results
         """
-        # Lazy imports - only import when actually running prediction
         import cv2
-        import urllib.request
+        from datasets import load_dataset
 
         if self.predictor is None:
             raise RuntimeError("Model not loaded. Call load_model() first.")
 
         # Load image
         if image_path is None:
-            # Use sample image from config
-            config = self._variant_config
-            if config.sample_image_url:
-                image_path = config.sample_image_url
+            ds = load_dataset("huggingface/cats-image", split="test")
+            pil_image = ds[0]["image"].convert("RGB")
+            im = cv2.cvtColor(np.array(pil_image), cv2.COLOR_RGB2BGR)
+        elif image_path.startswith("http"):
+            import urllib.request
 
-        if image_path.startswith("http"):
-            # Download image from URL
-            print(f"Downloading image from: {image_path}")
             with urllib.request.urlopen(image_path) as response:
                 image_data = np.asarray(bytearray(response.read()), dtype="uint8")
                 im = cv2.imdecode(image_data, cv2.IMREAD_COLOR)
         else:
-            # Load from local file
             im = cv2.imread(image_path)
 
         if im is None:

--- a/phi3/phi_3_5_vision/pytorch/loader.py
+++ b/phi3/phi_3_5_vision/pytorch/loader.py
@@ -8,7 +8,7 @@ import torch
 from transformers import AutoProcessor, AutoModelForCausalLM
 from PIL import Image
 from typing import Optional
-from ....tools.utils import get_file
+from datasets import load_dataset
 from ....base import ForgeModel
 from ....config import (
     ModelConfig,
@@ -124,11 +124,9 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor()
 
-        # Load image from URL
-        image_file = get_file(
-            "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
-        )
-        image = Image.open(image_file)
+        # Load image from HuggingFace dataset
+        ds = load_dataset("huggingface/cats-image", split="test")
+        image = ds[0]["image"].convert("RGB")
 
         # Set up messages
         self.messages = [

--- a/qwen_2_5_vl/pytorch/loader.py
+++ b/qwen_2_5_vl/pytorch/loader.py
@@ -7,7 +7,7 @@ Qwen 2.5 VL model loader implementation for vision-language tasks.
 import torch
 from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor, AwqConfig
 from typing import Optional
-
+from datasets import load_dataset
 
 from ...base import ForgeModel
 from ...config import (
@@ -58,18 +58,7 @@ class ModelLoader(ForgeModel):
     DEFAULT_VARIANT = ModelVariant.QWEN_2_5_VL_3B_INSTRUCT
 
     # Shared configuration parameters
-    messages = [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "image",
-                    "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
-                },
-                {"type": "text", "text": "Describe this image."},
-            ],
-        }
-    ]
+    messages = None
 
     # Vision processing parameters
     min_pixels = 56 * 56
@@ -178,6 +167,23 @@ class ModelLoader(ForgeModel):
         # Ensure processor is initialized
         if self.processor is None:
             self._load_processor()
+
+        # Load image from HuggingFace dataset
+        ds = load_dataset("huggingface/cats-image", split="test")
+        image = ds[0]["image"].convert("RGB")
+
+        self.messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "image": image,
+                    },
+                    {"type": "text", "text": "Describe this image."},
+                ],
+            }
+        ]
 
         # Apply chat template to get text prompt
         text = self.processor.apply_chat_template(

--- a/qwen_3_vl/image_to_text/pytorch/loader.py
+++ b/qwen_3_vl/image_to_text/pytorch/loader.py
@@ -7,6 +7,7 @@ Qwen 3 model loader implementation for image to text.
 
 from transformers import Qwen3VLForConditionalGeneration, AutoProcessor
 from typing import Optional
+from datasets import load_dataset
 
 from ....base import ForgeModel
 from ....config import (
@@ -128,13 +129,16 @@ class ModelLoader(ForgeModel):
         Returns:
             dict: Input tensors that can be fed to the model.
         """
+        ds = load_dataset("huggingface/cats-image", split="test")
+        image = ds[0]["image"].convert("RGB")
+
         messages = [
             {
                 "role": "user",
                 "content": [
                     {
                         "type": "image",
-                        "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+                        "image": image,
                     },
                     {"type": "text", "text": "Describe this image."},
                 ],


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge-models/issues/428)

### Problem description
Currently, model inputs are handled by links from different sources.This issue aims to standardize input handling across all models by using the Hugging Face load_dataset API as the primary source of input data

### What's changed
Modified phi3/phi_3_5_vision, qwen_3_vl, qwen_2_5_vl,deepseek/deepseek_ocr, panoptic_segmentation, and mnist
models to use load_dataset from HuggingFace instead of get_file/hardcoded URLs for image inputs

### Checklist
- [x] New/Existing tests provide coverage for changes

###log:
[test_deepseek_ocr.log](https://github.com/user-attachments/files/26115182/test_deepseek_ocr.log)
[test_mnist.log](https://github.com/user-attachments/files/26115184/test_mnist.log)
[test_panoptic_segmentation.log](https://github.com/user-attachments/files/26115187/test_panoptic_segmentation.log)
[test_phi3_vision.log](https://github.com/user-attachments/files/26115188/test_phi3_vision.log)
[test_qwen_2_5_vl.log](https://github.com/user-attachments/files/26115189/test_qwen_2_5_vl.log)
[test_qwen_3_vl.log](https://github.com/user-attachments/files/26115190/test_qwen_3_vl.log)
