### PR TITLE
Fix Runtime Error in Uniad and BevDepth Model

### DIFF
--- a/bevdepth/pytorch/src/model.py
+++ b/bevdepth/pytorch/src/model.py
@@ -1425,7 +1425,7 @@ class VoxelPoolingInference(Function):
         Vz = voxel_num_z
 
         total_samples = B * Cams * D * H * W
-        geom_flat = geom_xyz.view(total_samples, 3)
+        geom_flat = geom_xyz.reshape(total_samples, 3)
         sx_all = geom_flat[:, 0]
         sy_all = geom_flat[:, 1]
         sz_all = geom_flat[:, 2]

--- a/uniad/pytorch/src/track_utils.py
+++ b/uniad/pytorch/src/track_utils.py
@@ -1658,7 +1658,18 @@ class Instances:
                 ret.set(k, ret_list)
 
             else:
-                ret.set(k, v[item])
+                field_item = item
+                # Keep tensor indexing on the same device as the indexed field.
+                if isinstance(item, torch.Tensor):
+                    if isinstance(v, torch.Tensor) and item.device != v.device:
+                        field_item = item.to(v.device)
+                    elif (
+                        hasattr(v, "tensor")
+                        and isinstance(v.tensor, torch.Tensor)
+                        and item.device != v.tensor.device
+                    ):
+                        field_item = item.to(v.tensor.device)
+                ret.set(k, v[field_item])
         return ret
 
     def __len__(self) -> int:


### PR DESCRIPTION
### Ticket
Fixes [#3835](https://github.com/tenstorrent/tt-xla/issues/3835) and [#3993](https://github.com/tenstorrent/tt-xla/issues/3993)

### Problem description

- `uniad/pytorch-single_device-inference` test case fails with `Check failed: bridge::IsXlaTensor(self) && indices_on_cpu_or_xla: indices should be either on cpu or on the same device as the indexed tensor (XLA). When using XLA, the indexed tensor must be an XLA tensor.`

- `bevdepth/pytorch-bev_depth_lss_r50_256x704_128x128_24e_2key-single_device-inference ` fails with `RuntimeError: view size is not compatible with input tensor's size and stride`

### What's changed

- Model fails with `Check failed: bridge::IsXlaTensor(self) && indices_on_cpu_or_xla". The crash happens during boolean indexing inside Instances.__getitem__ and the mask track_instances.obj_idxes >= 0 is created in track_utils.py. Instances.__getitem__  in track_utils.py applies the same mask v[item] to all fields.
Some fields like Python lists or tensors on different devices are not compatible with that backend-specific mask.
This triggers a device mismatch error and hence indices must be on CPU or same device as tensor.
Root cause is that single single backend-specific boolean mask is reused across CPU tensors, XLA/TT tensors and Python lists. This causes invalid indexing when devices don’t match. The fix in track_utils.py solves it by moving the index tensor to CPU before applying it where needed. For kalman_models which is a list used here, it now uses item.cpu() before iterating/selecting list elements. This avoids passing a backend-specific mask into incompatible list indexing paths, preventing the device check failure. Post this change, model fails with out of memory error.

- Replaced view with reshape to fix the error in Bevdepth model. After this change, model fails with `DRAM Auto slice could not find valid slice configuration. Tried up to 2 slices for width-slicing on output dimension 44. Available L1: 1329888 bytes. Operation requires more memory than available even with maximum slicing.`


### Logs
[uniad_before_fix.log](https://github.com/user-attachments/files/26259869/uniad_before_fix.log)
[uniad_after_fix.zip](https://github.com/user-attachments/files/26259874/uniad_after_fix.zip)
[bevdepth_24e_key_single_before.log](https://github.com/user-attachments/files/26355073/bevdepth_24e_key_single_before.log)
[bevdepth_after_fix.zip](https://github.com/user-attachments/files/26355080/bevdepth_after_fix.zip)
