### PR TITLE
Add krea realtime video 14B component loaders (text_encoder, transformer, vae)

### DIFF
--- a/krea_realtime_video/pytorch/__init__.py
+++ b/krea_realtime_video/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant

--- a/krea_realtime_video/pytorch/loader.py
+++ b/krea_realtime_video/pytorch/loader.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Krea Realtime Video 14B component loader.
+
+Each variant corresponds to one independently loadable component:
+  - TextEncoder  → UMT5EncoderModel    (text_encoder subfolder)  params=6.73B
+  - Transformer  → CausalWanWrapper    (transformer subfolder, wrapped for simple forward)  params=14.29B
+  - Vae          → VAEDecoderWrapper   (vae subfolder, decoder-only)  params=0.13B
+"""
+
+from typing import Optional
+
+import torch
+
+from ...base import ForgeModel
+from ...config import (
+    Framework,
+    ModelConfig,
+    ModelGroup,
+    ModelInfo,
+    ModelSource,
+    ModelTask,
+    StrEnum,
+)
+from .src.model_utils import (
+    DTYPE,
+    LATENT_H,
+    LATENT_W,
+    MAX_SEQ_LEN,
+    MESH_NAMES,
+    MESH_SHAPES,
+    NUM_CHANNELS_LATENTS,
+    NUM_FRAMES_PER_BLOCK,
+    NUM_LATENT_FRAMES,
+    TEXT_EMBED_DIM,
+    UMT5_VOCAB_SIZE,
+    CausalWanWrapper,
+    VAEDecoderWrapper,
+    load_text_encoder,
+    load_transformer,
+    load_vae,
+    shard_text_encoder_specs,
+    shard_transformer_specs,
+)
+
+_KREA_REPO = "krea/krea-realtime-video"
+_WAN_REPO = "Wan-AI/Wan2.1-T2V-14B-Diffusers"
+
+
+class ModelVariant(StrEnum):
+    """Loadable components of the Krea Realtime Video 14B pipeline."""
+
+    TEXT_ENCODER = "TextEncoder"
+    TRANSFORMER = "Transformer"
+    VAE = "Vae"
+
+
+class ModelLoader(ForgeModel):
+    """Load individual Krea Realtime Video components without pulling the full pipeline.
+
+    The krea model reuses text_encoder and vae from Wan-AI/Wan2.1-T2V-14B-Diffusers;
+    only the transformer weights come from krea/krea-realtime-video.
+    See: krea/krea-realtime-video/modular_model_index.json
+    """
+
+    _VARIANTS = {
+        ModelVariant.TEXT_ENCODER: ModelConfig(pretrained_model_name=_WAN_REPO),
+        ModelVariant.TRANSFORMER: ModelConfig(pretrained_model_name=_KREA_REPO),
+        ModelVariant.VAE: ModelConfig(pretrained_model_name=_WAN_REPO),
+    }
+    DEFAULT_VARIANT = ModelVariant.TRANSFORMER
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        task = (
+            ModelTask.NLP_EMBED_GEN
+            if variant == ModelVariant.TEXT_ENCODER
+            else ModelTask.MM_VIDEO_TTT
+        )
+        return ModelInfo(
+            model="KreaRealtimeVideo",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=task,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, *, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Load and return the component for this variant as a torch.nn.Module.
+
+        Returns:
+            TEXT_ENCODER → UMT5EncoderModel
+            TRANSFORMER  → CausalWanWrapper (raw CausalWanModel with simplified forward)
+            VAE          → VAEDecoderWrapper (decoder-only, returns plain tensor)
+        """
+        model_name = self._variant_config.pretrained_model_name
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return load_text_encoder(model_name, dtype)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return CausalWanWrapper(load_transformer(model_name, dtype))
+        if self._variant == ModelVariant.VAE:
+            return VAEDecoderWrapper(load_vae(model_name, dtype))
+
+        raise ValueError(f"Unknown variant: {self._variant}")
+
+    def get_mesh_config(self, num_devices: int):
+        """Return (mesh_shape, mesh_names) for a ("batch", "model") 2D mesh.
+
+        Supported device counts: 1, 2, 4, 8, 32.
+        VAE fits on a single chip so any count maps to (1, 1).
+        """
+        if self._variant == ModelVariant.VAE:
+            return (1, 1), MESH_NAMES
+
+        if num_devices not in MESH_SHAPES:
+            raise ValueError(
+                f"Unsupported device count: {num_devices}. "
+                f"Expected one of {sorted(MESH_SHAPES)}."
+            )
+        return MESH_SHAPES[num_devices], MESH_NAMES
+
+    def load_shard_spec(self, model):
+        """Return tensor → partition_spec dict for the active component.
+
+        Expects the same model object returned by load_model():
+          TEXT_ENCODER → UMT5EncoderModel
+          TRANSFORMER  → CausalWanWrapper  (specs built from .transformer)
+          VAE          → None (single-chip, no sharding)
+        """
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return shard_text_encoder_specs(model)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return shard_transformer_specs(model.transformer)
+        if self._variant == ModelVariant.VAE:
+            return None
+        raise ValueError(f"Unknown variant: {self._variant}")
+
+    def load_inputs(self, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Return a list of synthetic input tensors for the active component.
+
+        TEXT_ENCODER  → [input_ids (1,512) int64, attention_mask (1,512) int64]
+        TRANSFORMER   → [x (1,16,3,60,104) bf16, t (1,3) f32, context (1,512,4096) bf16]
+        VAE           → [z (1,16,3,60,104) bf16]
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            input_ids = torch.randint(
+                0, UMT5_VOCAB_SIZE, (1, MAX_SEQ_LEN), dtype=torch.long
+            )
+            attention_mask = torch.ones(1, MAX_SEQ_LEN, dtype=torch.long)
+            return [input_ids, attention_mask]
+
+        if self._variant == ModelVariant.TRANSFORMER:
+            x = torch.randn(
+                1,
+                NUM_CHANNELS_LATENTS,
+                NUM_LATENT_FRAMES,
+                LATENT_H,
+                LATENT_W,
+                dtype=dtype,
+            )
+            t = torch.full((1, NUM_FRAMES_PER_BLOCK), 1000.0, dtype=torch.float32)
+            context = torch.randn(1, MAX_SEQ_LEN, TEXT_EMBED_DIM, dtype=dtype)
+            return [x, t, context]
+
+        if self._variant == ModelVariant.VAE:
+            z = torch.randn(
+                1,
+                NUM_CHANNELS_LATENTS,
+                NUM_LATENT_FRAMES,
+                LATENT_H,
+                LATENT_W,
+                dtype=dtype,
+            )
+            return [z]
+
+        raise ValueError(f"Unknown variant: {self._variant}")

--- a/krea_realtime_video/pytorch/src/__init__.py
+++ b/krea_realtime_video/pytorch/src/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/krea_realtime_video/pytorch/src/model_utils.py
+++ b/krea_realtime_video/pytorch/src/model_utils.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Component loaders and wrappers for Krea Realtime Video 14B.
+
+Model: krea/krea-realtime-video
+Components:
+  - text_encoder: UMT5EncoderModel (UMT5-XXL)
+  - transformer:  CausalWanModel (14B video DiT)
+  - vae:          AutoencoderKLWan (3D causal VAE)
+"""
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Model identity
+# ---------------------------------------------------------------------------
+
+# text_encoder, vae, tokenizer, scheduler come from the Wan 2.1 14B base repo.
+# Only the transformer weights come from krea (modular_model_index.json).
+KREA_REPO_ID = "krea/krea-realtime-video"
+WAN_REPO_ID = "Wan-AI/Wan2.1-T2V-14B-Diffusers"
+DTYPE = torch.bfloat16
+
+# ---------------------------------------------------------------------------
+# Inference shape constants
+# ---------------------------------------------------------------------------
+
+HEIGHT = 480
+WIDTH = 832
+NUM_BLOCKS = 1
+MAX_SEQ_LEN = 512  # text token length
+
+LATENT_H = HEIGHT // 8  # 60
+LATENT_W = WIDTH // 8  # 104
+NUM_FRAMES_PER_BLOCK = 3
+NUM_LATENT_FRAMES = NUM_BLOCKS * NUM_FRAMES_PER_BLOCK  # 3
+NUM_CHANNELS_LATENTS = 16
+TEXT_EMBED_DIM = 4096
+
+# KV-cache config (self-attention over video frames)
+KV_CACHE_NUM_FRAMES = 3
+FRAME_SEQ_LENGTH = 1560
+SEQ_LENGTH = 32760
+LOCAL_ATTN_SIZE = KV_CACHE_NUM_FRAMES + NUM_FRAMES_PER_BLOCK  # 6
+KV_CACHE_SIZE = LOCAL_ATTN_SIZE * FRAME_SEQ_LENGTH  # 9360
+
+# UMT5 vocabulary size (Embedding(256384, 4096) from model architecture)
+UMT5_VOCAB_SIZE = 256384
+
+# ---------------------------------------------------------------------------
+# Component loaders
+# ---------------------------------------------------------------------------
+
+
+def load_text_encoder(pretrained_model_name: str, dtype: torch.dtype):
+    """Load UMT5EncoderModel from the text_encoder subfolder."""
+    from transformers import UMT5EncoderModel
+
+    return UMT5EncoderModel.from_pretrained(
+        pretrained_model_name,
+        subfolder="text_encoder",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_transformer(pretrained_model_name: str, dtype: torch.dtype):
+    """Load CausalWanModel from the transformer subfolder.
+
+    CausalWanModel is a custom architecture defined in krea/krea-realtime-video.
+    diffusers.AutoModel with trust_remote_code=True downloads and runs the
+    custom model code from the repo to resolve the class.
+    """
+    from diffusers import AutoModel
+
+    return AutoModel.from_pretrained(
+        pretrained_model_name,
+        subfolder="transformer",
+        torch_dtype=dtype,
+        device_map="cpu",
+        trust_remote_code=True,
+    ).eval()
+
+
+def load_vae(pretrained_model_name: str, dtype: torch.dtype):
+    """Load AutoencoderKLWan from the vae subfolder."""
+    from diffusers import AutoencoderKLWan
+
+    return AutoencoderKLWan.from_pretrained(
+        pretrained_model_name,
+        subfolder="vae",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+# ---------------------------------------------------------------------------
+# Sinusoidal embedding fix
+# ---------------------------------------------------------------------------
+
+
+def fixed_sinusoidal_embedding_1d(dim, position):
+    """Device-agnostic replacement for Krea's CUDA-hardcoded sinusoidal embedding.
+
+    Upstream (transformer/model.py:33) uses `device=torch.cuda.current_device()`
+    which crashes on CPU and TT. We replace it with `device=position.device`.
+    Ref: https://github.com/tenstorrent/tt-xla/issues/4464
+    """
+    assert dim % 2 == 0
+    half = dim // 2
+    position = position.type(torch.float64)
+    sinusoid = torch.outer(
+        position,
+        torch.pow(
+            10000,
+            -torch.arange(half, device=position.device, dtype=torch.float64).div(half),
+        ),
+    )
+    return torch.cat([torch.cos(sinusoid), torch.sin(sinusoid)], dim=1)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper modules
+# ---------------------------------------------------------------------------
+
+
+class CausalWanWrapper(torch.nn.Module):
+    """Simplify CausalWanModel forward to (x, t, context) -> noise_pred.
+
+    The raw model requires kv_cache, crossattn_cache, seq_len, and several
+    positional args on every call. This wrapper:
+      - rebuilds all caches fresh each forward (stateless, no side effects)
+      - patches out the CUDA-hardcoded sinusoidal_embedding_1d
+      - sets per-block self-attention attributes expected by WanRTSetupKVCache
+    """
+
+    def __init__(self, transformer, num_frames_per_block: int = NUM_FRAMES_PER_BLOCK):
+        super().__init__()
+        self.transformer = transformer
+
+        # Replace the CUDA-only embedding function in the model's global scope
+        transformer.forward.__globals__[
+            "sinusoidal_embedding_1d"
+        ] = fixed_sinusoidal_embedding_1d
+
+        for blk in self.transformer.blocks:
+            blk.self_attn.local_attn_size = -1
+            blk.self_attn.num_frame_per_block = num_frames_per_block
+
+        self._num_blocks = len(self.transformer.blocks)
+        self._num_heads = self.transformer.config.num_heads
+        self._head_dim = self.transformer.config.dim // self._num_heads
+
+    def _make_caches(self, device, dtype):
+        kv_shape = [1, KV_CACHE_SIZE, self._num_heads, self._head_dim]
+        ca_shape = [1, MAX_SEQ_LEN, self._num_heads, self._head_dim]
+        kv_cache = [
+            {
+                "k": torch.zeros(kv_shape, dtype=dtype, device=device).contiguous(),
+                "v": torch.zeros(kv_shape, dtype=dtype, device=device).contiguous(),
+                "global_end_index": 0,
+                "local_end_index": 0,
+            }
+            for _ in range(self._num_blocks)
+        ]
+        crossattn_cache = [
+            {
+                "k": torch.zeros(ca_shape, dtype=dtype, device=device).contiguous(),
+                "v": torch.zeros(ca_shape, dtype=dtype, device=device).contiguous(),
+                "is_init": False,
+            }
+            for _ in range(self._num_blocks)
+        ]
+        return kv_cache, crossattn_cache
+
+    def forward(self, x, t, context):
+        kv_cache, crossattn_cache = self._make_caches(x.device, x.dtype)
+        return self.transformer(
+            x=x,
+            t=t,
+            context=context,
+            kv_cache=kv_cache,
+            seq_len=SEQ_LENGTH,
+            crossattn_cache=crossattn_cache,
+            current_start=0,
+            cache_start=None,
+        )
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    """Expose only the decoder half of AutoencoderKLWan as (z) -> tensor.
+
+    The default vae(z) runs encode+decode and returns a ModelOutput object.
+    This wrapper calls decode directly and unwraps the output to a plain tensor.
+    """
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+# ---------------------------------------------------------------------------
+# SPMD shard specifications
+# ---------------------------------------------------------------------------
+
+# (batch, model) mesh shapes by device count
+MESH_SHAPES = {32: (8, 4), 8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
+MESH_NAMES = ("batch", "model")
+
+
+def shard_text_encoder_specs(encoder) -> dict:
+    """Shard specs for UMT5EncoderModel.
+
+    Mesh axes: ("batch", "model")
+    Column-parallel (q, k, v, wi_0, wi_1): ("model", "batch")
+    Row-parallel   (o, wo):                ("batch", "model")
+    """
+    specs = {encoder.shared.weight: (None, "batch")}
+
+    for block in encoder.encoder.block:
+        sa = block.layer[0].SelfAttention
+        specs[sa.q.weight] = ("model", "batch")
+        specs[sa.k.weight] = ("model", "batch")
+        specs[sa.v.weight] = ("model", "batch")
+        specs[sa.o.weight] = ("batch", "model")
+        specs[block.layer[0].layer_norm.weight] = ("batch",)
+
+        ffn = block.layer[1].DenseReluDense
+        specs[ffn.wi_0.weight] = ("model", "batch")
+        specs[ffn.wi_1.weight] = ("model", "batch")
+        specs[ffn.wo.weight] = ("batch", "model")
+        specs[block.layer[1].layer_norm.weight] = ("batch",)
+
+    specs[encoder.encoder.final_layer_norm.weight] = ("batch",)
+    return specs
+
+
+def shard_transformer_specs(transformer) -> dict:
+    """Shard specs for CausalWanModel.
+
+    Mesh axes: ("batch", "model")
+    Column-parallel (Q, K, V, FFN up): ("model", "batch")
+    Row-parallel   (O, FFN down):      ("batch", "model")
+    """
+    specs = {
+        transformer.patch_embedding.weight: ("batch", None, None, None, None),
+        transformer.patch_embedding.bias: ("batch",),
+    }
+
+    specs[transformer.text_embedding[0].weight] = ("model", "batch")
+    specs[transformer.text_embedding[0].bias] = ("model",)
+    specs[transformer.text_embedding[2].weight] = ("batch", "model")
+    specs[transformer.text_embedding[2].bias] = ("batch",)
+
+    specs[transformer.time_embedding[0].weight] = ("model", "batch")
+    specs[transformer.time_embedding[0].bias] = ("model",)
+    specs[transformer.time_embedding[2].weight] = ("batch", "model")
+    specs[transformer.time_embedding[2].bias] = ("batch",)
+
+    specs[transformer.time_projection[1].weight] = ("model", "batch")
+    specs[transformer.time_projection[1].bias] = ("model",)
+
+    for block in transformer.blocks:
+        if hasattr(block.norm3, "weight") and block.norm3.weight is not None:
+            specs[block.norm3.weight] = ("batch",)
+
+        for attn in (block.self_attn, block.cross_attn):
+            specs[attn.q.weight] = ("model", "batch")
+            specs[attn.q.bias] = ("model",)
+            specs[attn.k.weight] = ("model", "batch")
+            specs[attn.k.bias] = ("model",)
+            specs[attn.v.weight] = ("model", "batch")
+            specs[attn.v.bias] = ("model",)
+            specs[attn.o.weight] = ("batch", "model")
+            specs[attn.o.bias] = ("batch",)
+            if hasattr(attn.norm_q, "weight") and attn.norm_q.weight is not None:
+                specs[attn.norm_q.weight] = ("model",)
+            if hasattr(attn.norm_k, "weight") and attn.norm_k.weight is not None:
+                specs[attn.norm_k.weight] = ("model",)
+
+        specs[block.ffn[0].weight] = ("model", "batch")
+        specs[block.ffn[0].bias] = ("model",)
+        specs[block.ffn[2].weight] = ("batch", "model")
+        specs[block.ffn[2].bias] = ("batch",)
+
+    specs[transformer.head.head.weight] = (None, "batch")
+    specs[transformer.head.head.bias] = (None,)
+
+    return specs


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4463

### Problem description

- Add component loaders for the Krea Realtime Video 14B pipeline 

### What's changed

New package: `krea_realtime_video/pytorch/`

| File | Purpose |
|------|---------|
| `loader.py` | `ForgeModel` subclass with three variants (`TextEncoder`, `Transformer`, `Vae`), each loading only its own component via `from_pretrained(subfolder=...)` |
| `src/model_utils.py` | Component loaders, wrapper modules, shard specs, mesh shapes, inference shape constants |

**Component sources** (discovered from `modular_model_index.json`):

| Variant | Source repo | Class |
|---------|-------------|-------|
| `TextEncoder` | `Wan-AI/Wan2.1-T2V-14B-Diffusers` | `UMT5EncoderModel` (params=6.73B) |
| `Transformer` | `krea/krea-realtime-video` | `CausalWanModel` via `diffusers.AutoModel` + `trust_remote_code=True` (params=14.29B) |
| `Vae` | `Wan-AI/Wan2.1-T2V-14B-Diffusers` | `AutoencoderKLWan` (params=0.13B) |

Each component is loaded independently — no full pipeline is instantiated.

**`ModelLoader` API:**
- `load_model(dtype_override)` — returns the component as a `torch.nn.Module`
- `load_inputs(dtype_override)` — returns synthetic input tensors matched to the component's forward signature
- `get_mesh_config(num_devices)` — returns `(mesh_shape, mesh_names)` for a 2D `(batch, model)` SPMD mesh (supports 1 / 2 / 4 / 8 / 32 devices)
- `load_shard_spec(model)` — returns per-tensor partition specs for tensor parallelism

**Wrapper modules in `src/model_utils.py`:**
- `CausalWanWrapper` — simplifies `CausalWanModel` forward to `(x, t, context)`, rebuilds KV / cross-attention caches per call, and monkey-patches the [CUDA-hardcoded sinusoidal embedding](https://huggingface.co/krea/krea-realtime-video/blob/main/transformer/model.py#L33) with a device-agnostic version
- `VAEDecoderWrapper` — exposes decoder-only path `(z) -> tensor`, bypassing the default encode+decode round-trip

### Checklist
- [x] verify changes by local testing in Wormhole

### Logs

- [may4_decoder.log](https://github.com/user-attachments/files/27370731/may4_decoder.log)
- [may4_text_encoder_sharded.log](https://github.com/user-attachments/files/27370735/may4_text_encoder_sharded.log)
- [may4_transformer_sharded.log](https://github.com/user-attachments/files/27370741/may4_transformer_sharded.log)
