### PR TITLE
Adds loader for ltx_2_3 model

### DIFF
--- a/ltx_2_3/__init__.py
+++ b/ltx_2_3/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/ltx_2_3/pytorch/__init__.py
+++ b/ltx_2_3/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant
+
+__all__ = ["ModelLoader", "ModelVariant"]

--- a/ltx_2_3/pytorch/loader.py
+++ b/ltx_2_3/pytorch/loader.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+LTX-2.3 model loader.
+
+LTX-2.3 is a 22B DiT (Diffusion Transformer) video generation model by Lightricks.
+Repository: https://github.com/Lightricks/LTX-2
+Weights:    https://huggingface.co/Lightricks/LTX-2.3
+
+Variants
+--------
+LTX_23_FAST  —  distilled checkpoint, 8 steps, guidance_scale=1.0 (CFG off)
+LTX_23_PRO   —  dev checkpoint, ~40 steps, guidance_scale=5.0 (CFG on)
+
+Both variants share the same 22B DiT architecture. Only the checkpoint weights,
+inference step count, and guidance settings differ.
+
+Supported subfolders
+--------------------
+None          — returns the raw transformer nn.Module loaded from the checkpoint
+"transformer" — same as None (kept for API symmetry with other loaders)
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import torch
+
+from ...base import ForgeModel
+from ...config import (
+    Framework,
+    ModelConfig,
+    ModelGroup,
+    ModelInfo,
+    ModelSource,
+    ModelTask,
+    StrEnum,
+)
+from .src.utils import (
+    DEFAULT_HEIGHT,
+    DEFAULT_NUM_FRAMES,
+    DEFAULT_WIDTH,
+    load_transformer_direct,
+    load_transformer_inputs,
+)
+
+_SUPPORTED_SUBFOLDERS = {None, "transformer"}
+_HF_REPO = "Lightricks/LTX-2.3"
+
+
+@dataclass
+class LTX23Config(ModelConfig):
+    checkpoint: str = ""
+    pipeline_class: str = "DistilledPipeline"
+    num_inference_steps: int = 8
+    guidance_scale: float = 1.0
+
+
+class ModelVariant(StrEnum):
+    LTX_23_FAST = "ltx-2.3-22b-distilled-1.1"
+    LTX_23_PRO = "ltx-2.3-22b-dev"
+
+
+class ModelLoader(ForgeModel):
+    """
+    Loader for LTX-2.3 Fast and Pro variants.
+
+    Typical usage (transformer compilation target)::
+
+        loader = ModelLoader(ModelVariant.LTX_23_FAST, subfolder="transformer")
+        model  = loader.load_model()   # returns the DiT nn.Module
+        inputs = loader.load_inputs()  # returns dict of synthetic tensors
+    """
+
+    _VARIANTS = {
+        ModelVariant.LTX_23_FAST: LTX23Config(
+            pretrained_model_name=_HF_REPO,
+            checkpoint="ltx-2.3-22b-distilled-1.1.safetensors",
+            pipeline_class="DistilledPipeline",
+            num_inference_steps=8,
+            guidance_scale=1.0,
+        ),
+        ModelVariant.LTX_23_PRO: LTX23Config(
+            pretrained_model_name=_HF_REPO,
+            checkpoint="ltx-2.3-22b-dev.safetensors",
+            pipeline_class="TI2VidOneStagePipeline",
+            num_inference_steps=40,
+            guidance_scale=5.0,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.LTX_23_FAST
+
+    def __init__(
+        self,
+        variant: Optional[ModelVariant] = None,
+        subfolder: Optional[str] = None,
+    ):
+        super().__init__(variant)
+        if subfolder not in _SUPPORTED_SUBFOLDERS:
+            raise ValueError(
+                f"Unknown subfolder '{subfolder}'. Supported: {_SUPPORTED_SUBFOLDERS}"
+            )
+        self._subfolder = subfolder
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="LTX-2.3",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.MM_VIDEO_TTT,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, **kwargs) -> torch.nn.Module:
+        cfg: LTX23Config = self._variant_config
+        transformer = load_transformer_direct(cfg.pretrained_model_name, cfg.checkpoint)
+        transformer.eval()
+        return transformer
+
+    def load_inputs(
+        self,
+        dtype: torch.dtype = torch.bfloat16,
+        height: int = DEFAULT_HEIGHT,
+        width: int = DEFAULT_WIDTH,
+        num_frames: int = DEFAULT_NUM_FRAMES,
+        **kwargs,
+    ) -> Dict[str, torch.Tensor]:
+        cfg: LTX23Config = self._variant_config
+        return load_transformer_inputs(
+            dtype=dtype,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            guidance_scale=cfg.guidance_scale,
+        )
+
+    def unpack_forward_output(self, output: Any) -> torch.Tensor:
+        if hasattr(output, "sample"):
+            return output.sample
+        if isinstance(output, (tuple, list)):
+            return output[0]
+        return output

--- a/ltx_2_3/pytorch/src/__init__.py
+++ b/ltx_2_3/pytorch/src/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/ltx_2_3/pytorch/src/utils.py
+++ b/ltx_2_3/pytorch/src/utils.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+LTX-2.3 transformer loading and input generation utilities.
+
+Architecture constants are derived from the LTX-Video VAE family.
+
+The loader bypasses the DistilledPipeline (which requires CUDA-capable torchaudio
+and local file paths) and loads the transformer directly from the safetensors
+checkpoint using ltx_core.loader.SingleGPUModelBuilder.
+"""
+
+import sys
+import types
+from typing import Dict, Tuple
+
+import torch
+
+# VAE compression ratios (LTX-Video / LTX-2 family)
+SPATIAL_COMPRESSION = 32
+TEMPORAL_COMPRESSION = 8
+
+# Number of latent channels output by the VAE encoder
+LATENT_CHANNELS = 128
+
+# Gemma 3 text encoder (used by LTX-2.3).
+# TEXT_HIDDEN_DIM matches the 4B variant; update if a larger encoder is used.
+TEXT_HIDDEN_DIM = 3072
+TEXT_SEQ_LEN = 256
+
+# Default test resolution — constraints:
+#   height % 32 == 0, width % 32 == 0
+#   (num_frames - 1) % 8 == 0  →  9, 17, 25, 33, ...
+DEFAULT_HEIGHT = 256
+DEFAULT_WIDTH = 256
+DEFAULT_NUM_FRAMES = 9
+DEFAULT_BATCH_SIZE = 1
+
+
+def compute_latent_dims(
+    height: int = DEFAULT_HEIGHT,
+    width: int = DEFAULT_WIDTH,
+    num_frames: int = DEFAULT_NUM_FRAMES,
+) -> Tuple[int, int, int, int]:
+    """Return (lat_h, lat_w, lat_t, seq_len) for the given video resolution."""
+    assert (
+        height % SPATIAL_COMPRESSION == 0
+    ), f"height must be divisible by {SPATIAL_COMPRESSION}, got {height}"
+    assert (
+        width % SPATIAL_COMPRESSION == 0
+    ), f"width must be divisible by {SPATIAL_COMPRESSION}, got {width}"
+    assert (
+        num_frames - 1
+    ) % TEMPORAL_COMPRESSION == 0, (
+        f"num_frames must satisfy 8k+1 (e.g. 9, 17, 25), got {num_frames}"
+    )
+    lat_h = height // SPATIAL_COMPRESSION
+    lat_w = width // SPATIAL_COMPRESSION
+    lat_t = (num_frames - 1) // TEMPORAL_COMPRESSION + 1
+    return lat_h, lat_w, lat_t, lat_t * lat_h * lat_w
+
+
+def _stub_audio_modules() -> None:
+    """Stub ltx_core audio submodules that transitively import torchaudio.
+
+    torchaudio is installed but its native extension requires libcudart.so.13
+    which is unavailable on this host. We only need the video transformer, so
+    audio code paths are never exercised.
+    """
+    if "ltx_core.model.audio_vae.ops" not in sys.modules:
+        stub = types.ModuleType("ltx_core.model.audio_vae.ops")
+        # Sentinel classes used in type annotations within audio_vae.audio_vae.
+        stub.AudioProcessor = type("AudioProcessor", (), {})
+        stub.PerChannelStatistics = type("PerChannelStatistics", (), {})
+        sys.modules["ltx_core.model.audio_vae.ops"] = stub
+
+
+def load_transformer_direct(
+    hf_repo: str,
+    checkpoint_filename: str,
+    dtype: torch.dtype = torch.bfloat16,
+    device: torch.device | None = None,
+) -> torch.nn.Module:
+    """Download checkpoint from HuggingFace and build the LTX-2.3 transformer.
+
+    Uses ltx_core.loader.SingleGPUModelBuilder with LTXModelConfigurator to
+    instantiate the DiT directly from the safetensors file, without requiring
+    the full DistilledPipeline.
+    """
+    _stub_audio_modules()
+
+    from huggingface_hub import hf_hub_download
+
+    from ltx_core.loader.single_gpu_model_builder import SingleGPUModelBuilder
+    from ltx_core.model.transformer import (
+        LTXV_MODEL_COMFY_RENAMING_MAP,
+        LTXModelConfigurator,
+    )
+
+    checkpoint_path = hf_hub_download(repo_id=hf_repo, filename=checkpoint_filename)
+
+    builder = SingleGPUModelBuilder(
+        model_class_configurator=LTXModelConfigurator,
+        model_path=checkpoint_path,
+        model_sd_ops=LTXV_MODEL_COMFY_RENAMING_MAP,
+    )
+    transformer = builder.build(device=device, dtype=dtype)
+    return transformer
+
+
+def load_transformer_inputs(
+    dtype: torch.dtype = torch.bfloat16,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    height: int = DEFAULT_HEIGHT,
+    width: int = DEFAULT_WIDTH,
+    num_frames: int = DEFAULT_NUM_FRAMES,
+    guidance_scale: float = 1.0,
+) -> Dict[str, torch.Tensor]:
+    """
+    Generate synthetic transformer inputs for LTX-2.3.
+
+    hidden_states shape follows the LTX-Video 0.9.x spatial convention:
+    [B, C, T, H, W] — the transformer handles patchification internally.
+
+    When guidance_scale > 1 (CFG active), the batch is doubled to hold
+    [unconditional, conditional] pairs, matching the pipeline's behaviour.
+    """
+    lat_h, lat_w, lat_t, _ = compute_latent_dims(height, width, num_frames)
+    b = batch_size * 2 if guidance_scale > 1.0 else batch_size
+
+    return {
+        "hidden_states": torch.randn(
+            b, LATENT_CHANNELS, lat_t, lat_h, lat_w, dtype=dtype
+        ),
+        "encoder_hidden_states": torch.randn(
+            b, TEXT_SEQ_LEN, TEXT_HIDDEN_DIM, dtype=dtype
+        ),
+        "encoder_attention_mask": torch.ones(b, TEXT_SEQ_LEN, dtype=torch.bool),
+        "timestep": torch.full((b,), 0.5, dtype=dtype),
+        "num_frames": lat_t,
+        "height": lat_h,
+        "width": lat_w,
+    }


### PR DESCRIPTION
### Ticket
Fixes : [Link to Github Issue](https://github.com/tenstorrent/tt-forge-models/issues/621)

### Problem description
                                                                                                                                                                               

- LTX-2.3 is a 22B DiT (Diffusion Transformer) video generation model by Lightricks. There was no loader in tt-forge-models to enable compilation and benchmarking of this model on Tenstorrent hardware.                                                                                                                                             

- The model's full DistilledPipeline requires CUDA-capable torchaudio and local file paths, making it incompatible with the standard loader pattern. The transformer also needed synthetic inputs shaped to match its spatial latent conventions.

### What's changed
Added a new ltx_2_3/pytorch/ module with a ModelLoader and supporting utilities:                                                                                             
                  
  - loader.py — implements ModelLoader(ForgeModel) with two variants:                                                                                                          
    - LTX_23_FAST — distilled checkpoint (ltx-2.3-22b-distilled-1.1.safetensors), 8 steps, CFG off (guidance_scale=1.0)
    - LTX_23_PRO — dev checkpoint (ltx-2.3-22b-dev.safetensors), 40 steps, CFG on (guidance_scale=5.0)                                                                         
  - src/utils.py — bypasses the full pipeline by loading the 22B DiT directly via ltx_core.loader.SingleGPUModelBuilder. Stubs out ltx_core.model.audio_vae.ops to avoid a     
  missing libcudart.so.13 dependency at import time. Provides load_transformer_inputs() to generate synthetic inputs (hidden_states, encoder_hidden_states, timestep, etc.)    
  sized for a given resolution. CFG-active variants automatically double the batch dimension.   

### Checklist
- [ ] New/Existing tests provide coverage for changes
