### PR TITLE
Support Mistral model with text-based approach

### DIFF
--- a/mistral/pytorch/loader.py
+++ b/mistral/pytorch/loader.py
@@ -269,6 +269,10 @@ class ModelLoader(ForgeModel):
             inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
 
         elif self._variant in self._USE_Mistral3ForConditionalGeneration_VARIANTS:
+            # TODO: While running the model with image + text, an error is encountered.
+            # This needs to be fixed and is being tracked in: https://github.com/tenstorrent/tt-xla/issues/4568.
+            # This is a temporary workaround to run the model with text-only input.
+            """
             from mistral_common.protocol.instruct.request import ChatCompletionRequest
 
             image_url = "https://static.wikia.nocookie.net/essentialsdocs/images/7/70/Battle.png/revision/latest?cb=20220523172438"
@@ -302,6 +306,20 @@ class ModelLoader(ForgeModel):
                 "pixel_values": pixel_values,
                 "image_sizes": image_sizes,
             }
+            """
+            from mistral_common.protocol.instruct.messages import UserMessage
+            from mistral_common.protocol.instruct.request import ChatCompletionRequest
+
+            req = ChatCompletionRequest(
+                messages=[UserMessage(content=test_input)],
+            )
+            encoded = self.tokenizer.encode_chat_completion(req)
+            token_ids = encoded.tokens
+
+            input_ids = torch.tensor([token_ids], dtype=torch.long)
+            attention_mask = torch.ones_like(input_ids, dtype=torch.long)
+            inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
+
         else:
             inputs = self.tokenizer(test_input, return_tensors="pt")
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4568

### Problem description
While running the model (mistral/pytorch-mistral_small_3.2_24b_instruct_2506-tensor_parallel-inference) with the text-image approach, a runtime error is encountered. As a temporary fix, the text-only approach has been enabled to handle this issue for now.

The text-based approach model is passing with a PCC of 0.99.

### What's changed
Edited the input functions by commenting out the image+text generation code and enabling only text input generation.

logs:
[mistral_text_approach.log](https://github.com/user-attachments/files/27465395/mistral_text_approach.log)



### Checklist
- [ ] New/Existing tests provide coverage for changes
