### PR TITLE
Add missing transformers pin to Jax model requirements

### DIFF
--- a/gpt_j/causal_lm/jax/requirements.txt
+++ b/gpt_j/causal_lm/jax/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
 
 eformer==0.0.62
+transformers==4.57.1

--- a/mamba/causal_lm/jax/requirements.txt
+++ b/mamba/causal_lm/jax/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
 
 eformer==0.0.62
+transformers==4.57.1

--- a/mamba2/causal_lm/jax/requirements.txt
+++ b/mamba2/causal_lm/jax/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
 
 eformer==0.0.62
+transformers==4.57.1

--- a/mistral/causal_lm/jax/requirements.txt
+++ b/mistral/causal_lm/jax/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
 
 eformer==0.0.62
+transformers==4.57.1

--- a/stablelm/causal_lm/jax/requirements.txt
+++ b/stablelm/causal_lm/jax/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/erfanzar/EasyDeL.git@77ced9d2f2ab6a3d705936d26112eb97d9f9e64a
 
 eformer==0.0.62
+transformers==4.57.1


### PR DESCRIPTION
- Pin transformers==4.57.1 in EasyDeL-based JAX loaders (mamba, mamba2, stablelm, mistral, gpt_j)                                                                                
- Fixes ImportError: cannot import name 'download_url' from 'transformers.utils' under transformers 5.x                                                                          
- Matches the workaround already used by sibling EasyDeL models (qwen, phi, llama, falcon, glm, gpt2, whisper)  
