### PR TITLE
Fix Device Propogation Error in BevFormer and Maptr

### DIFF
--- a/bevformer/pytorch/src/model.py
+++ b/bevformer/pytorch/src/model.py
@@ -1069,25 +1069,25 @@ class BEVFormer(MVXTwoStageDetector):
             float(img_metas[0][0]["can_bus"][2]),
         ]
         tmp_angle = float(img_metas[0][0]["can_bus"][-1])
-        if self.prev_frame_info["prev_bev"] is not None:
-            can_bus = img_metas[0][0]["can_bus"]
-            can_bus[:3] = [
-                float(can_bus[0]) - float(self.prev_frame_info["prev_pos"][0]),
-                float(can_bus[1]) - float(self.prev_frame_info["prev_pos"][1]),
-                float(can_bus[2]) - float(self.prev_frame_info["prev_pos"][2]),
-            ]
-            can_bus[-1] = float(can_bus[-1]) - float(self.prev_frame_info["prev_angle"])
-        else:
-            img_metas[0][0]["can_bus"][-1] = 0
-            img_metas[0][0]["can_bus"][:3] = 0
-
-        # Convert can_bus from numpy to a tensor on the model's device so that
-        # the compiled graph fragment for simple_test receives a properly placed
-        # tensor instead of a CPU tensor (which breaks XLA graph partitioning).
+        # Keep can_bus as a tensor on the model device before any in-place edits.
+        # Using Python-list slice assignment on an XLA tensor can introduce CPU
+        # values into the graph and trigger device propagation failures.
         _dev = next(self.parameters()).device
-        img_metas[0][0]["can_bus"] = torch.as_tensor(
-            img_metas[0][0]["can_bus"], dtype=torch.float64
-        ).to(_dev)
+        can_bus = torch.as_tensor(img_metas[0][0]["can_bus"], dtype=torch.float64).to(
+            _dev
+        )
+        can_bus = can_bus.clone()
+
+        if self.prev_frame_info["prev_bev"] is not None:
+            prev_pos = can_bus.new_tensor(self.prev_frame_info["prev_pos"])
+            prev_angle = can_bus.new_tensor(self.prev_frame_info["prev_angle"])
+            can_bus[:3] = can_bus[:3] - prev_pos
+            can_bus[-1] = can_bus[-1] - prev_angle
+        else:
+            can_bus[:3] = 0.0
+            can_bus[-1] = 0.0
+
+        img_metas[0][0]["can_bus"] = can_bus
 
         new_prev_bev, bbox_results = self.simple_test(
             img_metas[0], img[0], prev_bev=self.prev_frame_info["prev_bev"], **kwargs

--- a/maptr/pytorch/src/maptr.py
+++ b/maptr/pytorch/src/maptr.py
@@ -6388,16 +6388,17 @@ class MapTR(MVXTwoStageDetector):
         tmp_pos = copy.deepcopy(img_metas[0][0]["can_bus"][:3])
         tmp_angle = copy.deepcopy(img_metas[0][0]["can_bus"][-1])
 
-        img_metas[0][0]["can_bus"][-1] = 0
-        img_metas[0][0]["can_bus"][:3] = 0
-
-        # Convert can_bus from numpy to a tensor on the model's device so that
-        # the compiled graph fragment for simple_test receives a properly placed
-        # tensor instead of a CPU tensor (which breaks XLA graph partitioning).
+        # Keep can_bus as a tensor on the model device before any in-place edits.
+        # Using Python scalar/list slice assignment on an XLA tensor can introduce
+        # CPU values into the graph and trigger device propagation failures.
         _dev = next(self.parameters()).device
-        img_metas[0][0]["can_bus"] = torch.as_tensor(
-            img_metas[0][0]["can_bus"], dtype=torch.float64
-        ).to(_dev)
+        can_bus = torch.as_tensor(img_metas[0][0]["can_bus"], dtype=torch.float64).to(
+            _dev
+        )
+        can_bus = can_bus.clone()
+        can_bus[:3] = 0.0
+        can_bus[-1] = 0.0
+        img_metas[0][0]["can_bus"] = can_bus
 
         new_prev_bev, bbox_results = self.simple_test(
             img_metas[0],


### PR DESCRIPTION
### Ticket
Fixes [#3787](https://github.com/tenstorrent/tt-xla/issues/3787)

### Problem description
`bevformer/pytorch-Base-single_device-inference` and `maptr/pytorch-Tiny_R50_24e-single_device-inference `variant fails with `RuntimeError: Unhandled FakeTensor Device Propagation for aten.where.self, found two different devices cpu, xla:0`

### What's changed

-  Refactored the can_bus handling to ensure all computations stay on same device from the very beginning, eliminating CPU/XLA mixing.

- Instead of modifying a cpu element and later converting it, can_bus has been converted into a tensor on the target device and perform all updates in-place using tensor operations.

- Replaced Python list-based slice assignments with direct tensor arithmetic, created previous state values (prev_pos, prev_angle) directly on the same device and dtype as can_bus

- Finally, stored the updated tensor back into img_metas so the rest of the code receives the correctly placed tensor.

- This preserves the original behavior while ensuring consistent device placement, resolving the FakeTensor propagation error caused by mixing CPU values with XLA tensors during graph tracing.

- Similar changes were done to maptr model as well.

- Post these changes model fails with out of memory error.

- Verified that these changes do not affect the final results from the original cpu run results.

### Logs
[bev_base_before.log](https://github.com/user-attachments/files/26259179/bev_base_before.log)
[bev_base_after.zip](https://github.com/user-attachments/files/26259241/bev_base_after.zip)
[maptr_tiny_before.log](https://github.com/user-attachments/files/26261485/maptr_tiny_before.log)
[maptr_after_fix.log](https://github.com/user-attachments/files/26261491/maptr_after_fix.log)
