### PR TITLE
Add HunyuanVideo 1.5 component loaders (text_encoder, text_encoder_2,transformer, vae)

### DIFF
--- a/hunyuan_1_5/pytorch/__init__.py
+++ b/hunyuan_1_5/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant

--- a/hunyuan_1_5/pytorch/loader.py
+++ b/hunyuan_1_5/pytorch/loader.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HunyuanVideo 1.5 (480p t2v distilled) component loader.
+
+Each variant corresponds to one independently loadable component:
+  - TextEncoder   → Qwen2.5-VL encoder (text_encoder)       params=7.07B
+  - TextEncoder2  → ByT5 encoder (text_encoder_2)            params=0.22B
+  - Transformer   → HunyuanVideo15TransformerWrapper (DiT)   params=8.33B
+  - Vae           → VAEDecoderWrapper (decoder-only)         params=1.26B
+"""
+
+from typing import Optional
+
+import torch
+
+from ...base import ForgeModel
+from ...config import (
+    Framework,
+    ModelConfig,
+    ModelGroup,
+    ModelInfo,
+    ModelSource,
+    ModelTask,
+    StrEnum,
+)
+from .src.model_utils import (
+    BYT5_VOCAB_SIZE,
+    DTYPE,
+    IMAGE_EMBED_DIM,
+    IMAGE_EMBED_SEQ,
+    LATENT_H,
+    LATENT_W,
+    MESH_NAMES,
+    MESH_SHAPES,
+    NUM_CHANNELS_LATENTS,
+    NUM_LATENT_FRAMES,
+    QWEN_VOCAB_SIZE,
+    TEXT_EMBED_2_DIM,
+    TEXT_EMBED_DIM,
+    TEXT_TOKEN_2_MAX_LEN,
+    TEXT_TOKEN_MAX_LEN,
+    TRANSFORMER_IN_CHANNELS,
+    TRANSFORMER_TEXT_2_SEQ,
+    TRANSFORMER_TEXT_SEQ,
+    HunyuanVideo15TransformerWrapper,
+    VAEDecoderWrapper,
+    load_text_encoder,
+    load_text_encoder_2,
+    load_transformer,
+    load_vae,
+    shard_text_encoder_specs,
+    shard_transformer_specs,
+)
+
+_REPO_ID = "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v_distilled"
+
+
+class ModelVariant(StrEnum):
+    """Loadable components of the HunyuanVideo 1.5 pipeline."""
+
+    TEXT_ENCODER = "TextEncoder"
+    TEXT_ENCODER_2 = "TextEncoder2"
+    TRANSFORMER = "Transformer"
+    VAE = "Vae"
+
+
+class ModelLoader(ForgeModel):
+    """Load individual HunyuanVideo 1.5 components without pulling the full pipeline."""
+
+    _VARIANTS = {
+        ModelVariant.TEXT_ENCODER: ModelConfig(pretrained_model_name=_REPO_ID),
+        ModelVariant.TEXT_ENCODER_2: ModelConfig(pretrained_model_name=_REPO_ID),
+        ModelVariant.TRANSFORMER: ModelConfig(pretrained_model_name=_REPO_ID),
+        ModelVariant.VAE: ModelConfig(pretrained_model_name=_REPO_ID),
+    }
+    DEFAULT_VARIANT = ModelVariant.TRANSFORMER
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        task = (
+            ModelTask.NLP_EMBED_GEN
+            if variant in (ModelVariant.TEXT_ENCODER, ModelVariant.TEXT_ENCODER_2)
+            else ModelTask.MM_VIDEO_TTT
+        )
+        return ModelInfo(
+            model="HunyuanVideo15",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=task,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, *, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Load and return the component for this variant as a torch.nn.Module.
+
+        Returns:
+            TEXT_ENCODER   → Qwen2.5-VL encoder model
+            TEXT_ENCODER_2 → ByT5 encoder model
+            TRANSFORMER    → HunyuanVideo15TransformerWrapper
+            VAE            → VAEDecoderWrapper (decoder-only, returns plain tensor)
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return load_text_encoder(dtype)
+        if self._variant == ModelVariant.TEXT_ENCODER_2:
+            return load_text_encoder_2(dtype)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return HunyuanVideo15TransformerWrapper(load_transformer(dtype)).eval()
+        if self._variant == ModelVariant.VAE:
+            return VAEDecoderWrapper(load_vae(dtype)).eval()
+
+        raise ValueError(f"Unknown variant: {self._variant}")
+
+    def get_mesh_config(self, num_devices: int):
+        """Return (mesh_shape, mesh_names) for a ("batch", "model") 2D mesh.
+
+        Supported device counts: 1, 2, 4, 8, 32.
+        TEXT_ENCODER_2 and VAE fit on a single chip so any count maps to (1, 1).
+        """
+        if self._variant in (ModelVariant.TEXT_ENCODER_2, ModelVariant.VAE):
+            return (1, 1), MESH_NAMES
+
+        if num_devices not in MESH_SHAPES:
+            raise ValueError(
+                f"Unsupported device count: {num_devices}. "
+                f"Expected one of {sorted(MESH_SHAPES)}."
+            )
+        return MESH_SHAPES[num_devices], MESH_NAMES
+
+    def load_shard_spec(self, model):
+        """Return tensor → partition_spec dict for the active component.
+
+        Expects the same model object returned by load_model():
+          TEXT_ENCODER   → Qwen2.5-VL encoder
+          TEXT_ENCODER_2 → None (single-chip, no sharding)
+          TRANSFORMER    → HunyuanVideo15TransformerWrapper (specs from .transformer)
+          VAE            → None (single-chip, no sharding)
+        """
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return shard_text_encoder_specs(model)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return shard_transformer_specs(model.transformer)
+        return None
+
+    def load_inputs(self, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Return a list of synthetic input tensors for the active component.
+
+        TEXT_ENCODER   → [input_ids (1,1108) int64, attention_mask (1,1108) int64]
+        TEXT_ENCODER_2 → [input_ids (1,256) int64, attention_mask (1,256) float32]
+        TRANSFORMER    → [hidden_states, timestep, encoder_hidden_states,
+                          encoder_attention_mask, encoder_hidden_states_2,
+                          encoder_attention_mask_2, image_embeds]
+        VAE            → [z (1,32,5,30,53) bfloat16]
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            input_ids = torch.randint(
+                0, QWEN_VOCAB_SIZE, (1, TEXT_TOKEN_MAX_LEN), dtype=torch.long
+            )
+            attention_mask = torch.ones(1, TEXT_TOKEN_MAX_LEN, dtype=torch.long)
+            return [input_ids, attention_mask]
+
+        if self._variant == ModelVariant.TEXT_ENCODER_2:
+            input_ids = torch.randint(
+                0, BYT5_VOCAB_SIZE, (1, TEXT_TOKEN_2_MAX_LEN), dtype=torch.long
+            )
+            # Pipeline calls text_encoder_2 with attention_mask.float()
+            attention_mask = torch.ones(1, TEXT_TOKEN_2_MAX_LEN, dtype=torch.float32)
+            return [input_ids, attention_mask]
+
+        if self._variant == ModelVariant.TRANSFORMER:
+            hidden_states = torch.randn(
+                1,
+                TRANSFORMER_IN_CHANNELS,
+                NUM_LATENT_FRAMES,
+                LATENT_H,
+                LATENT_W,
+                dtype=dtype,
+            )
+            timestep = torch.tensor([1000.0], dtype=dtype)
+            encoder_hidden_states = torch.randn(
+                1, TRANSFORMER_TEXT_SEQ, TEXT_EMBED_DIM, dtype=dtype
+            )
+            encoder_attention_mask = torch.ones(1, TRANSFORMER_TEXT_SEQ, dtype=dtype)
+            encoder_hidden_states_2 = torch.randn(
+                1, TRANSFORMER_TEXT_2_SEQ, TEXT_EMBED_2_DIM, dtype=dtype
+            )
+            encoder_attention_mask_2 = torch.ones(
+                1, TRANSFORMER_TEXT_2_SEQ, dtype=dtype
+            )
+            image_embeds = torch.zeros(1, IMAGE_EMBED_SEQ, IMAGE_EMBED_DIM, dtype=dtype)
+            return [
+                hidden_states,
+                timestep,
+                encoder_hidden_states,
+                encoder_attention_mask,
+                encoder_hidden_states_2,
+                encoder_attention_mask_2,
+                image_embeds,
+            ]
+
+        if self._variant == ModelVariant.VAE:
+            z = torch.randn(
+                1,
+                NUM_CHANNELS_LATENTS,
+                NUM_LATENT_FRAMES,
+                LATENT_H,
+                LATENT_W,
+                dtype=dtype,
+            )
+            return [z]
+
+        raise ValueError(f"Unknown variant: {self._variant}")

--- a/hunyuan_1_5/pytorch/src/__init__.py
+++ b/hunyuan_1_5/pytorch/src/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/hunyuan_1_5/pytorch/src/model_utils.py
+++ b/hunyuan_1_5/pytorch/src/model_utils.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Component loaders and wrappers for HunyuanVideo 1.5 (480p t2v distilled).
+
+Model: hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v_distilled
+Components:
+  - text_encoder:   Qwen2.5-VL encoder (7.07B)
+  - text_encoder_2: ByT5 encoder (0.22B)
+  - transformer:    HunyuanVideo15Transformer3DModel DiT (8.33B)
+  - vae:            AutoencoderKLHunyuanVideo15 (1.26B)
+"""
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Model identity
+# ---------------------------------------------------------------------------
+
+REPO_ID = "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v_distilled"
+DTYPE = torch.bfloat16
+
+# ---------------------------------------------------------------------------
+# Inference shape constants
+# ---------------------------------------------------------------------------
+
+NUM_FRAMES = 17  # smallest valid (4k+1) — for smoke
+NUM_LATENT_FRAMES = 5  # (17-1)//4 + 1
+LATENT_H = 30  # 480 // 16
+LATENT_W = 53  # 848 // 16
+
+NUM_CHANNELS_LATENTS = 32  # VAE latent channels
+TRANSFORMER_IN_CHANNELS = 65  # 32 latent + 32 cond + 1 mask
+
+TEXT_EMBED_DIM = 3584  # Qwen2.5-VL hidden_state dim
+TEXT_EMBED_2_DIM = 1472  # ByT5 hidden_state dim
+
+IMAGE_EMBED_DIM = 1152  # transformer.config.image_embed_dim
+IMAGE_EMBED_SEQ = 64  # pipeline.vision_num_semantic_tokens default
+
+TEXT_TOKEN_MAX_LEN = 1108  # Qwen2.5-VL tokenized prompt length
+TEXT_TOKEN_2_MAX_LEN = 256  # ByT5 tokenizer_2_max_length default
+TRANSFORMER_TEXT_SEQ = 1000  # encoder_hidden_states seq dim into transformer
+TRANSFORMER_TEXT_2_SEQ = 256  # encoder_hidden_states_2 seq dim
+
+# Vocabulary sizes
+QWEN_VOCAB_SIZE = 151936  # Qwen2.5-VL text encoder
+BYT5_VOCAB_SIZE = 384  # ByT5 text_encoder_2
+
+# ---------------------------------------------------------------------------
+# Component loaders
+# ---------------------------------------------------------------------------
+
+
+def load_text_encoder(dtype: torch.dtype = DTYPE):
+    """Load Qwen2.5-VL text encoder from the text_encoder subfolder."""
+    from transformers import AutoModel
+
+    return AutoModel.from_pretrained(
+        REPO_ID,
+        subfolder="text_encoder",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_text_encoder_2(dtype: torch.dtype = DTYPE):
+    """Load ByT5 text encoder from the text_encoder_2 subfolder."""
+    from transformers import T5EncoderModel
+
+    return T5EncoderModel.from_pretrained(
+        REPO_ID,
+        subfolder="text_encoder_2",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_transformer(dtype: torch.dtype = DTYPE):
+    """Load HunyuanVideo15Transformer3DModel from the transformer subfolder."""
+    from diffusers import HunyuanVideo15Transformer3DModel
+
+    return HunyuanVideo15Transformer3DModel.from_pretrained(
+        REPO_ID,
+        subfolder="transformer",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_vae(dtype: torch.dtype = DTYPE):
+    """Load AutoencoderKLHunyuanVideo15 from the vae subfolder."""
+    from diffusers import AutoencoderKLHunyuanVideo15
+
+    return AutoencoderKLHunyuanVideo15.from_pretrained(
+        REPO_ID,
+        subfolder="vae",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+# ---------------------------------------------------------------------------
+# Wrapper modules
+# ---------------------------------------------------------------------------
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    """Expose only AutoencoderKLHunyuanVideo15 decoder as (z) -> tensor."""
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+class HunyuanVideo15TransformerWrapper(torch.nn.Module):
+    """Simplify HunyuanVideo15Transformer3DModel forward to tensor-only inputs/outputs."""
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+
+    def forward(
+        self,
+        hidden_states,
+        timestep,
+        encoder_hidden_states,
+        encoder_attention_mask,
+        encoder_hidden_states_2,
+        encoder_attention_mask_2,
+        image_embeds,
+    ):
+        return self.transformer(
+            hidden_states=hidden_states,
+            image_embeds=image_embeds,
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            encoder_hidden_states_2=encoder_hidden_states_2,
+            encoder_attention_mask_2=encoder_attention_mask_2,
+            return_dict=False,
+        )[0]
+
+
+# ---------------------------------------------------------------------------
+# SPMD shard specifications
+# ---------------------------------------------------------------------------
+
+# (batch, model) mesh shapes by device count
+MESH_SHAPES = {32: (8, 4), 8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
+MESH_NAMES = ("batch", "model")
+
+
+def shard_text_encoder_specs(encoder) -> dict:
+    """Shard specs for Qwen2.5-VL text encoder.
+
+    Column-parallel (q, k, v, gate, up): ("model", "batch")
+    Row-parallel   (o, down):            ("batch", "model")
+    """
+    specs = {}
+
+    if hasattr(encoder, "embed_tokens"):
+        specs[encoder.embed_tokens.weight] = (None, "batch")
+
+    layers = getattr(encoder, "layers", None)
+    if layers is None:
+        return specs
+
+    for layer in layers:
+        sa = layer.self_attn
+        specs[sa.q_proj.weight] = ("model", "batch")
+        if sa.q_proj.bias is not None:
+            specs[sa.q_proj.bias] = ("model",)
+        specs[sa.k_proj.weight] = ("model", "batch")
+        if sa.k_proj.bias is not None:
+            specs[sa.k_proj.bias] = ("model",)
+        specs[sa.v_proj.weight] = ("model", "batch")
+        if sa.v_proj.bias is not None:
+            specs[sa.v_proj.bias] = ("model",)
+        specs[sa.o_proj.weight] = ("batch", "model")
+
+        mlp = layer.mlp
+        specs[mlp.gate_proj.weight] = ("model", "batch")
+        specs[mlp.up_proj.weight] = ("model", "batch")
+        specs[mlp.down_proj.weight] = ("batch", "model")
+
+        specs[layer.input_layernorm.weight] = ("batch",)
+        specs[layer.post_attention_layernorm.weight] = ("batch",)
+
+    if hasattr(encoder, "norm"):
+        specs[encoder.norm.weight] = ("batch",)
+
+    return specs
+
+
+# text_encoder_2 (ByT5, 0.22B params) is small enough to fit on a single chip — no sharding needed.
+
+
+def shard_transformer_specs(transformer) -> dict:
+    """Shard specs for HunyuanVideo15Transformer3DModel.
+
+    Column-parallel (Q, K, V, FFN up): ("model", "batch")
+    Row-parallel   (O, FFN down):      ("batch", "model")
+    """
+    specs = {}
+
+    if hasattr(transformer.x_embedder, "proj"):
+        specs[transformer.x_embedder.proj.weight] = ("batch", None, None, None, None)
+        if transformer.x_embedder.proj.bias is not None:
+            specs[transformer.x_embedder.proj.bias] = ("batch",)
+
+    for block in transformer.transformer_blocks:
+        for norm_name in ("norm1", "norm1_context"):
+            if hasattr(block, norm_name) and hasattr(
+                getattr(block, norm_name), "linear"
+            ):
+                lin = getattr(block, norm_name).linear
+                specs[lin.weight] = ("model", "batch")
+                if lin.bias is not None:
+                    specs[lin.bias] = ("model",)
+
+        if hasattr(block, "attn"):
+            attn = block.attn
+            for proj_name in (
+                "to_q",
+                "to_k",
+                "to_v",
+                "add_q_proj",
+                "add_k_proj",
+                "add_v_proj",
+            ):
+                if hasattr(attn, proj_name):
+                    proj = getattr(attn, proj_name)
+                    specs[proj.weight] = ("model", "batch")
+                    if proj.bias is not None:
+                        specs[proj.bias] = ("model",)
+            for proj_name in ("to_out", "to_add_out"):
+                if hasattr(attn, proj_name):
+                    out = getattr(attn, proj_name)
+                    target = (
+                        out[0]
+                        if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
+                        else out
+                    )
+                    specs[target.weight] = ("batch", "model")
+                    if target.bias is not None:
+                        specs[target.bias] = ("batch",)
+
+        for ff_name in ("ff", "ff_context"):
+            if hasattr(block, ff_name):
+                ff = getattr(block, ff_name)
+                if hasattr(ff.net[0], "proj"):
+                    specs[ff.net[0].proj.weight] = ("model", "batch")
+                    if ff.net[0].proj.bias is not None:
+                        specs[ff.net[0].proj.bias] = ("model",)
+                specs[ff.net[2].weight] = ("batch", "model")
+                if ff.net[2].bias is not None:
+                    specs[ff.net[2].bias] = ("batch",)
+
+    specs[transformer.proj_out.weight] = (None, "batch")
+    if transformer.proj_out.bias is not None:
+        specs[transformer.proj_out.bias] = (None,)
+
+    return specs
+
+
+# VAE runs single-device (1.26B params fits); current TT-XLA hits a hang during decode — to debug.


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-xla/issues/4470

### Problem description
Add component loaders for the HunyuanVideo 1.5 (480p t2v distilled) pipeline

### What's changed
New package: `hunyuan_1_5/pytorch/`

| File | Purpose |
|------|---------|
| `loader.py` | ForgeModel subclass with four variants (TextEncoder, TextEncoder2, Transformer, Vae), each loading only its own component via `from_pretrained(subfolder=...)` |
| `src/model_utils.py` | Component loaders, wrapper modules, shard specs, mesh shapes, inference shape constants |

Component sources:

| Variant | Class | Params |
|---------|-------|--------|
| `TextEncoder` | Qwen2.5-VL encoder via `transformers.AutoModel` | 7.07B |
| `TextEncoder2` | ByT5 encoder via `transformers.T5EncoderModel` | 0.22B |
| `Transformer` | `HunyuanVideo15Transformer3DModel` | 8.33B |
| `Vae` | `AutoencoderKLHunyuanVideo15` | 1.26B |

Each component is loaded independently — no full pipeline is instantiated.

`ModelLoader` API:
- `load_model(dtype_override)` — returns the component as a `torch.nn.Module`
- `load_inputs(dtype_override)` — returns synthetic input tensors matched to the component's forward signature
- `get_mesh_config(num_devices)` — returns `(mesh_shape, mesh_names)` for a 2D `(batch, model)` SPMD mesh (supports 1 / 2 / 4 / 8 / 32 devices)
- `load_shard_spec(model)` — returns per-tensor partition specs for tensor parallelism

Wrapper modules in `src/model_utils.py`:
- `HunyuanVideo15TransformerWrapper` — flattens the DiT forward to tensor-only inputs/outputs `(hidden_states, timestep, encoder_hidden_states, ...) → noise_pred`
- `VAEDecoderWrapper` — exposes decoder-only path `(z) → tensor`, bypassing the default encode+decode round-trip

### Checklist
- [x] Verify changes by local testing in Wormhole

### Logs

- [may5_Hunyuan_1_5_encoder_2.log](https://github.com/user-attachments/files/27408292/may5_Hunyuan_1_5_encoder_2.log)
- [may5_Hunyuan_1_5_encoder_sharded.log](https://github.com/user-attachments/files/27408295/may5_Hunyuan_1_5_encoder_sharded.log)
- [may5_Hunyuan_1_5_transformer_sharded.log](https://github.com/user-attachments/files/27408296/may5_Hunyuan_1_5_transformer_sharded.log)
- [may5_hunyuanVideo_1_5_vae_decoder.log](https://github.com/user-attachments/files/27408299/may5_hunyuanVideo_1_5_vae_decoder.log)