### PR TITLE
Fix SAM compile token reset when ContextVar token is None

### DIFF
--- a/sam/pytorch/loader.py
+++ b/sam/pytorch/loader.py
@@ -10,6 +10,7 @@ from typing import Optional
 from PIL import Image
 from loguru import logger
 from transformers import SamModel, SamProcessor
+from .src.utils import patch_transformers_output_capturing
 
 from ...config import (
     ModelConfig,
@@ -95,6 +96,7 @@ class ModelLoader(ForgeModel):
         """
         # Get the pretrained model name from the instance's variant config
         model_name = self._variant_config.pretrained_model_name
+        patch_transformers_output_capturing()
 
         # Load SAM model from transformers
         framework_model = SamModel.from_pretrained(model_name, **kwargs).to("cpu")

--- a/sam/pytorch/src/utils.py
+++ b/sam/pytorch/src/utils.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import importlib
+
+
+def patch_transformers_output_capturing() -> None:
+    """Patch transformers output capturing for torch.compile token edge cases."""
+    output_capturing = importlib.import_module("transformers.utils.output_capturing")
+    context_var_cls = output_capturing.CompileableContextVar
+
+    if getattr(context_var_cls, "_tt_xla_none_token_patch", False):
+        return
+
+    def patched_get(self):
+        # Keep the original behavior, but fix compile-mode flag assignment.
+        if self.compiling:
+            return self.global_var
+        if output_capturing.is_torchdynamo_compiling():
+            self.compiling = True
+            return self.global_var
+        return self.context_var.get()
+
+    def patched_reset(self, token):
+        # In compile mode, set() may return None instead of a ContextVar Token.
+        if token is None:
+            self.global_var = None
+            self.compiling = False
+            return
+        if self.compiling:
+            self.global_var = None
+            self.compiling = False
+        else:
+            self.context_var.reset(token)
+
+    context_var_cls.get = patched_get
+    context_var_cls.reset = patched_reset
+    context_var_cls._tt_xla_none_token_patch = True


### PR DESCRIPTION
### Ticket
Fixes [#4148](https://github.com/tenstorrent/tt-xla/issues/4148)

### Problem description

- `sam/pytorch-Vit_Base-single_device-inference` test case fails with `TypeError: expected an instance of Token, got None`

### What's changed

- The failure originates from Hugging Face’s output-capturing logic under torch.compile, where set() can return None instead of a valid ContextVar token, leading to a crash when reset(None) is called. The fix introduces a monkey patch that safely handles this case by skipping the invalid reset and resetting internal state when the token is None. It also improves compile-mode tracking in get() to ensure consistent behavior during compilation. By preventing an invalid ContextVar.reset call and stabilizing state handling, the patch eliminates the TypeError and allows the SAM model to run successfully under compile mode.

- There is no changes in final values after these changes in cpu run and model passes e2e after this change.


### Logs
[sam_before_fix.log](https://github.com/user-attachments/files/26589008/sam_before_fix.log)
[sam_after_fix.log](https://github.com/user-attachments/files/26589026/sam_after_fix.log)