### PR TITLE
Fix for PCC regression in nightly after Forge models uplift #3759

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -340,11 +340,12 @@ def get_static_cache_decode_inputs(
     token_id = get_simple_decode_token_id(tokenizer, config)
     input_ids = torch.full((batch_size, 1), fill_value=token_id, dtype=torch.long)
     prefill_len = max_cache_len - 1
-    prefill_input_ids = torch.full(
-        (batch_size, prefill_len),
-        token_id,
-        dtype=torch.long,
-        device=device,
+
+    sample_text = "The quick brown fox jumps over the lazy dog. " * 10
+    sample_ids = tokenizer.encode(sample_text, add_special_tokens=False)
+    tiled = (sample_ids * ((prefill_len // len(sample_ids)) + 1))[:prefill_len]
+    prefill_input_ids = (
+        torch.tensor(tiled, dtype=torch.long).unsqueeze(0).expand(batch_size, -1)
     )
 
     with torch.no_grad():


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3759)

### Problem description
Previous implementation used a constant token ID to fill the prefill inputs. This created a all-identical key/value vectors which collapsed attention in Qwen 2.5 models and caused two variants to fail PCC.

### What's changed
Updated the prefill input_ids generation in get_static_cache_decode_inputs with sample-text-based token IDs produces a realistic, non-degenerate KV cache by tokenizing a fixed sample sentence, avoiding the attention collapse caused by all-identical key/value vectors.

CI run: https://github.com/tenstorrent/tt-xla/actions/runs/23356895547
<img width="1001" height="262" alt="image" src="https://github.com/user-attachments/assets/fb4691e5-4080-406a-a38c-f0f99a50fb5a" />

FAILED tests/runner/test_models.py::test_llms_torch[llama/causal_lm/pytorch-3.2_3B-llm_decode-seq_1-batch_1-single_device-inference]
AssertionError: Evaluation result 0 failed: PCC comparison failed. Calculated: pcc=0.9786484942861905. Required: pcc=0.99.

### Checklist
- [ ] New/Existing tests provide coverage for changes
