### PR TITLE
Add GPT-2 Medium, MPNet, Nomic Embed loaders

### DIFF
--- a/deberta/sentence_embedding_generation/pytorch/__init__.py
+++ b/deberta/sentence_embedding_generation/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DeBERTa Sentence Embedding Generation PyTorch implementation.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/deberta/sentence_embedding_generation/pytorch/loader.py
+++ b/deberta/sentence_embedding_generation/pytorch/loader.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DeBERTa model loader implementation for sentence embedding generation.
+"""
+import torch
+from transformers import AutoModel, AutoTokenizer, AutoConfig
+from typing import Optional
+
+from third_party.tt_forge_models.config import (
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    LLMModelConfig,
+)
+from third_party.tt_forge_models.base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    """Available DeBERTa model variants for sentence embedding generation."""
+
+    V3_BASE = "microsoft/deberta-v3-base"
+
+
+class ModelLoader(ForgeModel):
+    """DeBERTa model loader implementation for sentence embedding generation."""
+
+    _VARIANTS = {
+        ModelVariant.V3_BASE: LLMModelConfig(
+            pretrained_model_name="microsoft/deberta-v3-base",
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.V3_BASE
+
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
+        super().__init__(variant)
+        self.model = None
+        self.tokenizer = None
+        self.num_layers = num_layers
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="DeBERTa",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.NLP_EMBED_GEN,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        if self.tokenizer is None:
+            model_name = self._variant_config.pretrained_model_name
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_name = self._variant_config.pretrained_model_name
+
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        if self.num_layers is not None:
+            config = AutoConfig.from_pretrained(model_name)
+            config.num_hidden_layers = self.num_layers
+            model_kwargs["config"] = config
+
+        model = AutoModel.from_pretrained(model_name, **model_kwargs)
+        model.eval()
+        self.model = model
+        return model
+
+    def input_preprocess(self, dtype_override=None, sentence=None, max_length=None):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        if sentence is None:
+            sentence = "The quick brown fox jumps over the lazy dog."
+
+        if max_length is None:
+            max_length = getattr(self._variant_config, "max_length", 128)
+
+        inputs = self.tokenizer(
+            sentence,
+            padding="max_length",
+            truncation=True,
+            max_length=max_length,
+            return_tensors="pt",
+        )
+        return inputs
+
+    def load_inputs(self, dtype_override=None, sentence=None):
+        return self.input_preprocess(
+            dtype_override=dtype_override,
+            sentence=sentence,
+        )
+
+    def output_postprocess(self, output, inputs=None):
+        if inputs is None:
+            inputs = self.load_inputs()
+
+        attention_mask = inputs["attention_mask"]
+
+        if isinstance(output, (tuple, list)):
+            token_embeddings = output[0]
+        elif hasattr(output, "last_hidden_state"):
+            token_embeddings = output.last_hidden_state
+        else:
+            token_embeddings = output
+
+        input_mask_expanded = (
+            attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+        )
+        sentence_embeddings = torch.sum(
+            token_embeddings * input_mask_expanded, 1
+        ) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+
+        return sentence_embeddings
+
+    def decode_output(self, outputs, inputs=None):
+        return self.output_postprocess(outputs, inputs=inputs)

--- a/gpt2/pytorch/loader.py
+++ b/gpt2/pytorch/loader.py
@@ -29,6 +29,7 @@ class ModelVariant(StrEnum):
     """Available GPT-2 model variants."""
 
     GPT2_BASE = "Default"
+    GPT2_MEDIUM = "Medium"
     GPT2_SEQUENCE_CLASSIFICATION = "Sequence_Classification"
 
 
@@ -38,6 +39,10 @@ class ModelLoader(ForgeModel):
     _VARIANTS = {
         ModelVariant.GPT2_BASE: LLMModelConfig(
             pretrained_model_name="gpt2",
+            max_length=256,
+        ),
+        ModelVariant.GPT2_MEDIUM: LLMModelConfig(
+            pretrained_model_name="gpt2-medium",
             max_length=256,
         ),
         ModelVariant.GPT2_SEQUENCE_CLASSIFICATION: LLMModelConfig(
@@ -91,7 +96,7 @@ class ModelLoader(ForgeModel):
     def load_model(self, *, dtype_override=None, **kwargs):
         model_name = self._variant_config.pretrained_model_name
 
-        if self._variant == ModelVariant.GPT2_BASE:
+        if self._variant in (ModelVariant.GPT2_BASE, ModelVariant.GPT2_MEDIUM):
             config = GPT2Config.from_pretrained(model_name)
             config_dict = config.to_dict()
             config_dict["use_cache"] = True
@@ -119,7 +124,7 @@ class ModelLoader(ForgeModel):
         if self.tokenizer is None:
             self._load_tokenizer()
 
-        if self._variant == ModelVariant.GPT2_BASE:
+        if self._variant in (ModelVariant.GPT2_BASE, ModelVariant.GPT2_MEDIUM):
             # Use random input for text generation
             vocab_size = GPT2Config.from_pretrained(
                 self._variant_config.pretrained_model_name

--- a/mpnet/sentence_embedding_generation/pytorch/__init__.py
+++ b/mpnet/sentence_embedding_generation/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MPNet Sentence Embedding Generation PyTorch implementation.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/mpnet/sentence_embedding_generation/pytorch/loader.py
+++ b/mpnet/sentence_embedding_generation/pytorch/loader.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+MPNet model loader for sentence embedding generation (all-mpnet-base-v2).
+"""
+import torch
+from transformers import AutoModel, AutoTokenizer, AutoConfig
+from typing import Optional
+
+from third_party.tt_forge_models.config import (
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    LLMModelConfig,
+)
+from third_party.tt_forge_models.base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    ALL_MPNET_BASE_V2 = "sentence-transformers/all-mpnet-base-v2"
+
+
+class ModelLoader(ForgeModel):
+    _VARIANTS = {
+        ModelVariant.ALL_MPNET_BASE_V2: LLMModelConfig(
+            pretrained_model_name="sentence-transformers/all-mpnet-base-v2",
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.ALL_MPNET_BASE_V2
+
+    def __init__(self, variant=None, num_layers=None):
+        super().__init__(variant)
+        self.model = None
+        self.tokenizer = None
+        self.num_layers = num_layers
+
+    @classmethod
+    def _get_model_info(cls, variant=None):
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="MPNet",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.NLP_EMBED_GEN,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        if self.tokenizer is None:
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                self._variant_config.pretrained_model_name
+            )
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_name = self._variant_config.pretrained_model_name
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        if self.num_layers is not None:
+            config = AutoConfig.from_pretrained(model_name)
+            config.num_hidden_layers = self.num_layers
+            model_kwargs["config"] = config
+
+        model = AutoModel.from_pretrained(model_name, **model_kwargs)
+        model.eval()
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, sentence=None):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+        if sentence is None:
+            sentence = "The quick brown fox jumps over the lazy dog."
+        max_length = getattr(self._variant_config, "max_length", 128)
+        return self.tokenizer(
+            sentence, padding="max_length", truncation=True,
+            max_length=max_length, return_tensors="pt",
+        )
+
+    def output_postprocess(self, output, inputs=None):
+        if inputs is None:
+            inputs = self.load_inputs()
+        attention_mask = inputs["attention_mask"]
+        if isinstance(output, (tuple, list)):
+            token_embeddings = output[0]
+        elif hasattr(output, "last_hidden_state"):
+            token_embeddings = output.last_hidden_state
+        else:
+            token_embeddings = output
+        mask = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+        return torch.sum(token_embeddings * mask, 1) / torch.clamp(mask.sum(1), min=1e-9)
+
+    def decode_output(self, outputs, inputs=None):
+        return self.output_postprocess(outputs, inputs=inputs)

--- a/nomic_embed/sentence_embedding_generation/pytorch/__init__.py
+++ b/nomic_embed/sentence_embedding_generation/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Nomic Embed Sentence Embedding Generation PyTorch implementation.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/nomic_embed/sentence_embedding_generation/pytorch/loader.py
+++ b/nomic_embed/sentence_embedding_generation/pytorch/loader.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Nomic Embed model loader for sentence embedding generation (nomic-embed-text-v1.5).
+"""
+import torch
+from transformers import AutoModel, AutoTokenizer, AutoConfig
+from typing import Optional
+
+from third_party.tt_forge_models.config import (
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+    LLMModelConfig,
+)
+from third_party.tt_forge_models.base import ForgeModel
+
+
+class ModelVariant(StrEnum):
+    NOMIC_EMBED_TEXT_V1_5 = "nomic-ai/nomic-embed-text-v1.5"
+
+
+class ModelLoader(ForgeModel):
+    _VARIANTS = {
+        ModelVariant.NOMIC_EMBED_TEXT_V1_5: LLMModelConfig(
+            pretrained_model_name="nomic-ai/nomic-embed-text-v1.5",
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.NOMIC_EMBED_TEXT_V1_5
+
+    def __init__(self, variant=None, num_layers=None):
+        super().__init__(variant)
+        self.model = None
+        self.tokenizer = None
+        # num_layers not supported: NomicBert custom code uses strict state_dict loading
+        self.num_layers = None
+
+    @classmethod
+    def _get_model_info(cls, variant=None):
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="NomicEmbed",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.NLP_EMBED_GEN,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        if self.tokenizer is None:
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                self._variant_config.pretrained_model_name
+            )
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_name = self._variant_config.pretrained_model_name
+        model_kwargs = {"trust_remote_code": True}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        if self.num_layers is not None:
+            config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+            config.num_hidden_layers = self.num_layers
+            model_kwargs["config"] = config
+
+        model = AutoModel.from_pretrained(model_name, **model_kwargs)
+        model.eval()
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, sentence=None):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+        if sentence is None:
+            sentence = "search_query: The quick brown fox jumps over the lazy dog."
+        max_length = getattr(self._variant_config, "max_length", 128)
+        return self.tokenizer(
+            sentence, padding="max_length", truncation=True,
+            max_length=max_length, return_tensors="pt",
+        )
+
+    def output_postprocess(self, output, inputs=None):
+        if inputs is None:
+            inputs = self.load_inputs()
+        attention_mask = inputs["attention_mask"]
+        if isinstance(output, (tuple, list)):
+            token_embeddings = output[0]
+        elif hasattr(output, "last_hidden_state"):
+            token_embeddings = output.last_hidden_state
+        else:
+            token_embeddings = output
+        mask = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+        embeddings = torch.sum(token_embeddings * mask, 1) / torch.clamp(mask.sum(1), min=1e-9)
+        return torch.nn.functional.normalize(embeddings, p=2, dim=1)
+
+    def decode_output(self, outputs, inputs=None):
+        return self.output_postprocess(outputs, inputs=inputs)


### PR DESCRIPTION
## Summary
- **GPT-2 Medium**: Add `Medium` variant to existing `gpt2/pytorch` loader
- **MPNet (all-mpnet-base-v2)**: New sentence embedding loader for RAG use cases
- **Nomic Embed (nomic-embed-text-v1.5)**: New modern embedding loader with L2 normalization

## Test plan
- [x] MPNet full model: PCC 0.9995, 186 samples/sec
- [x] Nomic Embed full model: PCC 0.9998, 77 samples/sec
- [x] GPT-2 Medium 1-layer: PCC 0.9998

🤖 Generated with [Claude Code](https://claude.com/claude-code)