### PR TITLE
Fix(smolvla loader): patch torch.cumsum for bool inputs

### DIFF
--- a/smolvla/vision_language_action/pytorch/loader.py
+++ b/smolvla/vision_language_action/pytorch/loader.py
@@ -17,6 +17,27 @@ import numpy as np
 import torch
 
 from ....base import ForgeModel
+
+
+def _patch_torch_cumsum_bool_to_int64() -> None:
+    """torch.compile/XLA can keep bool dtype through cumsum; subtracting 1 then fails.
+
+    Eager PyTorch promotes bool cumsum to int64. Casting bool inputs here matches that
+    behavior and fixes SmolVLA's ``torch.cumsum(pad_masks, dim=1) - 1`` (lerobot).
+    """
+    if getattr(torch, "_tt_xla_cumsum_bool_patch_applied", False):
+        return
+    _orig_cumsum = torch.cumsum
+
+    def cumsum(input, *args, **kwargs):  # noqa: A002
+        if isinstance(input, torch.Tensor) and input.dtype == torch.bool:
+            input = input.to(dtype=torch.int64)
+        return _orig_cumsum(input, *args, **kwargs)
+
+    torch.cumsum = cumsum  # type: ignore[method-assign]
+    torch._tt_xla_cumsum_bool_patch_applied = True  # type: ignore[attr-defined]
+
+
 from ....config import (
     Framework,
     ModelConfig,
@@ -99,6 +120,7 @@ class ModelLoader(ForgeModel):
         )
 
     def _load_processors(self, device: torch.device):
+        _patch_torch_cumsum_bool_to_int64()
         _setup_policies_namespace()
         import lerobot.policies.smolvla.processor_smolvla  # noqa: F401
         from lerobot.processor import PolicyProcessorPipeline
@@ -110,6 +132,7 @@ class ModelLoader(ForgeModel):
         )
 
     def load_model(self, *, dtype_override=None, device: str = "cpu", **kwargs):
+        _patch_torch_cumsum_bool_to_int64()
         _setup_policies_namespace()
         from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
 


### PR DESCRIPTION
### Ticket

- Fixes [#4412](https://github.com/tenstorrent/tt-xla/issues/4412)

### Problem description

`smolvla/vision_language_action/pytorch-smolvla_base-single_device-inference` test fails with `RuntimeError: Check failed: type1 != at::kBool && type2 != at::kBool: Subtraction, the `-` operator, with a bool tensor is not supported. If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.`

### What's changed

1. SmolVLA computes prefix_position_ids with torch.cumsum(prefix_pad_masks, dim=1) - 1, where prefix_pad_masks is a boolean padding mask. The failure is that the next step uses subtraction (- 1), and PyTorch does not allow the - operator when a bool tensor is involved in that sub.

2. Cumsum on a bool tensor behaves like summing 0/1 values and yields an integer-typed result, so subtracting one is ordinary integer math. Under torch.compile / XLA / Dynamo, the traced graph can leave cumsum operating on or producing bool in a way that still feeds a bool into - 1, which then triggers the unsupported bool subtraction error.

3. The fix in loader.py installs a small patch on torch.cumsum: if the input is a bool tensor, it is cast to int64 before calling the original cumsum, aligning compiled behavior with eager. That ensures the value passed to - 1 is integer, not bool. The patch runs once  and is invoked from _load_processors and load_model so it is in place before the model and processors run.

4. Model then fails with pcc=0.8302279596346094 , verified that final model results do not deviate from the original unchanged code to ensure the new changes does not cause pcc drop.

### Logs
[smolvla_before_fix.log](https://github.com/user-attachments/files/27190213/smolvla_before_fix.log)
[smolvla_after_fix.log](https://github.com/user-attachments/files/27190219/smolvla_after_fix.log)