### PR TITLE
Debug the PCC drop in Qwen variants

### DIFF
--- a/qwen_2/causal_lm/pytorch/loader.py
+++ b/qwen_2/causal_lm/pytorch/loader.py
@@ -131,7 +131,6 @@ class ModelLoader(ForgeModel):
         )
         model.eval()
         self.config = model.config
-
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):
@@ -154,14 +153,14 @@ class ModelLoader(ForgeModel):
         # Use chat template for QwQ-32B
         messages = [{"role": "user", "content": self.sample_text}]
         text = self.tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True, enable_thinking=True
+            messages, tokenize=False, add_generation_prompt=True
         )
         prompts = [text]
 
         inputs = self.tokenizer(
             prompts,
             return_tensors="pt",
-            padding="max_length",
+            padding=True,
             truncation=True,
             max_length=max_length,
         )
@@ -170,7 +169,6 @@ class ModelLoader(ForgeModel):
         for key in inputs:
             if torch.is_tensor(inputs[key]):
                 inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
-
         return inputs
 
     def get_mesh_config(self, num_devices: int):

--- a/qwen_2/causal_lm/pytorch/loader.py
+++ b/qwen_2/causal_lm/pytorch/loader.py
@@ -119,7 +119,6 @@ class ModelLoader(ForgeModel):
         )
         model.eval()
         self.config = model.config
-
         return model
 
     def load_inputs(self, dtype_override=None, batch_size=1):
@@ -141,14 +140,14 @@ class ModelLoader(ForgeModel):
         # Use chat template for QwQ-32B
         messages = [{"role": "user", "content": self.sample_text}]
         text = self.tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True, enable_thinking=True
+            messages, tokenize=False, add_generation_prompt=True
         )
         prompts = [text]
 
         inputs = self.tokenizer(
             prompts,
             return_tensors="pt",
-            padding="max_length",
+            padding=True,
             truncation=True,
             max_length=max_length,
         )
@@ -157,7 +156,6 @@ class ModelLoader(ForgeModel):
         for key in inputs:
             if torch.is_tensor(inputs[key]):
                 inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
-
         return inputs
 
     def get_mesh_config(self, num_devices: int):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/3781

### Problem description
Debug the PCC drop in Qwen variants(qwen_2/causal_lm/pytorch-Qwq_32B-tensor_parallel-inference)

### What's changed
Initially, the model was failing due to a low PCC; after setting truncation to True, it began passing with a good PCC.
ci run: https://github.com/tenstorrent/tt-xla/actions/runs/24704960710



### Checklist
- [ ] New/Existing tests provide coverage for changes
