### PR TITLE
Fix UNet output_postprocess crash on bfloat16 outputs

### DIFF
--- a/unet/pytorch/loader.py
+++ b/unet/pytorch/loader.py
@@ -365,7 +365,7 @@ class ModelLoader(ForgeModel):
             if output_tensor is None:
                 return None
 
-            output_np = output_tensor.detach().cpu().numpy()
+            output_np = output_tensor.detach().float().cpu().numpy()
             binary_mask = (output_np > threshold).astype(np.float32)
 
             lcc_actually_applied = False
@@ -439,7 +439,7 @@ class ModelLoader(ForgeModel):
 
             return {
                 "output": output_tensor,
-                "output_numpy": output_tensor.detach().cpu().numpy(),
+                "output_numpy": output_tensor.detach().float().cpu().numpy(),
                 "output_shape": list(output_tensor.shape),
                 "output_dtype": str(output_tensor.dtype),
             }


### PR DESCRIPTION
## Summary

`torch.Tensor.numpy()` does not support bfloat16, so when the Forge inference server runs UNet with the default `dtype=torch.bfloat16` (set in tt-media-server's `ForgeRunner`), `output_postprocess()` raises `"Got unsupported ScalarType BFloat16"` during server warmup. This is what's failing the **Forge UNet release test in tt-shield CI** (e.g. [run-release-unet-n150-n150 in run 22418024620](https://github.com/tenstorrent/tt-shield/actions/runs/22418024620/job/64910131760)), where 230/230 liveness checks get HTTP 500 because the worker never warms up.

Fix: cast the output tensor to float32 before `.numpy()` in both branches of `unet/pytorch/loader.py::ModelLoader.output_postprocess` (the `TORCHHUB_BRAIN_UNET` segmentation path at line 372, and the generic fallback at line 446). No change in numerical behavior — the thresholding / shape / dtype string reporting downstream are unaffected.

## Test plan
- [x] Root cause verified against CI log: `[warmup] async failed after 72.1390 seconds. Error: Got unsupported ScalarType BFloat16`, stack trace matching `output_postprocess -> .numpy()`.
- [x] Local repro on `bgd-lab-23` with tt-inference-server + this patch sparse-checked into `tt-media-server/tt_model_runners/forge_runners/model_loaders/`: CPU-mode warmup for `ForgeUnetRunner` now completes (0.45s, no `Got unsupported ScalarType BFloat16`). Without the patch it fails identically to CI.
- [ ] tt-shield release UNet job on n150 (will follow up via PR on tt-inference-server bumping `FORGE_MODELS_SHA` to this commit).

## Notes
- Only affects the UNet loader. Other forge_runner models (resnet / segformer / vit / vovnet / mobilenetv2 / efficientnet) do not call `.numpy()` on the raw model output in their loaders, so they aren't affected.
- A separate latent bug exists in the UNet post-processing API (the pytest path `forge_runner._postprocess_model_output` passes `top_k=...` to `output_postprocess`, which UNet's signature doesn't accept, and downstream expects `labels`/`probabilities` keys that UNet doesn't emit). That path is only hit by direct `POST /v1/cnn/search-image` requests, not by the liveness-only release test — and it's arguably a design mismatch between a classifier-oriented `ForgeRunner` and a segmentation model. Happy to file / fix that separately if desired; kept out of this PR to keep the change minimal and targeted at the CI blocker.