### PR TITLE
Fix Runtime Error in Gemma3 Model

### DIFF
--- a/gemma3/multimodal/pytorch/loader.py
+++ b/gemma3/multimodal/pytorch/loader.py
@@ -7,6 +7,7 @@ Gemma3 model loader implementation for multimodal modeling.
 
 from typing import Optional, Any
 
+import torch
 from transformers import (
     AutoProcessor,
     Gemma3ForConditionalGeneration,
@@ -24,6 +25,43 @@ from ....config import (
 from ....base import ForgeModel
 from ....tools.utils import cast_input_to_type, get_file
 from PIL import Image
+
+
+def _patch_hf_dynamic_sliding_window_layer_for_torch_compile() -> None:
+    """HuggingFace uses ``[:, :, -sliding_window + 1:, :]`` on KV cat; when seq <
+    ``sliding_window - 1`` that negative start is invalid under torch.compile/XLA."""
+    from transformers.cache_utils import DynamicSlidingWindowLayer
+
+    if getattr(
+        DynamicSlidingWindowLayer, "_tt_forge_sliding_window_update_patch", False
+    ):
+        return
+
+    def update(self, key_states, value_states, cache_kwargs=None):
+        if not self.is_initialized:
+            self.lazy_initialization(key_states, value_states)
+
+        self.cumulative_length += key_states.shape[-2]
+
+        full_key_states = torch.cat([self.keys, key_states], dim=-2)
+        full_value_states = torch.cat([self.values, value_states], dim=-2)
+
+        max_keep = self.sliding_window - 1
+        seq_len = full_key_states.shape[-2]
+        if seq_len > max_keep:
+            self.keys = full_key_states[:, :, -max_keep:, :]
+            self.values = full_value_states[:, :, -max_keep:, :]
+        else:
+            self.keys = full_key_states
+            self.values = full_value_states
+
+        return full_key_states, full_value_states
+
+    DynamicSlidingWindowLayer.update = update
+    DynamicSlidingWindowLayer._tt_forge_sliding_window_update_patch = True
+
+
+_patch_hf_dynamic_sliding_window_layer_for_torch_compile()
 
 
 class ModelVariant(StrEnum):


### PR DESCRIPTION
### Ticket
Fixes [#4161](https://github.com/tenstorrent/tt-xla/issues/4161)

### Problem description

- `gemma3/multimodal/pytorch-google/gemma-3-4b-it-single_device-inference` fails with `Value out of range (expected to be in range of [-277, 276], but got -1023)
`
### What's changed

- The failure happens because Hugging Face’s sliding-window KV cache assumes the sequence length is at least as large as the configured window. In this case, after concatenating past and current key/value tensors, the total sequence length is only 277, but the cache still slices using a fixed negative index based on a window of 1024 (i.e., -1023). That index is out of bounds for such a short sequence, causing the runtime error. The patch modifies how DynamicSlidingWindowLayer.update trims its cached key and value tensors. Instead of always slicing with a fixed negative index based on the full sliding window size , it first concatenates past and current states into full_key_states and full_value_states, then checks their actual sequence length. It defines max_keep = sliding_window - 1 and only applies the tail slice if the sequence length exceeds this limit and  it keeps the entire tensor unchanged. This avoids invalid negative indexing when the sequence is still shorter than the window.

- There is no changes in final values after these changes in cpu run and model fails with out of memory error post this change.

### Logs
[gemma3_before_fix.log](https://github.com/user-attachments/files/26665927/gemma3_before_fix.log)
[gemma3_modified_latest.log](https://github.com/user-attachments/files/26919861/gemma3_modified_latest.log)
