### PR TITLE
Add loaders for onnx models:Set2

### DIFF
--- a/beit/image_classification/onnx/__init__.py
+++ b/beit/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/beit/image_classification/onnx/loader.py
+++ b/beit/image_classification/onnx/loader.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+BEiT ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        output = self.model(pixel_values=pixel_values)
+        return output.logits
+
+
+class ModelLoader(PyTorchModelLoader):
+    """BEiT ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load BEiT as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.BASE is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        torch_model.eval()
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for BEiT image classification."""
+        inputs = self.torch_loader.load_inputs(**kwargs)
+        return [inputs["pixel_values"]]

--- a/deit/image_classification/onnx/__init__.py
+++ b/deit/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/deit/image_classification/onnx/__init__.py
+++ b/deit/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ..pytorch.loader import ModelVariant

--- a/deit/image_classification/onnx/loader.py
+++ b/deit/image_classification/onnx/loader.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DeiT ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ..pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        output = self.model(pixel_values)
+        if isinstance(output, (list, tuple)):
+            return output[0]
+        return output.logits
+
+
+class ModelLoader(PyTorchModelLoader):
+    """DeiT ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load DeiT as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.BASE is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for DeiT image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]

--- a/deit/image_classification/onnx/loader.py
+++ b/deit/image_classification/onnx/loader.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DeiT ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader, ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        output = self.model(pixel_values)
+        if isinstance(output, (list, tuple)):
+            return output[0]
+        return output.logits
+
+
+class ModelLoader(PyTorchModelLoader):
+    """DeiT ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load DeiT as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.BASE is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for DeiT image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]

--- a/detr/object_detection/onnx/__init__.py
+++ b/detr/object_detection/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/detr/object_detection/onnx/__init__.py
+++ b/detr/object_detection/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ..pytorch.loader import ModelVariant

--- a/detr/object_detection/onnx/loader.py
+++ b/detr/object_detection/onnx/loader.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DETR ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        output = self.model(pixel_values=pixel_values)
+
+        # Export stable tensor outputs for object detection
+        if isinstance(output, (list, tuple)):
+            return output[0], output[1]
+
+        return output.logits, output.pred_boxes
+
+
+class ModelLoader(PyTorchModelLoader):
+    """DETR ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load DETR as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.RESNET_50 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for DETR object detection."""
+        inputs = self.torch_loader.load_inputs(**kwargs)
+        return [inputs["pixel_values"]]

--- a/detr/object_detection/onnx/loader.py
+++ b/detr/object_detection/onnx/loader.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DETR ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ..pytorch.loader import ModelLoader as PyTorchModelLoader
+from ..pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        output = self.model(pixel_values=pixel_values)
+
+        # Export stable tensor outputs for object detection
+        if isinstance(output, (list, tuple)):
+            return output[0], output[1]
+
+        return output.logits, output.pred_boxes
+
+
+class ModelLoader(PyTorchModelLoader):
+    """DETR ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load DETR as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.RESNET_50 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            opset_version=18,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for DETR object detection."""
+        inputs = self.torch_loader.load_inputs(**kwargs)
+        return [inputs["pixel_values"]]

--- a/detr/segmentation/onnx/__init__.py
+++ b/detr/segmentation/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/detr/segmentation/onnx/__init__.py
+++ b/detr/segmentation/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ..pytorch.loader import ModelVariant

--- a/detr/segmentation/onnx/loader.py
+++ b/detr/segmentation/onnx/loader.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DETR segmentation ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        output = self.model(pixel_values=pixel_values)
+
+        # Export stable segmentation tensors
+        if isinstance(output, (list, tuple)):
+            return output[0], output[1], output[2]
+
+        return output.logits, output.pred_boxes, output.pred_masks
+
+
+class ModelLoader(PyTorchModelLoader):
+    """DETR segmentation ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load DETR segmentation model, export to ONNX, then return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.RESNET_50_PANOPTIC is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for DETR image segmentation."""
+        inputs = self.torch_loader.load_inputs(**kwargs)
+        return [inputs["pixel_values"]]

--- a/detr/segmentation/onnx/loader.py
+++ b/detr/segmentation/onnx/loader.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DETR segmentation ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ..pytorch.loader import ModelLoader as PyTorchModelLoader
+from ..pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        output = self.model(pixel_values=pixel_values)
+
+        # Export stable segmentation tensors
+        if isinstance(output, (list, tuple)):
+            return output[0], output[1], output[2]
+
+        return output.logits, output.pred_boxes, output.pred_masks
+
+
+class ModelLoader(PyTorchModelLoader):
+    """DETR segmentation ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load DETR segmentation model, export to ONNX, then return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.RESNET_50_PANOPTIC is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for DETR image segmentation."""
+        inputs = self.torch_loader.load_inputs(**kwargs)
+        return [inputs["pixel_values"]]

--- a/dla/image_classification/onnx/__init__.py
+++ b/dla/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/dla/image_classification/onnx/loader.py
+++ b/dla/image_classification/onnx/loader.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DLA ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, pixel_values):
+        output = self.model(pixel_values)
+        if isinstance(output, (list, tuple)):
+            return output[0]
+        return output
+
+
+class ModelLoader(PyTorchModelLoader):
+    """DLA ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load DLA as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.DLA34 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            opset_version=18,
+            input_names=["input"],
+            output_names=["output"],
+            dynamic_axes={"input": {0: "batch"}, "output": {0: "batch"}},
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for DLA image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities."""
+        print_compiled_model_results(outputs)

--- a/ghostnet/image_classification/onnx/__init__.py
+++ b/ghostnet/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/ghostnet/image_classification/onnx/loader.py
+++ b/ghostnet/image_classification/onnx/loader.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+GhostNet ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """GhostNet ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load GhostNet as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.GHOSTNET_100 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for GhostNet image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities."""
+        print_compiled_model_results(outputs)

--- a/glpn_kitti/image_classification/onnx/__init__.py
+++ b/glpn_kitti/image_classification/onnx/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader

--- a/glpn_kitti/image_classification/onnx/loader.py
+++ b/glpn_kitti/image_classification/onnx/loader.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+GLPN-KITTI ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ModelLoader(PyTorchModelLoader):
+    """GLPN-KITTI ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load GLPN-KITTI as a torch model, export to ONNX, then return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        torch_model.eval()
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader.model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            input_names=["input"],
+            output_names=["output"],
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for GLPN-KITTI depth estimation."""
+        inputs = self.torch_loader.load_inputs(**kwargs)
+        return [inputs["pixel_values"]]

--- a/hrnet/image_classification/onnx/__init__.py
+++ b/hrnet/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/hrnet/image_classification/onnx/loader.py
+++ b/hrnet/image_classification/onnx/loader.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HRNet ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """HRNet ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load HRNet as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.HRNET_W18_SMALL is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for HRNet image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities."""
+        print_compiled_model_results(outputs)

--- a/inception/image_classification/onnx/__init__.py
+++ b/inception/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/inception/image_classification/onnx/loader.py
+++ b/inception/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Inception ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """Inception ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load Inception as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.INCEPTION_V4 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            input_names=["input"],
+            output_names=["output"],
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for Inception image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities."""
+        print_compiled_model_results(outputs)

--- a/mgp_str_base/image_classification/onnx/__init__.py
+++ b/mgp_str_base/image_classification/onnx/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader

--- a/mgp_str_base/image_classification/onnx/loader.py
+++ b/mgp_str_base/image_classification/onnx/loader.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MGP-STR Base ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, inputs):
+        return self.model(inputs)[0]
+
+
+class ModelLoader(PyTorchModelLoader):
+    """MGP-STR Base ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load MGP-STR as a torch model, export to ONNX, then return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader.model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            input_names=["input"],
+            output_names=["output"],
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for MGP-STR scene text recognition."""
+        return [self.torch_loader.load_inputs(**kwargs)]

--- a/mlp_mixer/image_classification/onnx/__init__.py
+++ b/mlp_mixer/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/mlp_mixer/image_classification/onnx/loader.py
+++ b/mlp_mixer/image_classification/onnx/loader.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MLP-Mixer ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ModelLoader(PyTorchModelLoader):
+    """MLP-Mixer ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load MLP-Mixer as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.MIXER_S32_224 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            input_names=["input"],
+            output_names=["output"],
+            keep_initializers_as_inputs=True,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for MLP-Mixer image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]
+
+    def print_cls_results(self, outputs):
+        """Print classification results using the variant-specific label set."""
+        self.torch_loader.print_cls_results(outputs)

--- a/mnist/image_classification/onnx/__init__.py
+++ b/mnist/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/mnist/image_classification/onnx/__init__.py
+++ b/mnist/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ..pytorch.loader import ModelVariant

--- a/mnist/image_classification/onnx/loader.py
+++ b/mnist/image_classification/onnx/loader.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MNIST ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ModelLoader(PyTorchModelLoader):
+    """MNIST ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load MNIST as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.CNN_DROPOUT is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            input_names=["input"],
+            output_names=["output"],
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for MNIST image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]

--- a/mnist/image_classification/onnx/loader.py
+++ b/mnist/image_classification/onnx/loader.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MNIST ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ..pytorch.loader import ModelLoader as PyTorchModelLoader
+from ..pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ModelLoader(PyTorchModelLoader):
+    """MNIST ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load MNIST as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.CNN_DROPOUT is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            input_names=["input"],
+            output_names=["output"],
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for MNIST image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]

--- a/monodepth2/image_classification/onnx/__init__.py
+++ b/monodepth2/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/monodepth2/image_classification/onnx/loader.py
+++ b/monodepth2/image_classification/onnx/loader.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Monodepth2 ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ModelLoader(PyTorchModelLoader):
+    """Monodepth2 ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load Monodepth2 as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.MONO_640X192 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            input_names=["input"],
+            output_names=["output"],
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for Monodepth2 depth estimation."""
+        return [self.torch_loader.load_inputs(**kwargs)]

--- a/oft_stable_diffusion/text_to_image/onnx/__init__.py
+++ b/oft_stable_diffusion/text_to_image/onnx/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+OFT ONNX model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/oft_stable_diffusion/text_to_image/onnx/loader.py
+++ b/oft_stable_diffusion/text_to_image/onnx/loader.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+OFT ONNX model loader.
+"""
+
+import torch
+import peft.tuners.oft.layer as oft_layer
+from diffusers import StableDiffusionPipeline
+from peft import OFTConfig, OFTModel
+
+from ...base import ForgeModel
+from ...config import Framework, ModelGroup, ModelInfo, ModelSource, ModelTask
+from ...tools.utils import export_torch_model_to_onnx
+
+
+class StableDiffusionWrapper(torch.nn.Module):
+    """Wrap Stable Diffusion UNet forward for ONNX export."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, latents, timesteps, prompt_embeds):
+        return self.model.unet(
+            latents,
+            timesteps,
+            encoder_hidden_states=prompt_embeds,
+        ).sample
+
+
+class ModelLoader(ForgeModel):
+    """OFT ONNX loader implementation."""
+
+    DEFAULT_MODEL_NAME = "runwayml/stable-diffusion-v1-5"
+
+    def __init__(self, variant=None):
+        super().__init__(variant)
+        self.model_name = variant or self.DEFAULT_MODEL_NAME
+        self.pipe = None
+
+    @classmethod
+    def _get_model_info(cls, variant_name: str = None):
+        """Get model information for dashboard and metrics reporting."""
+        if variant_name is None:
+            variant_name = cls.DEFAULT_MODEL_NAME.split("/")[-1]
+        return ModelInfo(
+            model="OFT",
+            variant=variant_name,
+            group=ModelGroup.RED,
+            task=ModelTask.CONDITIONAL_GENERATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.ONNX,
+        )
+
+    @staticmethod
+    def _get_oft_configs():
+        config_te = OFTConfig(
+            r=8,
+            target_modules=["k_proj", "q_proj", "v_proj", "out_proj", "fc1", "fc2"],
+            module_dropout=0.0,
+            init_weights=True,
+        )
+        config_unet = OFTConfig(
+            r=8,
+            target_modules=[
+                "proj_in",
+                "proj_out",
+                "to_k",
+                "to_q",
+                "to_v",
+                "to_out.0",
+                "ff.net.0.proj",
+                "ff.net.2",
+            ],
+            module_dropout=0.0,
+            init_weights=True,
+        )
+        return config_te, config_unet
+
+    @staticmethod
+    def _patch_oft_cayley_with_lstsq():
+        def _safe_cayley(self, data):
+            data = data.detach()
+            b, r, c = data.shape
+            skew_mat = 0.5 * (data - data.transpose(1, 2))
+            id_mat = torch.eye(r, device=data.device).unsqueeze(0).expand(b, r, c)
+            try:
+                return torch.linalg.solve(id_mat + skew_mat, id_mat - skew_mat)
+            except RuntimeError:
+                return torch.linalg.lstsq(id_mat + skew_mat, id_mat - skew_mat).solution
+
+        oft_layer.Linear._cayley_batch = _safe_cayley
+
+    @staticmethod
+    def _freeze_oft_params(module):
+        for _, layer in module.named_modules():
+            if hasattr(layer, "oft_r"):
+                for key in layer.oft_r:
+                    layer.oft_r[key].requires_grad = False
+            if hasattr(layer, "oft_s"):
+                for key in layer.oft_s:
+                    layer.oft_s[key].requires_grad = False
+
+    def _build_pipeline(self):
+        self._patch_oft_cayley_with_lstsq()
+        pipe = StableDiffusionPipeline.from_pretrained(self.model_name)
+        config_te, config_unet = self._get_oft_configs()
+        pipe.text_encoder = OFTModel(pipe.text_encoder, config_te, "default")
+        pipe.unet = OFTModel(pipe.unet, config_unet, "default")
+        self._freeze_oft_params(pipe.text_encoder)
+        self._freeze_oft_params(pipe.unet)
+        pipe.to("cpu")
+        pipe.text_encoder.eval()
+        pipe.unet.eval()
+        self.pipe = pipe
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load OFT model, export to ONNX, then load and return the ONNX model."""
+        if self.pipe is None:
+            self._build_pipeline()
+
+        inputs = self.load_inputs(**kwargs)
+        torch_model = StableDiffusionWrapper(self.pipe)
+        model_name = f"{self.model_name.split('/')[-1].replace('-', '_')}_oft"
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+            input_names=["latents", "timesteps", "prompt_embeds"],
+            output_names=["sample"],
+            do_constant_folding=True,
+        )
+
+    def load_inputs(
+        self,
+        prompt: str = "A beautiful mountain landscape during sunset",
+        num_inference_steps: int = 30,
+    ):
+        """Load and return sample inputs for OFT ONNX export and compile."""
+        if self.pipe is None:
+            self._build_pipeline()
+
+        prompt_embeds, negative_prompt_embeds, *_ = self.pipe.encode_prompt(
+            prompt=prompt,
+            negative_prompt="",
+            device="cpu",
+            do_classifier_free_guidance=True,
+            num_images_per_prompt=1,
+        )
+        prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+
+        height = self.pipe.unet.config.sample_size * self.pipe.vae_scale_factor
+        width = height
+        latents = torch.randn(
+            (
+                1,
+                self.pipe.unet.config.in_channels,
+                height // self.pipe.vae_scale_factor,
+                width // self.pipe.vae_scale_factor,
+            )
+        )
+        latents = latents * self.pipe.scheduler.init_noise_sigma
+        latents = torch.cat([latents] * 2, dim=0)
+
+        self.pipe.scheduler.set_timesteps(num_inference_steps)
+        timestep = self.pipe.scheduler.timesteps[0].expand(latents.shape[0])
+
+        return (latents, timestep, prompt_embeds)

--- a/oft_stable_diffusion/text_to_image/onnx/loader.py
+++ b/oft_stable_diffusion/text_to_image/onnx/loader.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+OFT ONNX model loader.
+"""
+
+import torch
+import peft.tuners.oft.layer as oft_layer
+from diffusers import StableDiffusionPipeline
+from peft import OFTConfig, OFTModel
+
+from ....base import ForgeModel
+from ....config import Framework, ModelGroup, ModelInfo, ModelSource, ModelTask
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class StableDiffusionWrapper(torch.nn.Module):
+    """Wrap Stable Diffusion UNet forward for ONNX export."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, latents, timesteps, prompt_embeds):
+        return self.model.unet(
+            latents,
+            timesteps,
+            encoder_hidden_states=prompt_embeds,
+        ).sample
+
+
+class ModelLoader(ForgeModel):
+    """OFT ONNX loader implementation."""
+
+    DEFAULT_MODEL_NAME = "runwayml/stable-diffusion-v1-5"
+
+    def __init__(self, variant=None):
+        super().__init__(variant)
+        self.model_name = variant or self.DEFAULT_MODEL_NAME
+        self.pipe = None
+
+    @classmethod
+    def _get_model_info(cls, variant_name: str = None):
+        """Get model information for dashboard and metrics reporting."""
+        if variant_name is None:
+            variant_name = cls.DEFAULT_MODEL_NAME.split("/")[-1]
+        return ModelInfo(
+            model="OFT",
+            variant=variant_name,
+            group=ModelGroup.RED,
+            task=ModelTask.CONDITIONAL_GENERATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.ONNX,
+        )
+
+    @staticmethod
+    def _get_oft_configs():
+        config_te = OFTConfig(
+            r=8,
+            oft_block_size=0,
+            target_modules=["k_proj", "q_proj", "v_proj", "out_proj", "fc1", "fc2"],
+            module_dropout=0.0,
+            init_weights=True,
+        )
+        config_unet = OFTConfig(
+            r=8,
+            oft_block_size=0,
+            target_modules=[
+                "proj_in",
+                "proj_out",
+                "to_k",
+                "to_q",
+                "to_v",
+                "to_out.0",
+                "ff.net.0.proj",
+                "ff.net.2",
+            ],
+            module_dropout=0.0,
+            init_weights=True,
+        )
+        return config_te, config_unet
+
+    @staticmethod
+    def _patch_oft_cayley_with_lstsq():
+        def _safe_cayley(self, data):
+            data = data.detach()
+            b, r, c = data.shape
+            skew_mat = 0.5 * (data - data.transpose(1, 2))
+            id_mat = torch.eye(r, device=data.device).unsqueeze(0).expand(b, r, c)
+            try:
+                return torch.linalg.solve(id_mat + skew_mat, id_mat - skew_mat)
+            except RuntimeError:
+                return torch.linalg.lstsq(id_mat + skew_mat, id_mat - skew_mat).solution
+
+        oft_layer.Linear._cayley_batch = _safe_cayley
+
+    @staticmethod
+    def _freeze_oft_params(module):
+        for _, layer in module.named_modules():
+            if hasattr(layer, "oft_r"):
+                for key in layer.oft_r:
+                    layer.oft_r[key].requires_grad = False
+            if hasattr(layer, "oft_s"):
+                for key in layer.oft_s:
+                    layer.oft_s[key].requires_grad = False
+
+    def _build_pipeline(self):
+        self._patch_oft_cayley_with_lstsq()
+        pipe = StableDiffusionPipeline.from_pretrained(self.model_name)
+        config_te, config_unet = self._get_oft_configs()
+        pipe.text_encoder = OFTModel(pipe.text_encoder, config_te, "default")
+        pipe.unet = OFTModel(pipe.unet, config_unet, "default")
+        self._freeze_oft_params(pipe.text_encoder)
+        self._freeze_oft_params(pipe.unet)
+        pipe.to("cpu")
+        pipe.text_encoder.eval()
+        pipe.unet.eval()
+        self.pipe = pipe
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load OFT model, export to ONNX, then load and return the ONNX model."""
+        if self.pipe is None:
+            self._build_pipeline()
+
+        inputs = self.load_inputs(**kwargs)
+        torch_model = StableDiffusionWrapper(self.pipe)
+        model_name = f"{self.model_name.split('/')[-1].replace('-', '_')}_oft"
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            inputs,
+            model_name,
+            input_names=["latents", "timesteps", "prompt_embeds"],
+            output_names=["sample"],
+            do_constant_folding=True,
+        )
+
+    def load_inputs(
+        self,
+        prompt: str = "A beautiful mountain landscape during sunset",
+        num_inference_steps: int = 30,
+    ):
+        """Load and return sample inputs for OFT ONNX export and compile."""
+        if self.pipe is None:
+            self._build_pipeline()
+
+        prompt_embeds, negative_prompt_embeds, *_ = self.pipe.encode_prompt(
+            prompt=prompt,
+            negative_prompt="",
+            device="cpu",
+            do_classifier_free_guidance=True,
+            num_images_per_prompt=1,
+        )
+        prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+
+        height = self.pipe.unet.config.sample_size * self.pipe.vae_scale_factor
+        width = height
+        latents = torch.randn(
+            (
+                1,
+                self.pipe.unet.config.in_channels,
+                height // self.pipe.vae_scale_factor,
+                width // self.pipe.vae_scale_factor,
+            )
+        )
+        latents = latents * self.pipe.scheduler.init_noise_sigma
+        latents = torch.cat([latents] * 2, dim=0)
+
+        self.pipe.scheduler.set_timesteps(num_inference_steps)
+        timestep = self.pipe.scheduler.timesteps[0].expand(latents.shape[0])
+
+        return (latents, timestep, prompt_embeds)

--- a/perceiverio_vision/image_classification/onnx/__init__.py
+++ b/perceiverio_vision/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/perceiverio_vision/image_classification/onnx/loader.py
+++ b/perceiverio_vision/image_classification/onnx/loader.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+PerceiverIO Vision ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """PerceiverIO Vision ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load PerceiverIO Vision as a torch model, export to ONNX, then return ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.VISION_PERCEIVER_CONV is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            input_names=["input"],
+            output_names=["output"],
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for PerceiverIO image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities."""
+        print_compiled_model_results(outputs)

--- a/regnet/image_classification/onnx/__init__.py
+++ b/regnet/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/regnet/image_classification/onnx/loader.py
+++ b/regnet/image_classification/onnx/loader.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+RegNet ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """RegNet ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load RegNet as a torch model, export to ONNX, then load and return ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.Y_040 is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+            opset_version=18,
+            input_names=["input"],
+            output_names=["output"],
+            dynamic_axes={"input": {0: "batch"}, "output": {0: "batch"}},
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for RegNet image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities."""
+        print_compiled_model_results(outputs)

--- a/resnext/image_classification/onnx/__init__.py
+++ b/resnext/image_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/resnext/image_classification/onnx/loader.py
+++ b/resnext/image_classification/onnx/loader.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+ResNeXt ONNX model loader.
+"""
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx, print_compiled_model_results
+
+
+class ModelLoader(PyTorchModelLoader):
+    """ResNeXt ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load ResNeXt as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.RESNEXT50_32X4D is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        inputs = self.load_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            torch_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for ResNeXt image classification."""
+        return [self.torch_loader.load_inputs(**kwargs)]
+
+    def print_cls_results(self, outputs):
+        """Decode logits to top-k class labels and probabilities."""
+        print_compiled_model_results(outputs)

--- a/stable_diffusion_xl/text_to_image/onnx/loader.py
+++ b/stable_diffusion_xl/text_to_image/onnx/loader.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Stable Diffusion XL model loader implementation
+"""
+
+import torch
+from typing import Optional
+
+from ...base import ForgeModel
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from .src.model_utils import load_pipe, stable_diffusion_preprocessing_xl
+from ...tools.utils import export_torch_model_to_onnx
+
+
+class StableDiffusionXLWrapper(torch.nn.Module):
+    def __init__(self, model, added_cond_kwargs, cross_attention_kwargs=None):
+        super().__init__()
+        self.model = model
+        self.cross_attention_kwargs = cross_attention_kwargs
+        self.added_cond_kwargs = added_cond_kwargs
+
+    def forward(self, latent_model_input, timestep, prompt_embeds):
+        noise_pred = self.model(
+            latent_model_input,
+            timestep[0],
+            encoder_hidden_states=prompt_embeds,
+            timestep_cond=None,
+            cross_attention_kwargs=self.cross_attention_kwargs,
+            added_cond_kwargs=self.added_cond_kwargs,
+        )[0]
+        return noise_pred
+
+
+class ModelVariant(StrEnum):
+    """Available Stable Diffusion XL model variants."""
+
+    STABLE_DIFFUSION_XL_BASE_1_0 = "Base_1.0"
+
+
+class ModelLoader(ForgeModel):
+    """Stable Diffusion XL model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.STABLE_DIFFUSION_XL_BASE_1_0: ModelConfig(
+            pretrained_model_name="stable-diffusion-xl-base-1.0",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.STABLE_DIFFUSION_XL_BASE_1_0
+
+    # Shared configuration parameters
+    prompt = "An astronaut riding a green horse"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.pipeline = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="Stable Diffusion XL",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.CONDITIONAL_GENERATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, onnx_tmp_path, dtype_override=None, **kwargs):
+        """Load and return the Stable Diffusion XL pipeline for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            DiffusionPipeline: The Stable Diffusion XL pipeline instance.
+        """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        # Load the pipeline
+        self.pipeline = load_pipe(pretrained_model_name)
+
+        # Apply dtype conversion if specified
+        if dtype_override is not None:
+            self.pipeline = self.pipeline.to(dtype_override)
+
+        self.framework_model = StableDiffusionXLWrapper(
+            self.pipeline.unet,
+            self.load_inputs()[-1],
+            cross_attention_kwargs=None,
+        )
+        export_torch_model_to_onnx(
+            self.framework_model,
+            onnx_tmp_path,
+            self.load_inputs()[:3],
+            pretrained_model_name,
+        )
+        return self.pipeline
+
+    def load_inputs(self, dtype_override=None):
+        """Load and return sample inputs for the Stable Diffusion XL model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+
+        Returns:
+            List : Input tensors that can be fed to the model:
+                - latent_model_input (torch.Tensor): Latent input for the UNet
+                - timestep (torch.Tensor): Timestep tensor
+                - prompt_embeds (torch.Tensor): Encoded prompt embeddings
+                - added_cond_kwargs (dict): Additional conditioning inputs (e.g., text/image embeddings,
+                  time IDs, or other auxiliary information required by the pipeline).
+        """
+        # Ensure pipeline is initialized
+        if self.pipeline is None:
+            self.load_model(dtype_override=dtype_override)
+
+        # Generate preprocessed inputs
+        (
+            latent_model_input,
+            timesteps,
+            prompt_embeds,
+            timestep_cond,
+            added_cond_kwargs,
+            add_time_ids,
+        ) = stable_diffusion_preprocessing_xl(self.pipeline, self.prompt)
+
+        # Apply dtype conversion if specified
+        if dtype_override:
+            latent_model_input = latent_model_input.to(dtype_override)
+            timesteps = timesteps.to(dtype_override)
+            prompt_embeds = prompt_embeds.to(dtype_override)
+
+        return [latent_model_input, timesteps, prompt_embeds, added_cond_kwargs]

--- a/stable_diffusion_xl/text_to_image/onnx/loader.py
+++ b/stable_diffusion_xl/text_to_image/onnx/loader.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Stable Diffusion XL model loader implementation
+"""
+
+import torch
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ...pytorch.src.model_utils import load_pipe, stable_diffusion_preprocessing_xl
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class StableDiffusionXLWrapper(torch.nn.Module):
+    def __init__(self, model, added_cond_kwargs, cross_attention_kwargs=None):
+        super().__init__()
+        self.model = model
+        self.cross_attention_kwargs = cross_attention_kwargs
+        self.added_cond_kwargs = added_cond_kwargs
+
+    def forward(self, latent_model_input, timestep, prompt_embeds):
+        noise_pred = self.model(
+            latent_model_input,
+            timestep[0],
+            encoder_hidden_states=prompt_embeds,
+            timestep_cond=None,
+            cross_attention_kwargs=self.cross_attention_kwargs,
+            added_cond_kwargs=self.added_cond_kwargs,
+        )[0]
+        return noise_pred
+
+
+class ModelVariant(StrEnum):
+    """Available Stable Diffusion XL model variants."""
+
+    STABLE_DIFFUSION_XL_BASE_1_0 = "Base_1.0"
+
+
+class ModelLoader(ForgeModel):
+    """Stable Diffusion XL model loader implementation."""
+
+    # Dictionary of available model variants using structured configs
+    _VARIANTS = {
+        ModelVariant.STABLE_DIFFUSION_XL_BASE_1_0: ModelConfig(
+            pretrained_model_name="stable-diffusion-xl-base-1.0",
+        ),
+    }
+
+    # Default variant to use
+    DEFAULT_VARIANT = ModelVariant.STABLE_DIFFUSION_XL_BASE_1_0
+
+    # Shared configuration parameters
+    prompt = "An astronaut riding a green horse"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.pipeline = None
+
+    def _ensure_pipeline(self, dtype_override=None) -> None:
+        """Load the diffusion pipeline without exporting ONNX (used by :meth:`load_inputs`)."""
+        if self.pipeline is not None:
+            if dtype_override is not None:
+                self.pipeline = self.pipeline.to(dtype_override)
+            return
+        pretrained_model_name = self._variant_config.pretrained_model_name
+        self.pipeline = load_pipe(pretrained_model_name)
+        if dtype_override is not None:
+            self.pipeline = self.pipeline.to(dtype_override)
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="Stable Diffusion XL",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.CONDITIONAL_GENERATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, onnx_tmp_path, dtype_override=None, **kwargs):
+        """Build the pipeline, export the UNet wrapper to ONNX, and return the ONNX model.
+
+        Args:
+            onnx_tmp_path: Directory to write the ``.onnx`` file.
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX graph for the UNet forward pass.
+        """
+        # Get the pretrained model name from the instance's variant config
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        self._ensure_pipeline(dtype_override=dtype_override)
+
+        self.framework_model = StableDiffusionXLWrapper(
+            self.pipeline.unet,
+            self.load_inputs(dtype_override=dtype_override)[-1],
+            cross_attention_kwargs=None,
+        )
+        return export_torch_model_to_onnx(
+            self.framework_model,
+            onnx_tmp_path,
+            tuple(self.load_inputs(dtype_override=dtype_override)[:3]),
+            pretrained_model_name,
+            opset_version=18,
+        )
+
+    def load_inputs(self, dtype_override=None):
+        """Load and return sample inputs for the Stable Diffusion XL model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+
+        Returns:
+            List : Input tensors that can be fed to the model:
+                - latent_model_input (torch.Tensor): Latent input for the UNet
+                - timestep (torch.Tensor): Timestep tensor
+                - prompt_embeds (torch.Tensor): Encoded prompt embeddings
+                - added_cond_kwargs (dict): Additional conditioning inputs (e.g., text/image embeddings,
+                  time IDs, or other auxiliary information required by the pipeline).
+        """
+        # Ensure pipeline is initialized
+        if self.pipeline is None:
+            self._ensure_pipeline(dtype_override=dtype_override)
+
+        # Generate preprocessed inputs
+        (
+            latent_model_input,
+            timesteps,
+            prompt_embeds,
+            timestep_cond,
+            added_cond_kwargs,
+            add_time_ids,
+        ) = stable_diffusion_preprocessing_xl(self.pipeline, self.prompt)
+
+        # Apply dtype conversion if specified
+        if dtype_override:
+            latent_model_input = latent_model_input.to(dtype_override)
+            timesteps = timesteps.to(dtype_override)
+            prompt_embeds = prompt_embeds.to(dtype_override)
+
+        return [latent_model_input, timesteps, prompt_embeds, added_cond_kwargs]

--- a/vilt/question_answering/onnx/__init__.py
+++ b/vilt/question_answering/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/vilt/question_answering/onnx/__init__.py
+++ b/vilt/question_answering/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ..pytorch.loader import ModelVariant

--- a/vilt/question_answering/onnx/loader.py
+++ b/vilt/question_answering/onnx/loader.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+ViLT ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ViltEmbeddingWrapper(torch.nn.Module):
+    """Build text-vision embeddings consumed by the ViLT encoder."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.vilt_model = model
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        pixel_values=None,
+        pixel_mask=None,
+        inputs_embeds=None,
+        image_embeds=None,
+        image_token_type_idx=None,
+    ):
+        embeddings, masks = self.vilt_model.vilt.embeddings(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            pixel_values=pixel_values,
+            pixel_mask=pixel_mask,
+            inputs_embeds=inputs_embeds,
+            image_embeds=image_embeds,
+            image_token_type_idx=image_token_type_idx,
+        )
+        return embeddings, masks
+
+
+class ViltQaModelWrapper(torch.nn.Module):
+    """Expose ViLT question-answering logits from embedding inputs."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.vilt_model = model
+
+    def forward(self, embedding_output, attention_mask, head_mask=None):
+        head_mask = self.vilt_model.vilt.get_head_mask(
+            head_mask, self.vilt_model.vilt.config.num_hidden_layers
+        )
+
+        extended_attention_mask = attention_mask[:, None, None, :]
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(
+            torch.float32
+        ).min
+
+        encoder_outputs = self.vilt_model.vilt.encoder(
+            embedding_output,
+            attention_mask=extended_attention_mask,
+            head_mask=head_mask,
+            return_dict=False,
+        )
+        sequence_output = encoder_outputs[0]
+        sequence_output = self.vilt_model.vilt.layernorm(sequence_output)
+        pooled_output = (
+            self.vilt_model.vilt.pooler(sequence_output)
+            if self.vilt_model.vilt.pooler is not None
+            else None
+        )
+
+        return self.vilt_model.classifier(pooled_output)
+
+
+class ModelLoader(PyTorchModelLoader):
+    """ViLT ONNX loader that inherits from the PyTorch loader."""
+
+    def _prepare_embedding_inputs(self, **kwargs):
+        if not hasattr(self, "torch_loader"):
+            self.torch_loader = PyTorchModelLoader(variant=self._variant)
+
+        if getattr(self.torch_loader, "model", None) is None:
+            torch_model = self.torch_loader.load_model(**kwargs)
+        else:
+            torch_model = self.torch_loader.model
+
+        raw_inputs = self.torch_loader.load_inputs(**kwargs)
+        embedding_model = ViltEmbeddingWrapper(torch_model)
+        embedding_model.eval()
+
+        with torch.no_grad():
+            embedding_output, attention_mask = embedding_model(**raw_inputs)
+
+        return [
+            embedding_output.detach().cpu(),
+            attention_mask.detach().cpu().to(torch.float32),
+        ]
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load ViLT as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.VQA is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        self.model = getattr(self.torch_loader, "model", torch_model)
+
+        wrapped_model = ViltQaModelWrapper(torch_model)
+        wrapped_model.eval()
+        inputs = self._prepare_embedding_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return ViLT QA embedding inputs for ONNX execution."""
+        return self._prepare_embedding_inputs(**kwargs)

--- a/vilt/question_answering/onnx/loader.py
+++ b/vilt/question_answering/onnx/loader.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+ViLT ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ..pytorch.loader import ModelLoader as PyTorchModelLoader
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class ViltEmbeddingWrapper(torch.nn.Module):
+    """Build text-vision embeddings consumed by the ViLT encoder."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.vilt_model = model
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        token_type_ids=None,
+        pixel_values=None,
+        pixel_mask=None,
+        inputs_embeds=None,
+        image_embeds=None,
+        image_token_type_idx=None,
+    ):
+        embeddings, masks = self.vilt_model.vilt.embeddings(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            pixel_values=pixel_values,
+            pixel_mask=pixel_mask,
+            inputs_embeds=inputs_embeds,
+            image_embeds=image_embeds,
+            image_token_type_idx=image_token_type_idx,
+        )
+        return embeddings, masks
+
+
+class ViltQaModelWrapper(torch.nn.Module):
+    """Expose ViLT question-answering logits from embedding inputs."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.vilt_model = model
+
+    def forward(self, embedding_output, attention_mask):
+        extended_attention_mask = attention_mask[:, None, None, :]
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(
+            torch.float32
+        ).min
+
+        encoder_outputs = self.vilt_model.vilt.encoder(
+            embedding_output,
+            attention_mask=extended_attention_mask,
+            return_dict=False,
+        )
+        sequence_output = encoder_outputs[0]
+        sequence_output = self.vilt_model.vilt.layernorm(sequence_output)
+        pooled_output = (
+            self.vilt_model.vilt.pooler(sequence_output)
+            if self.vilt_model.vilt.pooler is not None
+            else None
+        )
+
+        return self.vilt_model.classifier(pooled_output)
+
+
+class ModelLoader(PyTorchModelLoader):
+    """ViLT ONNX loader that inherits from the PyTorch loader."""
+
+    def _prepare_embedding_inputs(self, **kwargs):
+        if not hasattr(self, "torch_loader"):
+            self.torch_loader = PyTorchModelLoader(variant=self._variant)
+
+        if getattr(self.torch_loader, "model", None) is None:
+            torch_model = self.torch_loader.load_model(**kwargs)
+        else:
+            torch_model = self.torch_loader.model
+
+        raw_inputs = self.torch_loader.load_inputs(**kwargs)
+        embedding_model = ViltEmbeddingWrapper(torch_model)
+        embedding_model.eval()
+
+        with torch.no_grad():
+            embedding_output, attention_mask = embedding_model(**raw_inputs)
+
+        return [
+            embedding_output.detach().cpu(),
+            attention_mask.detach().cpu().to(torch.float32),
+        ]
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load ViLT as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.VQA is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        self.model = getattr(self.torch_loader, "model", torch_model)
+
+        wrapped_model = ViltQaModelWrapper(torch_model)
+        wrapped_model.eval()
+        inputs = self._prepare_embedding_inputs(**kwargs)
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return ViLT QA embedding inputs for ONNX execution."""
+        return self._prepare_embedding_inputs(**kwargs)

--- a/whisper/audio_classification/onnx/__init__.py
+++ b/whisper/audio_classification/onnx/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader
+from ...pytorch.loader import ModelVariant

--- a/whisper/audio_classification/onnx/loader.py
+++ b/whisper/audio_classification/onnx/loader.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Whisper ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_features, decoder_input_ids):
+        inputs = {
+            "input_features": input_features,
+            "decoder_input_ids": decoder_input_ids,
+        }
+        output = self.model(**inputs)
+        return output.logits
+
+
+class ModelLoader(PyTorchModelLoader):
+    """Whisper ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load Whisper as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.WHISPER_TINY is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for Whisper audio classification."""
+        return self.torch_loader.load_inputs(**kwargs)

--- a/whisper/audio_classification/onnx/loader.py
+++ b/whisper/audio_classification/onnx/loader.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Whisper ONNX model loader.
+"""
+
+import torch
+
+# Reuse the PyTorch ModelLoader as the base
+from ...pytorch.loader import ModelLoader as PyTorchModelLoader
+from ...pytorch.loader import ModelVariant
+from ....tools.utils import export_torch_model_to_onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_features, decoder_input_ids):
+        inputs = {
+            "input_features": input_features,
+            "decoder_input_ids": decoder_input_ids,
+        }
+        output = self.model(**inputs)
+        if hasattr(output, "logits") and output.logits is not None:
+            return output.logits
+        # WhisperModel (e.g. large-v3) returns last_hidden_state instead of logits
+        return output.last_hidden_state
+
+
+class ModelLoader(PyTorchModelLoader):
+    """Whisper ONNX loader that inherits from the PyTorch loader."""
+
+    def load_model(self, onnx_tmp_path, **kwargs):
+        """Load Whisper as a torch model, export to ONNX, then load and return the ONNX model.
+
+        Returns:
+            onnx.ModelProto: The loaded ONNX model.
+        """
+        # default variant ModelVariant.WHISPER_TINY is used if no variant is provided
+        self.torch_loader = PyTorchModelLoader(variant=self._variant)
+        torch_model = self.torch_loader.load_model(**kwargs)
+        wrapped_model = Wrapper(torch_model)
+        inputs = self.load_inputs()
+        model_name = self.torch_loader._variant_config.pretrained_model_name
+
+        return export_torch_model_to_onnx(
+            wrapped_model,
+            onnx_tmp_path,
+            tuple(inputs),
+            model_name,
+        )
+
+    def load_inputs(self, **kwargs):
+        """Load and return preprocessed inputs for Whisper audio classification."""
+        return self.torch_loader.load_inputs(**kwargs)


### PR DESCRIPTION
### Ticket
[#3231](https://github.com/tenstorrent/tt-forge-onnx/issues/3231)

### Problem description

- Standardize all model and input loading in tt-forge-onnx to use the tt-forge-models repository (e.g. third_party/tt_forge_models)

### What's changed
This PR adds onnx loaders for the below models:

- Deit
- Detr (Object Detection and Segmentation)
- Dla
- Ghostnet
- Glpn Kitti
- Hrnet
- Inception
- Mgp str base
- Mlp mixer
- Mnist
- Monodepth2
- Oft 
- Perceiverio
- Regnet
- Resnext
- Stable Diffusion XL
- Vilt
- Whisper

### Checklist
- [x] Verify successful model and input loading by running ort.