### PR TITLE
Add Cog VideoX for video component loaders

### DIFF
--- a/cog_videox/pytorch/__init__.py
+++ b/cog_videox/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant

--- a/cog_videox/pytorch/loader.py
+++ b/cog_videox/pytorch/loader.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+CogVideoX-5b (text-to-video) component loader.
+
+Each variant corresponds to one independently loadable component:
+  - TextEncoder   → T5 v1.1-XXL encoder (text_encoder)         params=4.76B
+  - Transformer   → CogVideoXTransformerWrapper (DiT)          params=5.0B
+  - Vae           → VAEDecoderWrapper (decoder-only)           params=0.22B
+"""
+
+from typing import Optional
+
+import torch
+
+from ...base import ForgeModel
+from ...config import (
+    Framework,
+    ModelConfig,
+    ModelGroup,
+    ModelInfo,
+    ModelSource,
+    ModelTask,
+    StrEnum,
+)
+from .src.model_utils import (
+    REPO_ID,
+    DTYPE,
+    CogVideoXTransformerWrapper,
+    VAEDecoderWrapper,
+    load_text_encoder,
+    load_text_encoder_inputs,
+    load_transformer,
+    load_transformer_inputs,
+    load_vae,
+    load_vae_inputs,
+)
+
+
+class ModelVariant(StrEnum):
+    """Loadable components of the CogVideoX-5b pipeline."""
+
+    TEXT_ENCODER = "TextEncoder"
+    TRANSFORMER = "Transformer"
+    VAE = "Vae"
+
+
+class ModelLoader(ForgeModel):
+    """Load individual CogVideoX-5b components without pulling the full pipeline."""
+
+    _VARIANTS = {
+        ModelVariant.TEXT_ENCODER: ModelConfig(pretrained_model_name=REPO_ID),
+        ModelVariant.TRANSFORMER: ModelConfig(pretrained_model_name=REPO_ID),
+        ModelVariant.VAE: ModelConfig(pretrained_model_name=REPO_ID),
+    }
+    DEFAULT_VARIANT = ModelVariant.TRANSFORMER
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        task = (
+            ModelTask.NLP_EMBED_GEN
+            if variant == ModelVariant.TEXT_ENCODER
+            else ModelTask.MM_VIDEO_TTT
+        )
+        return ModelInfo(
+            model="CogVideoX5b",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=task,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, *, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Load and return the component for this variant as a torch.nn.Module.
+
+        Returns:
+            TEXT_ENCODER → T5 v1.1-XXL encoder model
+            TRANSFORMER  → CogVideoXTransformerWrapper
+            VAE          → VAEDecoderWrapper (decoder-only, returns plain tensor)
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return load_text_encoder(dtype)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return CogVideoXTransformerWrapper(load_transformer(dtype)).eval()
+        if self._variant == ModelVariant.VAE:
+            return VAEDecoderWrapper(load_vae(dtype)).eval()
+
+        raise ValueError(f"Unknown variant: {self._variant}")
+
+    def load_inputs(self, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Return a list of synthetic input tensors for the active component.
+
+        TEXT_ENCODER → [input_ids (1,226) int64, attention_mask (1,226) int64]
+        TRANSFORMER  → [hidden_states, encoder_hidden_states, timestep,
+                        image_rotary_emb_cos, image_rotary_emb_sin]
+        VAE          → [z (1,16,3,60,90) bfloat16]
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return load_text_encoder_inputs(dtype)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return load_transformer_inputs(dtype)
+        if self._variant == ModelVariant.VAE:
+            return load_vae_inputs(dtype)
+
+        raise ValueError(f"Unknown variant: {self._variant}")

--- a/cog_videox/pytorch/src/model_utils.py
+++ b/cog_videox/pytorch/src/model_utils.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Component loaders and wrappers for CogVideoX-5b text-to-video.
+
+Model: THUDM/CogVideoX-5b
+Components:
+  - text_encoder: T5 v1.1-XXL encoder (~4.76B)
+  - transformer:  CogVideoXTransformer3DModel DiT (~5.0B)
+  - vae:          AutoencoderKLCogVideoX (~0.22B)
+"""
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Model identity
+# ---------------------------------------------------------------------------
+
+REPO_ID = "THUDM/CogVideoX-5b"
+DTYPE = torch.bfloat16
+
+# ---------------------------------------------------------------------------
+# Inference shape constants (mirrors test_cog5x.py: num_frames=9, default 480x720)
+# ---------------------------------------------------------------------------
+
+NUM_FRAMES = 9  # video frames at sampling time
+NUM_LATENT_FRAMES = 3  # (NUM_FRAMES - 1) // VAE_TEMPORAL_RATIO + 1 = (9-1)//4 + 1
+LATENT_H = 60  # 480 // VAE_SPATIAL_RATIO (8)
+LATENT_W = 90  # 720 // VAE_SPATIAL_RATIO (8)
+
+NUM_CHANNELS_LATENTS = 16  # CogVideoX VAE latent channels (transformer in/out channels)
+
+# Transformer (CogVideoX-5b)
+NUM_ATTENTION_HEADS = 48
+ATTENTION_HEAD_DIM = 64
+TRANSFORMER_HIDDEN_DIM = NUM_ATTENTION_HEADS * ATTENTION_HEAD_DIM  # 3072
+PATCH_SIZE = 2
+
+# Text embedding dims
+TEXT_EMBED_DIM = 4096  # T5 v1.1-XXL hidden size
+TEXT_TOKEN_MAX_LEN = 226  # max_text_seq_length / tokenizer_max_length default
+T5_VOCAB_SIZE = 32128
+
+# Rotary positional embedding shape (CogVideoX-5b uses use_rotary_positional_embeddings=True)
+ROTARY_NUM_PATCHES = (
+    NUM_LATENT_FRAMES * (LATENT_H // PATCH_SIZE) * (LATENT_W // PATCH_SIZE)
+)  # 3 * 30 * 45 = 4050
+
+# ---------------------------------------------------------------------------
+# Component loaders
+# ---------------------------------------------------------------------------
+
+
+def load_text_encoder(dtype: torch.dtype = DTYPE):
+    """Load T5 v1.1-XXL text encoder from the text_encoder subfolder."""
+    from transformers import T5EncoderModel
+
+    return T5EncoderModel.from_pretrained(
+        REPO_ID,
+        subfolder="text_encoder",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_transformer(dtype: torch.dtype = DTYPE):
+    """Load CogVideoXTransformer3DModel from the transformer subfolder."""
+    from diffusers import CogVideoXTransformer3DModel
+
+    return CogVideoXTransformer3DModel.from_pretrained(
+        REPO_ID,
+        subfolder="transformer",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_vae(dtype: torch.dtype = DTYPE):
+    """Load AutoencoderKLCogVideoX from the vae subfolder."""
+    from diffusers import AutoencoderKLCogVideoX
+
+    return AutoencoderKLCogVideoX.from_pretrained(
+        REPO_ID,
+        subfolder="vae",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+# ---------------------------------------------------------------------------
+# Component input builders
+# ---------------------------------------------------------------------------
+
+
+def load_text_encoder_inputs(dtype: torch.dtype = DTYPE):
+    """Synthetic inputs for the T5 text encoder: [input_ids, attention_mask]."""
+    input_ids = torch.randint(
+        0, T5_VOCAB_SIZE, (1, TEXT_TOKEN_MAX_LEN), dtype=torch.long
+    )
+    attention_mask = torch.ones(1, TEXT_TOKEN_MAX_LEN, dtype=torch.long)
+    return [input_ids, attention_mask]
+
+
+def load_transformer_inputs(dtype: torch.dtype = DTYPE):
+    """Synthetic inputs for the CogVideoX DiT transformer wrapper.
+
+    Returns [hidden_states, encoder_hidden_states, timestep,
+             image_rotary_emb_cos, image_rotary_emb_sin].
+    """
+    # CogVideoX hidden_states layout: (B, F, C, H, W)
+    hidden_states = torch.randn(
+        1,
+        NUM_LATENT_FRAMES,
+        NUM_CHANNELS_LATENTS,
+        LATENT_H,
+        LATENT_W,
+        dtype=dtype,
+    )
+    encoder_hidden_states = torch.randn(
+        1, TEXT_TOKEN_MAX_LEN, TEXT_EMBED_DIM, dtype=dtype
+    )
+    timestep = torch.tensor([1000.0], dtype=dtype)
+    # 3D rotary positional embeddings: (num_patches, head_dim) per cos/sin
+    image_rotary_emb_cos = torch.randn(
+        ROTARY_NUM_PATCHES, ATTENTION_HEAD_DIM, dtype=dtype
+    )
+    image_rotary_emb_sin = torch.randn(
+        ROTARY_NUM_PATCHES, ATTENTION_HEAD_DIM, dtype=dtype
+    )
+    return [
+        hidden_states,
+        encoder_hidden_states,
+        timestep,
+        image_rotary_emb_cos,
+        image_rotary_emb_sin,
+    ]
+
+
+def load_vae_inputs(dtype: torch.dtype = DTYPE):
+    """Synthetic inputs for the VAE decoder wrapper: [z (1,16,3,60,90)]."""
+    z = torch.randn(
+        1,
+        NUM_CHANNELS_LATENTS,
+        NUM_LATENT_FRAMES,
+        LATENT_H,
+        LATENT_W,
+        dtype=dtype,
+    )
+    return [z]
+
+
+# ---------------------------------------------------------------------------
+# Wrapper modules
+# ---------------------------------------------------------------------------
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    """Expose only AutoencoderKLCogVideoX decoder as (z) -> tensor."""
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+class CogVideoXTransformerWrapper(torch.nn.Module):
+    """Simplify CogVideoXTransformer3DModel forward to tensor-only inputs/outputs.
+
+    image_rotary_emb is reconstructed from (cos, sin) tensors so the wrapped forward
+    has a flat tensor-only signature suitable for tracing/compilation.
+    """
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+
+    def forward(
+        self,
+        hidden_states,
+        encoder_hidden_states,
+        timestep,
+        image_rotary_emb_cos,
+        image_rotary_emb_sin,
+    ):
+        return self.transformer(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            timestep=timestep,
+            image_rotary_emb=(image_rotary_emb_cos, image_rotary_emb_sin),
+            return_dict=False,
+        )[0]


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-xla/issues/4518

### Problem description
Add component loaders for the Cog VideoX 5B pipeline

### What's changed
New package: `cog_videox/pytorch/`

| File | Purpose |
|------|---------|
| `loader.py` | ForgeModel subclass with three variants (TextEncoder, Transformer, Vae), each loading only its own component via `from_pretrained(subfolder=...)` |
| `src/model_utils.py` | Component loaders, wrapper modules, , inference shape constants |

Component sources:

| Variant | Class | 
|---------|-------|
| `TextEncoder` | T5 v1.1-XXL encoder
| `Transformer` | CogVideoXTransformer3DModel DiT
| `Vae` | AutoencoderKLCogVideoX

Each component is loaded independently — no full pipeline is instantiated.

`ModelLoader` API:
- `load_model(dtype_override)` — returns the component as a `torch.nn.Module`
- `load_inputs(dtype_override)` — returns synthetic input tensors matched to the component's forward signature

Sharding has been removed for this model as model is only 5B and should be fitting in a single device, further debugging will be done as to the errors in single device runs.

### Checklist
- [x] Verify changes by local testing in Wormhole

### Logs

[cog5x_text_encoder.log](https://github.com/user-attachments/files/27597833/cog5x_text_encoder.log)
[cog5x_transformer.zip](https://github.com/user-attachments/files/27597803/cog5x_transformer.zip)
[cog5x_vae.log](https://github.com/user-attachments/files/27597685/cog5x_vae.log)