### PR TITLE
Fix(maptr): Resolve ambiguous boolean tensor evaluation causing runtime error

### DIFF
--- a/maptr/pytorch/src/maptr.py
+++ b/maptr/pytorch/src/maptr.py
@@ -4402,7 +4402,6 @@ class GeometryKernelAttention(BaseModule):
 
         bs, num_query, _ = query.shape
         bs, num_value, _ = value.shape
-        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
 
         value = self.value_proj(value)
         value = value.view(bs, num_value, self.num_heads, -1)
@@ -4427,9 +4426,9 @@ class GeometryKernelAttention(BaseModule):
                 reference_points = (
                     reference_points[:, :, :, None, :] * offset_normalizer
                 )
-                sampling_locations = (
-                    (reference_points[:, :, :, :, None, :] + offsets).round().long()
-                )
+                sampling_locations = torch.floor(
+                    (reference_points[:, :, :, :, None, :] + offsets) + 0.5
+                ).long()
             (
                 bs,
                 num_query,
@@ -4535,7 +4534,6 @@ class CustomMSDeformableAttention(BaseModule):
 
         bs, num_query, _ = query.shape
         bs, num_value, _ = value.shape
-        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
 
         value = self.value_proj(value)
         value = value.view(bs, num_value, self.num_heads, -1)
@@ -5666,6 +5664,9 @@ class BEVFormerEncoder(TransformerLayerSequence):
             device=bev_query.device,
             dtype=bev_query.dtype,
         )
+        bs = ref_2d.shape[0]
+        len_bev = ref_2d.shape[1]
+        num_bev_level = ref_2d.shape[2]
 
         reference_points_cam, bev_mask = self.point_sampling(
             ref_3d, self.pc_range, kwargs["img_metas"]
@@ -5676,7 +5677,6 @@ class BEVFormerEncoder(TransformerLayerSequence):
 
         bev_query = bev_query.permute(1, 0, 2)
         bev_pos = bev_pos.permute(1, 0, 2)
-        bs, len_bev, num_bev_level, _ = ref_2d.shape
 
         hybird_ref_2d = torch.stack([ref_2d, ref_2d], 1).reshape(
             bs * 2, len_bev, num_bev_level, 2


### PR DESCRIPTION
### Ticket

- Fixes [#4500](https://github.com/tenstorrent/tt-xla/issues/4500)

### Problem description

These two maptr variants` maptr/pytorch-Tiny_R50_110e-single_device-inference], maptr/pytorch-Tiny_R50_24e_Av2-single_device-inference` fail with 
```
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```
### What's changed

1. Removing the problematic check avoids these false errors while keeping the main computation unchanged.
2. Post this model failed with 

```
venv/lib/python3.12/site-packages/torch_xla/_dynamo/dynamo_bridge.py:539: in extract_internal
    xla_args_need_update) = extract_graph_helper(xla_model,
venv/lib/python3.12/site-packages/torch_xla/_dynamo/dynamo_bridge.py:483: in extract_graph_helper
    torch_xla._XLAC._xla_warm_up_cache(args_and_out_tensor_only, [])
E   ValueError: Error code: 13
```

3. The failure happens while XLA is building/warming the compiled graph (_xla_warm_up_cache), where error code 13 means compilation or lowering failed on some op in that subgraph—not a Python logic assert. Tensor .round() often lowers to a dedicated round-to-nearest path in XLA that can be missing, buggy, or unsupported on the stack , so the graph never becomes executable. Replacing it with torch.floor((reference_points[..., None, :] + offsets) + 0.5).long() still maps continuous sampling coordinates to the nearest integer grid index using only add, floor, and cast to long.

4.Finally model fails with a pcc=0.03079878350193446, verified that final model results do not deviate from the original unchanged code to ensure the new changes does not cause pcc drop.


### Logs
[maptr_tinyr50_110e_before_fix.log](https://github.com/user-attachments/files/27388615/maptr_before_fix_may5.log)
[maptr_tinyr50_110e_after_fix.log](https://github.com/user-attachments/files/27425128/maptr_tinyr50_110e_after_fix.log)
[maptr_tinyr50_24e_av2_before_fix.log](https://github.com/user-attachments/files/27425132/maptr_tinyr50_24e_av2_before_fix.log)
[maptr_tinyr50_24e_av2_after_fix.log](https://github.com/user-attachments/files/27425134/maptr_tinyr50_24e_av2_after_fix.log)

