### PR TITLE
Fix Torch Dynamo Runtime Failure in VadV2 Model

### DIFF
--- a/vadv2/pytorch/src/vad_utils.py
+++ b/vadv2/pytorch/src/vad_utils.py
@@ -46,10 +46,15 @@ def multi_scale_deformable_attn_pytorch(
     bs, _, num_heads, embed_dims = value.shape
     _, num_queries, num_heads, num_levels, num_points, _ = sampling_locations.shape
 
-    # Use tensor_split with tensor indices to avoid .item() / graph breaks
-    split_sizes = value_spatial_shapes[:, 0] * value_spatial_shapes[:, 1]
-    split_indices = torch.cumsum(split_sizes, 0)[:-1].to(torch.long)
-    value_list = list(torch.tensor_split(value, split_indices, dim=1))
+    # Use tensor_split with tensor indices to avoid .item() / graph breaks.
+    # Single-level case: cumsum[:-1] is empty; tensor_split(..., empty indices)
+    n_spatial_levels = value_spatial_shapes.size(0)
+    if n_spatial_levels <= 1:
+        value_list = [value]
+    else:
+        split_sizes = value_spatial_shapes[:, 0] * value_spatial_shapes[:, 1]
+        split_indices = torch.cumsum(split_sizes, 0)[:-1].to(torch.long)
+        value_list = list(torch.tensor_split(value, split_indices, dim=1))
 
     if spatial_shapes_ints is None:
         # Fallback: convert to ints (causes graph break from .item())


### PR DESCRIPTION
### Ticket
Fixes [#4187](https://github.com/tenstorrent/tt-xla/issues/4187)

### Problem description

- `vadv2/pytorch-single_device-inference` test case fails with

`torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <built-in method tensor_split of type object at 0x7fae2af828c0>(*(FakeTensor(..., device='xla:0', size=(12, 10000, 8, 32)), FakeTensor(..., device='xla:0', size=(0,), dtype=torch.int64)), **{'dim': 1}): got AssertionError()`

### What's changed

- The issue occurs in multi_scale_deformable_attn_pytorch when running under TorchDynamo with fake tensors (e.g., on XLA), where the code calls torch.tensor_split using an empty split_indices tensor. This happens because, in the single spatial level case, value_spatial_shapes has only one entry, so computing split_sizes yields a one-element tensor and torch.cumsum(... )[:-1] produces an empty tensor. Conceptually, no split is needed in this case, but the code still attempts to call tensor_split, which leads to an internal assertion failure under Dynamo’s stricter graph execution (even if eager execution may tolerate it). The fix explicitly checks the number of spatial levels: if there is only one, it bypasses tensor_split entirely and directly wraps the original value tensor in a list, which correctly represents a single chunk. For multiple levels, the original logic is preserved, ensuring valid non-empty split indices.

- There is no changes in final values after these changes in cpu run and model fails with out of memory error post this change.


### Logs
[vadv2_before_fix_apr13.log](https://github.com/user-attachments/files/26665979/vadv2_before_fix_apr13.log)
[vadv2_after_fix_apr13.log](https://github.com/user-attachments/files/26665980/vadv2_after_fix_apr13.log)