### PR TITLE
Remove GPU-specific chunking in panoptic segmentation model

### DIFF
--- a/panoptic_segmentation/pytorch/src/model.py
+++ b/panoptic_segmentation/pytorch/src/model.py
@@ -3095,19 +3095,7 @@ def paste_masks_in_image(
 
     img_h, img_w = image_shape
 
-    if device.type == "cpu" or torch.jit.is_scripting():
-        # CPU is most efficient when they are pasted one by one with skip_empty=True
-        # so that it performs minimal number of operations.
-        num_chunks = N
-    else:
-        # GPU benefits from parallelism for larger chunks, but may have memory issue
-        # int(img_h) because shape may be tensors in tracing
-        num_chunks = int(
-            np.ceil(N * int(img_h) * int(img_w) * BYTES_PER_FLOAT / GPU_MEM_LIMIT)
-        )
-        assert (
-            num_chunks <= N
-        ), "Default GPU_MEM_LIMIT in mask_ops.py is too small; try increasing it"
+    num_chunks = N
     chunks = torch.chunk(torch.arange(N, device=device), num_chunks)
 
     img_masks = torch.zeros(


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/4367

### Problem description

- `paste_masks_in_image` in the panoptic segmentation model crashed with NameError: name 'BYTES_PER_FLOAT' is not defined during inference post-processing. The GPU-specific chunking branch referenced constants (BYTES_PER_FLOAT, GPU_MEM_LIMIT) that were never defined in the vendored model file.

### What's changed

- Removed the GPU-specific chunking logic and set num_chunks = N directly, matching the existing CPU branch behavior. GPU is not a target device, so this branch was dead code.

### Checklist
- [x] Verify the changes through local testing in N150

### Logs

- [apr22_ps_res50_1x_before_fix.log.zip](https://github.com/user-attachments/files/26973754/apr22_ps_res50_1x.log.zip)
- [apr22_ps_res50_1x_after_fix.log.zip](https://github.com/user-attachments/files/26973747/apr22_ps_res50_1x_after_fix.log.zip)

