### PR TITLE
Add sliding attention support

### DIFF
--- a/base.py
+++ b/base.py
@@ -236,6 +236,14 @@ class ForgeModel(ABC):
         """
         return None
 
+    @property
+    def requires_model_rewrites(self) -> bool:
+        """Whether consumers should apply TT-friendly in-place model rewrites
+        (e.g. the sliding-window causal-mask patch) before compiling this
+        loader's model.
+        """
+        return False
+
     def get_weight_dtype_config_path(self) -> Optional[str]:
         """Return path to a per-variant weight dtype override JSON, if it exists.
 

--- a/mistral/pytorch/loader.py
+++ b/mistral/pytorch/loader.py
@@ -12,10 +12,12 @@ from transformers import (
     Mistral3ForConditionalGeneration,
     MistralForCausalLM,
 )
+from transformers.cache_utils import StaticCache
 from typing import Optional
 
 from ...base import ForgeModel
 from ...config import (
+    LLMModelConfig,
     ModelConfig,
     ModelInfo,
     ModelGroup,
@@ -57,6 +59,10 @@ class ModelLoader(ForgeModel):
     _USE_Mistral3ForConditionalGeneration_VARIANTS = {
         ModelVariant.MISTRAL_SMALL_3_2_24B_INSTRUCT_2506,
     }
+    # Ministral-8B uses sliding window attention and needs StaticCache + overrides.
+    _SLIDING_WINDOW_VARIANTS = {
+        ModelVariant.MINISTRAL_8B,
+    }
 
     # Dictionary of available model variants
     _VARIANTS = {
@@ -69,8 +75,9 @@ class ModelLoader(ForgeModel):
         ModelVariant.MINISTRAL_3B: ModelConfig(
             pretrained_model_name="ministral/Ministral-3b-instruct",
         ),
-        ModelVariant.MINISTRAL_8B: ModelConfig(
+        ModelVariant.MINISTRAL_8B: LLMModelConfig(
             pretrained_model_name="mistralai/Ministral-8B-Instruct-2410",
+            max_length=256,
         ),
         ModelVariant.MISTRAL_SMALL_24B_INSTRUCT_2501: ModelConfig(
             pretrained_model_name="mistralai/Mistral-Small-24B-Instruct-2501",
@@ -231,12 +238,15 @@ class ModelLoader(ForgeModel):
                 pretrained_model_name, **model_kwargs
             ).eval()
 
-        if self._variant == ModelVariant.MINISTRAL_8B:
-            model.config.layer_types = ["full_attention"] * len(
-                model.config.layer_types
+        if self._variant in self._SLIDING_WINDOW_VARIANTS:
+            from tt_torch.transformers_overrides import (
+                override_ministral_sliding_window_causal_mask,
             )
-        self.config = model.config
 
+            override_ministral_sliding_window_causal_mask()
+        print("model", model)
+        print("model.config", model.config)
+        self.config = model.config
         self.model = model
         return model
 
@@ -312,21 +322,56 @@ class ModelLoader(ForgeModel):
             }
         else:
             inputs = self.tokenizer(test_input, return_tensors="pt")
-
-        if (
-            hasattr(self.model.config, "sliding_window")
-            and self.model.config.sliding_window is not None
-        ):
-            # if the model uses sliding window attention, match sliding window value to input size so it
-            # does not go out of bounds when updating the cache
-            self.model.config.sliding_window = inputs["input_ids"].shape[1]
-
         # Add batch dimension
         for key in inputs:
             if torch.is_tensor(inputs[key]):
                 inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
-        return inputs
+        if self._variant not in self._SLIDING_WINDOW_VARIANTS:
+            return inputs
+
+        if self._variant in self._SLIDING_WINDOW_VARIANTS:
+            from tt_torch.transformers_overrides import (
+                override_cache_sliding_window_layers,
+                _init_static_cache,
+            )
+
+            max_cache_len = self._variant_config.max_length
+            # Sliding window variants: build full input_args with StaticCache
+            seq_len = inputs["input_ids"].shape[1]
+
+            static_cache = StaticCache(
+                config=self.config,
+                max_cache_len=max_cache_len,
+            )
+            _init_static_cache(static_cache, self.config, batch_size)
+            sliding_window = getattr(
+                self.config.get_text_config(decoder=True),
+                "sliding_window",
+                max_cache_len,
+            )
+            override_cache_sliding_window_layers(
+                static_cache, max_cache_len, sliding_window
+            )
+
+            # Attention mask must match max_cache_len to prevent recompilation or
+            # implicit padding by transformers, which can cause degenerate output.
+            full_attention_mask = torch.ones(
+                (batch_size, max_cache_len), dtype=inputs.attention_mask.dtype
+            )
+            full_attention_mask[:, :seq_len] = inputs.attention_mask
+
+            cache_position = torch.arange(0, seq_len)
+
+            input_args = {
+                "input_ids": inputs.input_ids,
+                "past_key_values": static_cache,
+                "cache_position": cache_position,
+                "use_cache": True,
+                "attention_mask": full_attention_mask,
+            }
+            print("input_args", input_args)
+            return input_args
 
     # TODO - Verify this function correct (was AI_GENERATED)
     def decode_output(self, outputs, dtype_override):

--- a/mistral/pytorch/loader.py
+++ b/mistral/pytorch/loader.py
@@ -16,6 +16,7 @@ from typing import Optional
 
 from ...base import ForgeModel
 from ...config import (
+    LLMModelConfig,
     ModelConfig,
     ModelInfo,
     ModelGroup,
@@ -57,6 +58,10 @@ class ModelLoader(ForgeModel):
     _USE_Mistral3ForConditionalGeneration_VARIANTS = {
         ModelVariant.MISTRAL_SMALL_3_2_24B_INSTRUCT_2506,
     }
+    # Ministral-8B uses sliding window attention and needs StaticCache + overrides.
+    _SLIDING_WINDOW_VARIANTS = {
+        ModelVariant.MINISTRAL_8B,
+    }
 
     # Dictionary of available model variants
     _VARIANTS = {
@@ -69,8 +74,9 @@ class ModelLoader(ForgeModel):
         ModelVariant.MINISTRAL_3B: ModelConfig(
             pretrained_model_name="ministral/Ministral-3b-instruct",
         ),
-        ModelVariant.MINISTRAL_8B: ModelConfig(
+        ModelVariant.MINISTRAL_8B: LLMModelConfig(
             pretrained_model_name="mistralai/Ministral-8B-Instruct-2410",
+            max_length=256,
         ),
         ModelVariant.MISTRAL_SMALL_24B_INSTRUCT_2501: ModelConfig(
             pretrained_model_name="mistralai/Mistral-Small-24B-Instruct-2501",
@@ -112,6 +118,11 @@ class ModelLoader(ForgeModel):
         self.tokenizer = None
         self.model = None
         self.num_layers = num_layers
+
+    @property
+    def requires_model_rewrites(self) -> bool:
+        """Sliding-window variants need the TT causal-mask rewrite applied."""
+        return self._variant in self._SLIDING_WINDOW_VARIANTS
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -224,12 +235,7 @@ class ModelLoader(ForgeModel):
                 pretrained_model_name, **model_kwargs
             ).eval()
 
-        if self._variant == ModelVariant.MINISTRAL_8B:
-            model.config.layer_types = ["full_attention"] * len(
-                model.config.layer_types
-            )
         self.config = model.config
-
         self.model = model
         return model
 
@@ -322,20 +328,26 @@ class ModelLoader(ForgeModel):
 
         else:
             inputs = self.tokenizer(test_input, return_tensors="pt")
-
-        if (
-            hasattr(self.model.config, "sliding_window")
-            and self.model.config.sliding_window is not None
-        ):
-            # if the model uses sliding window attention, match sliding window value to input size so it
-            # does not go out of bounds when updating the cache
-            self.model.config.sliding_window = inputs["input_ids"].shape[1]
-
         # Add batch dimension
         for key in inputs:
             if torch.is_tensor(inputs[key]):
                 inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
+        # Non-sliding variants: return standard tokenizer output
+        if self._variant not in self._SLIDING_WINDOW_VARIANTS:
+            return inputs
+
+        from tt_forge_models.tools.utils import (
+            prepare_inputs_for_sliding_window_attention,
+        )
+
+        inputs = prepare_inputs_for_sliding_window_attention(
+            inputs,
+            batch_size=batch_size,
+            max_cache_len=self._variant_config.max_length,
+            dtype_override=dtype_override,
+            config=self.config,
+        )
         return inputs
 
     # TODO - Verify this function correct (was AI_GENERATED)

--- a/olmo3/causal_lm/pytorch/loader.py
+++ b/olmo3/causal_lm/pytorch/loader.py
@@ -8,6 +8,8 @@ Olmo3 Causal LM model loader implementation
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
 from typing import Optional
+from transformers.cache_utils import StaticCache
+
 
 from ....base import ForgeModel
 from ....config import (
@@ -33,6 +35,12 @@ class ModelVariant(StrEnum):
 
 class ModelLoader(ForgeModel):
     """Olmo3 model loader implementation for causal language modeling tasks."""
+
+    # These variants use sliding window attention and need StaticCache + overrides.
+    _SLIDING_WINDOW_VARIANTS = {
+        ModelVariant.Olmo_3_1025_7B,
+        ModelVariant.Olmo_3_1125_32B,
+    }
 
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
@@ -107,12 +115,10 @@ class ModelLoader(ForgeModel):
         Returns:
             The loaded tokenizer instance
         """
-        # Initialize tokenizer with dtype override if specified
         tokenizer_kwargs = {}
         if dtype_override is not None:
             tokenizer_kwargs["torch_dtype"] = dtype_override
 
-        # Load the tokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(
             self._variant_config.pretrained_model_name, **tokenizer_kwargs
         )
@@ -146,12 +152,15 @@ class ModelLoader(ForgeModel):
         model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name, **model_kwargs
         )
-        if getattr(model.config, "use_cache", True):
-            model.config.layer_types = [
-                "full_attention"
-            ] * model.config.num_hidden_layers
-        model.eval()
+        if self._variant in self._SLIDING_WINDOW_VARIANTS:
+            from tt_torch.transformers_overrides import (
+                override_olmo3_sliding_window_causal_mask,
+            )
 
+            override_olmo3_sliding_window_causal_mask()
+        model.eval()
+        print("model", model)
+        print("model.config", model.config)
         self.config = model.config
         self.model = model
         return model
@@ -170,10 +179,17 @@ class ModelLoader(ForgeModel):
         if self.tokenizer is None:
             self._load_tokenizer(dtype_override=dtype_override)
 
+        max_cache_len = self._variant_config.max_length
+
         # Get max_length from the variant config
         max_length = self._variant_config.max_length
 
         prompts = [self.sample_text]
+
+        # Compute the actual prompt token length to get a consistent static shape
+        prompt_token_len = len(
+            self.tokenizer.encode(self.sample_text, add_special_tokens=False)
+        )
 
         inputs = self.tokenizer(
             prompts,
@@ -188,7 +204,50 @@ class ModelLoader(ForgeModel):
             if torch.is_tensor(inputs[key]):
                 inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
-        return inputs
+        # Non-sliding variants: return standard tokenizer output
+        if self._variant not in self._SLIDING_WINDOW_VARIANTS:
+            print("inputs", inputs)
+            return inputs
+
+        # Sliding window variants: build full input_args with StaticCache
+        seq_len = inputs.input_ids.shape[1]
+
+        from tt_torch.transformers_overrides import (
+            override_cache_sliding_window_layers,
+            _init_static_cache,
+        )
+
+        static_cache = StaticCache(
+            config=self.config,
+            max_cache_len=max_cache_len,
+        )
+        _init_static_cache(static_cache, self.config, batch_size)
+
+        sliding_window = getattr(
+            self.config.get_text_config(decoder=True), "sliding_window", max_cache_len
+        )
+        override_cache_sliding_window_layers(
+            static_cache, max_cache_len, sliding_window
+        )
+
+        # Attention mask must match max_cache_len to prevent recompilation or
+        # implicit padding by transformers, which can cause degenerate output.
+        full_attention_mask = torch.ones(
+            (batch_size, max_cache_len), dtype=inputs.attention_mask.dtype
+        )
+        full_attention_mask[:, :seq_len] = inputs.attention_mask
+
+        cache_position = torch.arange(0, seq_len)
+
+        input_args = {
+            "input_ids": inputs.input_ids,
+            "past_key_values": static_cache,
+            "cache_position": cache_position,
+            "use_cache": True,
+            "attention_mask": full_attention_mask,
+        }
+        print("input_args", input_args)
+        return input_args
 
     def get_mesh_config(self, num_devices: int):
 

--- a/olmo3/causal_lm/pytorch/loader.py
+++ b/olmo3/causal_lm/pytorch/loader.py
@@ -34,6 +34,12 @@ class ModelVariant(StrEnum):
 class ModelLoader(ForgeModel):
     """Olmo3 model loader implementation for causal language modeling tasks."""
 
+    # These variants use sliding window attention and need StaticCache + overrides.
+    _SLIDING_WINDOW_VARIANTS = {
+        ModelVariant.Olmo_3_1025_7B,
+        ModelVariant.Olmo_3_1125_32B,
+    }
+
     # Dictionary of available model variants using structured configs
     _VARIANTS = {
         ModelVariant.Olmo_3_7B_Think: LLMModelConfig(
@@ -75,6 +81,11 @@ class ModelLoader(ForgeModel):
         self.tokenizer = None
         self.config = None
         self.model = None
+
+    @property
+    def requires_model_rewrites(self) -> bool:
+        """Sliding-window variants need the TT causal-mask rewrite applied."""
+        return self._variant in self._SLIDING_WINDOW_VARIANTS
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -134,12 +145,7 @@ class ModelLoader(ForgeModel):
         model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name, **model_kwargs
         )
-        if getattr(model.config, "use_cache", True):
-            model.config.layer_types = [
-                "full_attention"
-            ] * model.config.num_hidden_layers
         model.eval()
-
         self.config = model.config
         self.model = model
         return model
@@ -157,9 +163,6 @@ class ModelLoader(ForgeModel):
         if self.tokenizer is None:
             self._load_tokenizer()
 
-        # Get max_length from the variant config
-        max_length = self._variant_config.max_length
-
         prompts = [self.sample_text]
 
         inputs = self.tokenizer(
@@ -167,7 +170,7 @@ class ModelLoader(ForgeModel):
             return_tensors="pt",
             padding=True,
             truncation=True,
-            max_length=max_length,
+            max_length=self._variant_config.max_length,
         )
 
         # Add batch dimension
@@ -175,6 +178,19 @@ class ModelLoader(ForgeModel):
             if torch.is_tensor(inputs[key]):
                 inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
 
+        # Non-sliding variants: return standard tokenizer output
+        if self._variant not in self._SLIDING_WINDOW_VARIANTS:
+            return inputs
+
+        from tools.utils import prepare_inputs_for_sliding_window_attention
+
+        inputs = prepare_inputs_for_sliding_window_attention(
+            inputs,
+            batch_size=batch_size,
+            max_cache_len=self._variant_config.max_length,
+            dtype_override=dtype_override,
+            config=self.config,
+        )
         return inputs
 
     def get_mesh_config(self, num_devices: int):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1238,3 +1238,80 @@ def export_torch_model_to_onnx(
     model = onnx.load(onnx_path)
     onnx.checker.check_model(model)
     return model
+
+
+### input preparation for sliding window attention
+def prepare_inputs_for_sliding_window_attention(
+    inputs,
+    batch_size=1,
+    max_cache_len=128,
+    dtype_override=None,
+    config=None,
+):
+    """Build the model input dict for sliding-window-attention variants.
+
+    Wraps the tokenized inputs in a ``StaticCache`` whose sliding-window
+    layers are replaced with the TT-friendly always-roll variant, and pads
+    the attention mask out to ``max_cache_len`` so the graph shape is
+    static across decode steps.
+
+    The returned dict contains only real model kwargs. The signal that a
+    model needs TT-friendly rewrites (e.g. the sliding-window mask patch) is
+    exposed separately via the loader's ``requires_model_rewrites`` property,
+    which tt-xla consumers (e.g. ``DynamicTorchModelTester``) query before
+    compilation — so this dict can be forwarded straight to ``model(**inputs)``.
+
+    Args:
+        inputs: Tokenizer output with ``input_ids`` and ``attention_mask``.
+        batch_size: Batch size of the request.
+        max_cache_len: Fixed KV-cache length; attention mask is padded to
+            this size to avoid recompilation / implicit padding by HF.
+        dtype_override: Optional dtype for the KV cache (default bfloat16).
+        config: HuggingFace ``PretrainedConfig`` for the model.
+
+    Returns:
+        dict: Kwargs ready to pass to ``model(**input_args)``
+    """
+    from transformers.cache_utils import StaticCache
+
+    from tt_torch.transformers_overrides import override_cache_sliding_window_layers
+
+    seq_len = inputs.input_ids.shape[1]
+
+    static_cache = StaticCache(
+        config=config,
+        max_cache_len=max_cache_len,
+    )
+
+    text_config = config.get_text_config(decoder=True)
+    head_dim = getattr(text_config, "head_dim", None) or (
+        text_config.hidden_size // text_config.num_attention_heads
+    )
+    cache_dtype = dtype_override if dtype_override is not None else torch.bfloat16
+    static_cache.early_initialization(
+        batch_size=batch_size,
+        num_heads=text_config.num_key_value_heads,
+        head_dim=head_dim,
+        dtype=cache_dtype,
+        device="cpu",
+    )
+
+    sliding_window = getattr(text_config, "sliding_window", max_cache_len)
+    override_cache_sliding_window_layers(static_cache, max_cache_len, sliding_window)
+
+    # Attention mask must match max_cache_len to prevent recompilation or
+    # implicit padding by transformers, which can cause degenerate output.
+    full_attention_mask = torch.ones(
+        (batch_size, max_cache_len), dtype=inputs.attention_mask.dtype
+    )
+    full_attention_mask[:, :seq_len] = inputs.attention_mask
+
+    cache_position = torch.arange(0, seq_len)
+
+    return {
+        "input_ids": inputs.input_ids,
+        "past_key_values": static_cache,
+        "cache_position": cache_position,
+        "use_cache": True,
+        "attention_mask": full_attention_mask,
+    }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4171

### Problem description
Add sliding attention support

### What's changed
I’ve been testing models with sliding attention, replacing the previously hardcoded full attention.

Edited the variants loader.py mentioned above.
[mistal.log](https://github.com/user-attachments/files/28343713/mistal.log)
[olmo.log](https://github.com/user-attachments/files/28343716/olmo.log)
[olmo3_1125_32b.log](https://github.com/user-attachments/files/28343721/olmo3_1125_32b.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes

