### PR TITLE
Fix(maptr): avoid CPU/xla device mismatch in can_bus zeroing

### DIFF
--- a/maptr/pytorch/src/maptr.py
+++ b/maptr/pytorch/src/maptr.py
@@ -6438,8 +6438,18 @@ class MapTR(MVXTwoStageDetector):
         tmp_pos = copy.deepcopy(img_metas[0][0]["can_bus"][:3])
         tmp_angle = copy.deepcopy(img_metas[0][0]["can_bus"][-1])
 
-        img_metas[0][0]["can_bus"][-1] = 0
-        img_metas[0][0]["can_bus"][:3] = 0
+        can_bus = img_metas[0][0]["can_bus"]
+        if torch.is_tensor(can_bus):
+            img_metas[0][0]["can_bus"] = torch.cat(
+                [
+                    torch.zeros(3, dtype=can_bus.dtype, device=can_bus.device),
+                    can_bus[3:-1],
+                    torch.zeros(1, dtype=can_bus.dtype, device=can_bus.device),
+                ]
+            )
+        else:
+            can_bus[-1] = 0
+            can_bus[:3] = 0
 
         new_prev_bev, bbox_results = self.simple_test(
             img_metas[0],


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/4410

### Problem description

- During torch.export of MapTR, the in-place writes can_bus[-1] = 0 and can_bus[:3] = 0 decompose into aten.where.self. The generated mask and zero literals land on CPU while can_bus is on xla:0, so FakeTensor device propagation fails and export crashes.

### What's changed

- Rewrote the zeroing as torch.cat, allocating the zero pieces on can_bus.device so all operands stay on the same device and no where is emitted. The numpy in-place path is kept for the eager reference run.

### Checklist
- [x] verify the changes through local testing

### Logs

- [apr27_maptr_bev_before_fix.log](https://github.com/user-attachments/files/27117598/apr27_maptr_bev.log)
- [apr27_maptr_bev_after_fix.log](https://github.com/user-attachments/files/27117596/apr27_maptr_bev_after_fix_1.log)


