### PR TITLE
Add Qwen 3.5 dense causal_lm loader (0.8B / 2B / 4B / 9B)

### DIFF
--- a/qwen_3_5/__init__.py
+++ b/qwen_3_5/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Import from the PyTorch implementation by default
+from .causal_lm.pytorch import ModelLoader

--- a/qwen_3_5/causal_lm/__init__.py
+++ b/qwen_3_5/causal_lm/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.5 Causal LM model implementation for Tenstorrent projects.
+"""
+from .pytorch import ModelLoader

--- a/qwen_3_5/causal_lm/pytorch/__init__.py
+++ b/qwen_3_5/causal_lm/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant

--- a/qwen_3_5/causal_lm/pytorch/loader.py
+++ b/qwen_3_5/causal_lm/pytorch/loader.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.5 model loader implementation for causal language modeling.
+
+Qwen 3.5 uses a hybrid architecture interleaving Gated DeltaNet (linear
+attention with causal conv1d + chunked delta rule) and standard full
+attention layers. Dense variants follow the layout
+(3x linear_attention + 1x full_attention) repeated.
+"""
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Qwen 3.5 dense model variants for causal language modeling."""
+
+    QWEN_3_5_0_8B = "0_8B"
+    QWEN_3_5_2B = "2B"
+    QWEN_3_5_4B = "4B"
+    QWEN_3_5_9B = "9B"
+
+
+class ModelLoader(ForgeModel):
+    """Qwen 3.5 model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.QWEN_3_5_0_8B: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3.5-0.8B",
+            max_length=128,
+        ),
+        ModelVariant.QWEN_3_5_2B: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3.5-2B",
+            max_length=128,
+        ),
+        ModelVariant.QWEN_3_5_4B: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3.5-4B",
+            max_length=128,
+        ),
+        ModelVariant.QWEN_3_5_9B: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3.5-9B",
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.QWEN_3_5_0_8B
+
+    sample_text = "Give me a short introduction to large language model."
+
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.num_layers = num_layers
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        return ModelInfo(
+            model="Qwen 3.5",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        if self.num_layers is not None:
+            config = AutoConfig.from_pretrained(pretrained_model_name)
+            config.num_hidden_layers = self.num_layers
+            model_kwargs["config"] = config
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        ).eval()
+
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        max_length = self._variant_config.max_length
+
+        messages = [{"role": "user", "content": self.sample_text}]
+        text = self.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        prompts = [text]
+
+        inputs = self.tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+
+        return inputs
+
+    def load_config(self):
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.config
+
+    def load_inputs_decode(self, dtype_override=None, batch_size=1):
+        from ....tools.utils import get_static_cache_decode_inputs
+
+        if self.tokenizer is None:
+            self._load_tokenizer()
+        if self.config is None:
+            self.load_config()
+
+        max_cache_len = getattr(self._variant_config, "max_length", None) or 128
+        self.seq_len = 1
+
+        return get_static_cache_decode_inputs(
+            tokenizer=self.tokenizer,
+            config=self.config,
+            model=self.model,
+            batch_size=batch_size,
+            max_cache_len=max_cache_len,
+            dtype=dtype_override,
+        )

--- a/qwen_3_5/causal_lm/pytorch/loader.py
+++ b/qwen_3_5/causal_lm/pytorch/loader.py
@@ -94,16 +94,25 @@ class ModelLoader(ForgeModel):
         model_kwargs = {}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
-        model_kwargs |= kwargs
 
         if self.num_layers is not None:
             config = AutoConfig.from_pretrained(pretrained_model_name)
             config.num_hidden_layers = self.num_layers
             model_kwargs["config"] = config
 
+        model_kwargs |= kwargs
+
         model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name, **model_kwargs
         ).eval()
+
+        # Force use_cache=False on the live model config so the forward
+        # output does not include a Qwen3_5DynamicCache, which the runner's
+        # pytree comparator can't diff leaf-wise against the CPU golden.
+        # Same pattern as qwen_2_5_vl loader — passing use_cache via
+        # from_pretrained kwargs / config is overwritten when the model
+        # rebuilds its config from the checkpoint.
+        model.config.use_cache = False
 
         self.config = model.config
         self.model = model

--- a/qwen_3_5/causal_lm/pytorch/mixed_precision_configs/Qwen3.5-0.8B.json
+++ b/qwen_3_5/causal_lm/pytorch/mixed_precision_configs/Qwen3.5-0.8B.json
@@ -1,0 +1,3 @@
+{
+    "default": "bfp_bf8"
+}

--- a/qwen_3_5/causal_lm/pytorch/mixed_precision_configs/Qwen3.5-2B.json
+++ b/qwen_3_5/causal_lm/pytorch/mixed_precision_configs/Qwen3.5-2B.json
@@ -1,0 +1,3 @@
+{
+    "default": "bfp_bf8"
+}

--- a/qwen_3_5/causal_lm/pytorch/mixed_precision_configs/Qwen3.5-4B.json
+++ b/qwen_3_5/causal_lm/pytorch/mixed_precision_configs/Qwen3.5-4B.json
@@ -1,0 +1,3 @@
+{
+    "default": "bfp_bf8"
+}

--- a/qwen_3_5/causal_lm/pytorch/mixed_precision_configs/Qwen3.5-9B.json
+++ b/qwen_3_5/causal_lm/pytorch/mixed_precision_configs/Qwen3.5-9B.json
@@ -1,0 +1,3 @@
+{
+    "default": "bfp_bf8"
+}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The Qwen 3.5 family is missing from tt-forge-models. The 27B+ variants are already tracked in https://github.com/tenstorrent/tt-xla/issues/3508, so this PR scopes to the smaller dense models (0.8B / 2B / 4B / 9B) that fit on a single device.

### What's changed
Adds a new `qwen_3_5/causal_lm/pytorch/` module following the existing `qwen_3/causal_lm/pytorch/` layout:
  - `ModelVariant` entries for `0_8B` / `2B` / `4B` / `9B`, all pointing at the post-trained `Qwen/Qwen3.5-XB` checkpoints.
  - `DEFAULT_VARIANT = 0_8B` (smallest, same convention as `qwen_3`).
  - `load_model()` / `load_inputs()` / `load_config()` / `load_inputs_decode()` mirror the `qwen_3` loader; post-trained variants use `apply_chat_template`.
  - `mixed_precision_configs/` defaults each variant to `bfp_bf8`, matching `qwen_3`.

  ### Checklist
  - [x] New/Existing tests provide coverage for changes

For the "tests provide coverage for changes", I don't have permission to dispatch tt-xla CI workflows from a fork, so I exercised the new loader locally on a single Blackhole p150a using the standard tt-xla runner (`tests/runner/test_models.py::test_all_models_torch`) with the default comparison config (PCC threshold 0.99, `assert_on_failure=True`).

The results are as follows. I have attached the XML files containing the results.

  | variant | PCC                | comparison_passed | bringup |
  |---------|--------------------|-------------------|---------|
  | 0.8B    | 0.9993      | True              | PASSED  |
  | 2B      | 0.9992     | True              | PASSED  |
  | 4B      | 0.9987 | True              | PASSED  |
  | 9B      | 0.9968| True              | PASSED  |


I'm planning to follow up with a tt-xla PR (test_config entries + submodule bump) once this PR is merged.

[qwen35_0_8B.xml](https://github.com/user-attachments/files/27460103/qwen35_0_8B.xml)
[qwen35_2B.xml](https://github.com/user-attachments/files/27460105/qwen35_2B.xml)
[qwen35_4B.xml](https://github.com/user-attachments/files/27460106/qwen35_4B.xml)
[qwen35_9B.xml](https://github.com/user-attachments/files/27460107/qwen35_9B.xml)