### PR TITLE
Add sliding window attention support for the gemma3/multimodal

### DIFF
--- a/gemma3/multimodal/pytorch/loader.py
+++ b/gemma3/multimodal/pytorch/loader.py
@@ -5,7 +5,7 @@
 Gemma3 model loader implementation for multimodal modeling.
 """
 
-from typing import Optional, Any
+from typing import Optional
 
 from transformers import (
     AutoProcessor,
@@ -110,6 +110,11 @@ class ModelLoader(ForgeModel):
         )
 
         model.eval()
+        from tt_torch.transformers_overrides import (
+            override_gemma3_sliding_window_causal_mask,
+        )
+
+        override_gemma3_sliding_window_causal_mask()
         self.model = model
         self.config = model.config
         return model
@@ -192,7 +197,7 @@ class ModelLoader(ForgeModel):
 
         shard_specs = {}
 
-        for layer in model.vision_tower.vision_model.encoder.layers:
+        for layer in model.model.vision_tower.vision_model.encoder.layers:
             shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
             shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
             shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
@@ -201,7 +206,7 @@ class ModelLoader(ForgeModel):
             shard_specs[layer.mlp.fc1.weight] = ("model", "batch")
             shard_specs[layer.mlp.fc2.weight] = ("batch", "model")
 
-        for layer in model.language_model.layers:
+        for layer in model.model.language_model.layers:
             shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
             shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
             shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
@@ -211,4 +216,6 @@ class ModelLoader(ForgeModel):
             shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
             shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
 
+        shard_specs[model.model.language_model.embed_tokens.weight] = ("model", "batch")
+        shard_specs[model.lm_head.weight] = ("model", "batch")
         return shard_specs


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/4357)

### Problem description
The gemma3 multimodal was failing with the following error   `RuntimeError: Value out of range (expected to be in range of [-277, 276], but got -1023)
`
### What's changed
Added Sliding Window Attention support to fix the Runtime error.
### Checklist
- [ ] New/Existing tests provide coverage for changes
