### PR TITLE
Pinned transformers version for GLM model

### DIFF
--- a/glm/causal_lm/jax/requirements.txt
+++ b/glm/causal_lm/jax/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
 
 eformer==0.0.62
+transformers==4.57.1


### PR DESCRIPTION

Ref : [Error in CI](https://github.com/tenstorrent/tt-xla/actions/runs/24019688703/job/70047925733)

### Problem description
GLM model is facing an error in main because of transformers version uplift

### What's changed
```
 RuntimeError: Failed to import easydel.modules.auto because of the following error (look up to see its traceback):
cannot import name 'download_url' from 'transformers.utils' 
```
The above error is faced from latest transformers version
* pinned transformers version as 4.57.1 in requirements file

### Checklist
- [x] New/Existing tests provide coverage for changes
Tested in CI and local