### PR TITLE
Add DeBERTa-v3-base sentence embedding loader

### DIFF
--- a/deberta/sentence_embedding_generation/pytorch/__init__.py
+++ b/deberta/sentence_embedding_generation/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DeBERTa Sentence Embedding Generation PyTorch implementation.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/deberta/sentence_embedding_generation/pytorch/loader.py
+++ b/deberta/sentence_embedding_generation/pytorch/loader.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DeBERTa model loader implementation for sentence embedding generation.
+"""
+import torch
+from transformers import AutoModel, AutoTokenizer, AutoConfig
+from typing import Optional
+
+from third_party.tt_forge_models.config import (
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    LLMModelConfig,
+)
+from third_party.tt_forge_models.base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available DeBERTa model variants for sentence embedding generation."""
+
+    V3_BASE = "microsoft/deberta-v3-base"
+
+
+class ModelLoader(ForgeModel):
+    """DeBERTa model loader implementation for sentence embedding generation."""
+
+    _VARIANTS = {
+        ModelVariant.V3_BASE: LLMModelConfig(
+            pretrained_model_name="microsoft/deberta-v3-base",
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.V3_BASE
+
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
+        super().__init__(variant)
+        self.model = None
+        self.tokenizer = None
+        self.num_layers = num_layers
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="DeBERTa",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.NLP_EMBED_GEN,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        if self.tokenizer is None:
+            model_name = self._variant_config.pretrained_model_name
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_name = self._variant_config.pretrained_model_name
+
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        if self.num_layers is not None:
+            config = AutoConfig.from_pretrained(model_name)
+            config.num_hidden_layers = self.num_layers
+            model_kwargs["config"] = config
+
+        model = AutoModel.from_pretrained(model_name, **model_kwargs)
+        model.eval()
+        self.model = model
+        return model
+
+    def input_preprocess(self, dtype_override=None, sentence=None, max_length=None):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        if sentence is None:
+            sentence = "The quick brown fox jumps over the lazy dog."
+
+        if max_length is None:
+            max_length = getattr(self._variant_config, "max_length", 128)
+
+        inputs = self.tokenizer(
+            sentence,
+            padding="max_length",
+            truncation=True,
+            max_length=max_length,
+            return_tensors="pt",
+        )
+        return inputs
+
+    def load_inputs(self, dtype_override=None, sentence=None):
+        return self.input_preprocess(
+            dtype_override=dtype_override,
+            sentence=sentence,
+        )
+
+    def output_postprocess(self, output, inputs=None):
+        if inputs is None:
+            inputs = self.load_inputs()
+
+        attention_mask = inputs["attention_mask"]
+
+        if isinstance(output, (tuple, list)):
+            token_embeddings = output[0]
+        elif hasattr(output, "last_hidden_state"):
+            token_embeddings = output.last_hidden_state
+        else:
+            token_embeddings = output
+
+        input_mask_expanded = (
+            attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+        )
+        sentence_embeddings = torch.sum(
+            token_embeddings * input_mask_expanded, 1
+        ) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+
+        return sentence_embeddings
+
+    def decode_output(self, outputs, inputs=None):
+        return self.output_postprocess(outputs, inputs=inputs)


### PR DESCRIPTION
## Summary
- Add ModelLoader for `microsoft/deberta-v3-base` sentence embedding generation
- Supports `num_layers` parameter for fast bringup iteration
- Validated on TT hardware: PCC 0.998 (bf16, opt_level=1)

## Test plan
- [x] 1-layer benchmark: PCC 0.9989
- [x] 2-layer benchmark: PCC 0.9980
- [x] Full model (12 layers): PCC 0.9981
- [x] Test runner discovery and execution passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)