### PR TITLE
Fix Unhandled FakeTensor Device Propagation in SSR

### DIFF
--- a/ssr/pytorch/src/model.py
+++ b/ssr/pytorch/src/model.py
@@ -2070,9 +2070,13 @@ class BEVFormerEncoder(TransformerLayerSequence):
         for img_meta in img_metas:
             lidar2img.append(img_meta["lidar2img"])
         lidar2img = np.asarray(lidar2img)
-        lidar2img = torch.from_numpy(lidar2img).to(
-            device=reference_points.device, dtype=reference_points.dtype
-        )  # (B, N, 4, 4)
+        lidar2img = torch.as_tensor(
+            lidar2img, device=reference_points.device, dtype=reference_points.dtype
+        )
+        if lidar2img.dim() == 2:
+            lidar2img = lidar2img.unsqueeze(0).unsqueeze(0)
+        elif lidar2img.dim() == 3:
+            lidar2img = lidar2img.unsqueeze(1)
         reference_points = reference_points.clone()
 
         reference_points[..., 0:1] = (
@@ -2091,6 +2095,14 @@ class BEVFormerEncoder(TransformerLayerSequence):
 
         reference_points = reference_points.permute(1, 0, 2, 3)
         D, B, num_query = reference_points.size()[:3]
+        if lidar2img.size(0) != B:
+            if lidar2img.size(0) == 1:
+                lidar2img = lidar2img.expand(B, -1, -1, -1)
+            else:
+                raise RuntimeError(
+                    f"point_sampling batch mismatch: lidar2img batch={lidar2img.size(0)}, "
+                    f"reference_points batch={B}"
+                )
         num_cam = lidar2img.size(1)
 
         reference_points = (
@@ -2179,6 +2191,14 @@ class BEVFormerEncoder(TransformerLayerSequence):
         bs, len_bev, num_bev_level, _ = ref_2d.shape
         if prev_bev is not None:
             prev_bev = prev_bev.permute(1, 0, 2)
+            if prev_bev.size(0) != bev_query.size(0):
+                if prev_bev.size(0) == 1:
+                    prev_bev = prev_bev.expand(bev_query.size(0), -1, -1)
+                else:
+                    raise RuntimeError(
+                        f"forward temporal batch mismatch: prev_bev batch={prev_bev.size(0)}, "
+                        f"bev_query batch={bev_query.size(0)}"
+                    )
             prev_bev = torch.stack([prev_bev, bev_query], 1).reshape(
                 bs * 2, len_bev, -1
             )
@@ -3196,18 +3216,27 @@ class SSR(MVXTwoStageDetector):
         if not self.video_test_mode:
             self.prev_frame_info["prev_bev"] = None
 
-        tmp_pos = copy.deepcopy(img_metas[0][0]["can_bus"][:3])
-        tmp_angle = copy.deepcopy(img_metas[0][0]["can_bus"][-1])
-        img_metas[0][0]["can_bus"][-1] = 0
-        img_metas[0][0]["can_bus"][:3] = 0
+        can_bus = img_metas[0][0]["can_bus"]
+        tmp_pos = copy.deepcopy(can_bus[:3])
+        tmp_angle = copy.deepcopy(can_bus[-1])
 
-        # Convert can_bus from numpy to a tensor on the model's device so that
-        # the compiled graph fragment for simple_test receives a properly placed
-        # tensor instead of a CPU tensor (which breaks XLA graph partitioning).
-        _dev = next(self.parameters()).device
-        img_metas[0][0]["can_bus"] = torch.as_tensor(
-            img_metas[0][0]["can_bus"], dtype=torch.float64
-        ).to(_dev)
+        # Keep can_bus updates on one device to avoid FakeTensor mixed-device
+        # propagation issues from in-place setitem lowering.
+        _dev = (
+            can_bus.device
+            if torch.is_tensor(can_bus)
+            else next(self.parameters()).device
+        )
+        can_bus = torch.as_tensor(can_bus, device=_dev)
+        can_bus = torch.cat(
+            [
+                torch.zeros_like(can_bus[:3]),
+                can_bus[3:-1],
+                torch.zeros_like(can_bus[-1:]),
+            ],
+            dim=0,
+        )
+        img_metas[0][0]["can_bus"] = can_bus
 
         new_prev_bev, bbox_results = self.simple_test(
             img_metas=img_metas[0],


### PR DESCRIPTION
### Ticket
Fixes [#4114](https://github.com/tenstorrent/tt-xla/issues/4114)

### Problem description

- `ssr/pytorch-single_device-inference` model fails with `Unhandled FakeTensor Device Propagation for aten.where.self, found two different devices cpu, xla:0 `

### What's changed

- The failure was caused by a device mismatch during FakeTensor propagation, where an internal aten.where operation received tensors on both CPU and XLA due to in-place slice updates. The fix ensures all operations occur on a single device by selecting a consistent target device, converting can_bus to a tensor on that device, and rebuilding it using torch.cat instead of mutating it in place. By using zeros_like, all replacement values match the original tensor’s device and dtype, and avoiding in-place updates prevents the lowering path that introduced mixed-device operations. As a result, the CPU/XLA conflict is eliminated and the error is resolved.

- Following this model failed with  `RuntimeError("shape '[1, 6, 1, 1, 4, 4]' is invalid for input of size 16")`. The update to model.py standardizes lidar2img handling before projection by converting it to a tensor on the same device and dtype as reference_points, and reshaping it into a consistent 4D format (B, N, 4, 4) regardless of input form. It also enforces proper batch alignment—expanding when batch size is 1 or raising a clear error otherwise—and derives num_cam directly from the normalized tensor shape. This prevents mismatches like the earlier failure where a single camera matrix was incorrectly treated as multiple cameras, leading to an invalid reshape. By canonicalizing shape and validating dimensions upfront, the fix eliminates the inconsistent assumptions that caused the runtime error.

- Finally it failed with `AssertionError('stack expects each tensor to be equal size, but got torch.Size([1, 10000, 256]) at entry 0 and torch.Size([6, 10000, 256]) at entry 1')`.The crash was caused by a shape mismatch when torch.stack tried to combine prev_bev (1, 10000, 256) and bev_query (6, 10000, 256), which require identical shapes. The fix adds a batch-size compatibility check after permuting prev_bev: if the batch sizes already match, it proceeds; if prev_bev has batch size 1, it is broadcast to match bev_query using expand; otherwise, a clear runtime error is raised. By explicitly handling the common case where a single cached BEV is reused across the batch, both tensors are guaranteed to have matching shapes before stacking, preventing the previous failure and replacing it with safer, more predictable behavior.

- There is no changes in final values after these changes in cpu run and model fails with OOM error in xla post these changes.


### Logs
[ssr_before_fix_apr8.log](https://github.com/user-attachments/files/26574753/ssr_before_fix_apr8.log)
[ssr_after_fix_apr8.log](https://github.com/user-attachments/files/26574757/ssr_after_fix_apr8.log)

