### PR TITLE
Updating the mistral loader file

### DIFF
--- a/mistral/pytorch/loader.py
+++ b/mistral/pytorch/loader.py
@@ -347,7 +347,11 @@ class ModelLoader(ForgeModel):
         return self.tokenizer.decode([next_token])
 
     def get_mesh_config(self, num_devices: int):
-        mesh_shape = (1, num_devices)
+        if num_devices == 32:  # Galaxy
+            mesh_shape = (4, 8)
+        else:
+            mesh_shape = (2, num_devices // 2)
+
         if self._variant not in [
             ModelVariant.MINISTRAL_3B,
         ]:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Updating the Mistral loader file to retrieve the mesh configuration for the Galaxy machine.

### What's changed
Added an if-else condition in get_mesh_config to enable mesh_shape for different machines.

ci run after fix: https://github.com/tenstorrent/tt-xla/actions/runs/23523620332


### Checklist
- [ ] New/Existing tests provide coverage for changes
