### PR TITLE
Fix Whisper PCC drop caused by Transformers 5.x

### DIFF
--- a/whisper/pytorch/loader.py
+++ b/whisper/pytorch/loader.py
@@ -118,7 +118,10 @@ class ModelLoader(ForgeModel):
         pretrained_model_name = self._variant_config.pretrained_model_name
 
         # Common model kwargs
-        model_kwargs = {}
+        # Force float32 to avoid Transformers 5.x respecting the HuggingFace config's
+        # torch_dtype (float16 for large-v3/turbo), which causes PCC drops on TT hardware
+        # due to float16 accumulation across 64 transformer blocks.
+        model_kwargs = {"torch_dtype": torch.float32}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
         model_kwargs |= kwargs


### PR DESCRIPTION
### Ticket
[tt-xla #4127](https://github.com/tenstorrent/tt-xla/issues/4127)

### Problem description
Transformers 5.x respects the HuggingFace config's torch_dtype when calling from_pretrained. `whisper-large-v3` and `whisper-large-v3-turbo` have `torch_dtype=float16` in their configs now but used to have `float32` in 4.57.1, so they now load in `float16`. This causes a drop in PCC from >0.99 to ~0.53. Smaller models (medium and below) still have `torch_dtype=float32` in config and were unaffected.

### What's changed
Force `torch_dtype=torch.float32` to restore the pre-uplift behavior.

### Checklist
- [ ] New/Existing tests provide coverage for changes - Failing tt-xla tests were run here: https://github.com/tenstorrent/tt-xla/actions/runs/24257229714
