### PR TITLE
Debugged the PCC drop in the Gemma variant

### DIFF
--- a/gemma/codegemma/pytorch/loader.py
+++ b/gemma/codegemma/pytorch/loader.py
@@ -139,7 +139,7 @@ def calculate_age(birth_year):
             input_prompt,
             return_tensors="pt",
             max_length=self._variant_config.max_length,
-            padding="max_length",
+            padding=True,
             truncation=True,
         )
 

--- a/gemma3/causal_lm/pytorch/loader.py
+++ b/gemma3/causal_lm/pytorch/loader.py
@@ -151,7 +151,7 @@ class ModelLoader(ForgeModel):
             [input_text],
             return_tensors="pt",
             max_length=max_length,
-            padding="max_length",
+            padding=True,
             truncation=True,
         )
         for key in inputs:


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Debugged the PCC drop in the Gemma variant

### What's changed
```
test_all_models_torch[gemma/codegemma/pytorch-2B-single_device-inference]                                                                  language    generality  bfloat16       n150         INCORRECT_RESULT           PASSING       0.9039602052284695     0.99       PCC_DIS  single_device    129.327  N/A           
test_all_models_torch[gemma/codegemma/pytorch-2B-single_device-inference]                                                                  language    generality  bfloat16       p150         INCORRECT_RESULT           PASSING       0.8999925187314077     0.99       PCC_DIS  single_device    74.322   N/A           
test_all_models_torch[gemma3/causal_lm/pytorch-1B_Instruct-single_device-inference]                                                        language    generality  bfloat16       n150         INCORRECT_RESULT           PASSING       0.9488788369785738     0.99       PCC_DIS  single_device    140.397  N/A           
test_all_models_torch[gemma3/causal_lm/pytorch-1B_Instruct-single_device-inference]                                                        language    generality  bfloat16       p150         INCORRECT_RESULT           PASSING       0.9547296886675886     0.99       PCC_DIS  single_device    92.449   N/A           
```


After setting padding=True, both variants in n150 and p150 pass with a PCC of 0.99.
ci runs: https://github.com/tenstorrent/tt-xla/actions/runs/24661060224
https://github.com/tenstorrent/tt-xla/actions/runs/24661079067
### Checklist
- [ ] New/Existing tests provide coverage for changes
