### PR TITLE
Updating gemma config

### DIFF
--- a/gemma/text_extraction_and_translation/pytorch/loader.py
+++ b/gemma/text_extraction_and_translation/pytorch/loader.py
@@ -118,7 +118,7 @@ class ModelLoader(ForgeModel):
         if self.processor is None:
             self._load_processor(dtype_override=dtype_override)
 
-        model_kwargs = {"return_dict": False}
+        model_kwargs = {}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
         model_kwargs |= kwargs
@@ -126,8 +126,11 @@ class ModelLoader(ForgeModel):
         model = AutoModelForImageTextToText.from_pretrained(
             pretrained_model_name, **model_kwargs
         )
+        if getattr(model.config, "use_cache", True):
+            model.config.text_config.layer_types = [
+                "full_attention"
+            ] * model.config.text_config.num_hidden_layers
         self.model = model
-
         return model
 
     def load_inputs(self, dtype_override=None):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4134

### Problem description
Updating gemma loader file

### What's changed
In the latest main version, while running Translategemma-4b-it, I encountered an AttributeError. After debugging, I found that it was caused by "return_dict": False. Removing this key from model_kwargs resolved the issue.

The model was using sliding attention; based on Aleks’ earlier comments, it has now been updated to use full attention.

All runtime and attribute errors have been resolved, but on the latest main, the model is now failing with an out-of-memory error.

Logs:
[gemma.log](https://github.com/user-attachments/files/26535431/gemma.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
