### PR TITLE
Skip BFloat16 conversion in clip-vit-large-patch14-336

### DIFF
--- a/clip/pytorch/loader.py
+++ b/clip/pytorch/loader.py
@@ -116,8 +116,18 @@ class ModelLoader(ForgeModel):
         model_kwargs = {"return_dict": False}
 
         # Load the model with dtype override if specified
-        if dtype_override is not None:
+        # Skip bf16 for Large_Patch14_336 - accumulated BF16 precision error across encoder
+        # layers gets amplified by the non-linear QuickGELU activation
+        # Reference: https://github.com/tenstorrent/tt-xla/issues/4185
+        if (
+            dtype_override is not None
+            and self._variant != ModelVariant.LARGE_PATCH14_336
+        ):
             model_kwargs["torch_dtype"] = dtype_override
+        elif dtype_override is not None:
+            print(
+                "NOTE: dtype_override ignored for Large_Patch14_336 - BF16 precision error amplified by QuickGELU"
+            )
         model_kwargs |= kwargs
 
         model = CLIPModel.from_pretrained(pretrained_model_name, **model_kwargs)
@@ -157,9 +167,18 @@ class ModelLoader(ForgeModel):
             if torch.is_tensor(inputs[key]):
                 inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
-        # Convert the input dtype to dtype_override if specified
-        if dtype_override is not None:
+        # Skip bf16 for Large_Patch14_336 - accumulated BF16 precision error across encoder
+        # layers gets amplified by the non-linear QuickGELU activation
+        # Reference: https://github.com/tenstorrent/tt-xla/issues/4185
+        if (
+            dtype_override is not None
+            and self._variant != ModelVariant.LARGE_PATCH14_336
+        ):
             inputs["pixel_values"] = inputs["pixel_values"].to(dtype_override)
+        elif dtype_override is not None:
+            print(
+                "NOTE: dtype_override ignored for Large_Patch14_336 - BF16 precision error amplified by QuickGELU"
+            )
 
         return inputs
 


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4185

### Problem description

- The `clip-vit-large-patch14-336` model having a PCC of `0.9574742356215242` when run in bfloat16.
- Root cause : The accumulated bf16 precision error from prior encoder layers gets amplified by the non-linear QuickGELU activation, causing a sharp PCC drop at layer 12.
- For complete context, please checkout [#4185](https://github.com/tenstorrent/tt-xla/issues/4185)
- Switching the model from BFP16 to FP32 improved PCC to `0.9936462742544213`
- Received confirmation from @nvukobratTT to run this model in FP32.

### What's changed

- Skipped bfloat16 conversion for `clip-vit-large-patch14-336`

### Checklist
- [x] verify the changes through local testing in N150

### Logs

- [apr15_clip_bfp16.log](https://github.com/user-attachments/files/26735597/apr15_clip_bfp16.log)
- [apr15_clip_fp32.log](https://github.com/user-attachments/files/26735599/apr15_clip_fp32.log)

