### PR TITLE
Fix Gemma3 KeyError by setting layer_types config before model construction

### DIFF
--- a/gemma/text_extraction_and_translation/pytorch/loader.py
+++ b/gemma/text_extraction_and_translation/pytorch/loader.py
@@ -5,7 +5,7 @@
 Gemma model loader implementation for text extraction and translation task.
 """
 import torch
-from transformers import AutoModelForImageTextToText, AutoProcessor
+from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
 from typing import Optional
 
 from ....base import ForgeModel
@@ -123,13 +123,15 @@ class ModelLoader(ForgeModel):
             model_kwargs["torch_dtype"] = dtype_override
         model_kwargs |= kwargs
 
-        model = AutoModelForImageTextToText.from_pretrained(
-            pretrained_model_name, **model_kwargs
-        )
-        if getattr(model.config, "use_cache", True):
-            model.config.text_config.layer_types = [
+        config = AutoConfig.from_pretrained(pretrained_model_name)
+        if getattr(config, "use_cache", True):
+            config.text_config.layer_types = [
                 "full_attention"
-            ] * model.config.text_config.num_hidden_layers
+            ] * config.text_config.num_hidden_layers
+
+        model = AutoModelForImageTextToText.from_pretrained(
+            pretrained_model_name, config=config, **model_kwargs
+        )
         self.model = model
         return model
 


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4223

### Problem description

- `gemma/text_extraction_and_translation` test fails with `KeyError: 'sliding_attention'` due to a config-vs-model desync — config.text_config.layer_types was overwritten to all "full_attention" after model construction, but the decoder layers still retained "sliding_attention" from init, causing a missing key in the causal mask dict.

### What's changed

- Moved the layer_types override to happen before from_pretrained, so the model is constructed with all "full_attention" layers from the start - no post-hoc patching needed.
- Post this fix, model fails due to OOM.

### Checklist
- [x] Verify the changes through local testing on N150

### Logs


- [apr13_gemma3_before_fix.log](https://github.com/user-attachments/files/26674298/apr13_gemma3.log)
- [apr13_gemma3_after_fix.log](https://github.com/user-attachments/files/26674282/apr13_gemma3_after_fix_1.log)

