### PR TITLE
Pass missing training-mode inputs in loaders (decoder_input_ids / targets / batch_size=2)

### DIFF
--- a/mobilenetv2/pytorch/loader.py
+++ b/mobilenetv2/pytorch/loader.py
@@ -284,7 +284,7 @@ class ModelLoader(ForgeModel):
             model_for_config=model_for_config,
         )
 
-    def load_inputs(self, dtype_override=None, batch_size=1, image=None):
+    def load_inputs(self, dtype_override=None, batch_size=2, image=None):
         """Load and return sample inputs (backward compatibility wrapper for input_preprocess).
 
         Args:

--- a/ssd300_resnet50/pytorch/loader.py
+++ b/ssd300_resnet50/pytorch/loader.py
@@ -105,7 +105,7 @@ class ModelLoader(ForgeModel):
 
         return model
 
-    def load_inputs(self, dtype_override=None, batch_size=1):
+    def load_inputs(self, dtype_override=None, batch_size=2):
         """Load and return sample inputs for the SSD300 ResNet50 model with this instance's variant settings.
 
         Args:
@@ -138,3 +138,23 @@ class ModelLoader(ForgeModel):
             input_batch = input_batch.to(dtype_override)
 
         return input_batch
+
+    def unpack_forward_output(self, fwd_output):
+        """Unpack forward pass output to extract a differentiable tensor.
+
+        Forward output structure:
+            tuple of (locs, confs) where
+              locs:  Tensor of shape (B, 4,  num_anchors=8732) — per-anchor box regressions
+              confs: Tensor of shape (B, 81, num_anchors=8732) — per-anchor class logits
+
+        What is selected and why:
+            Both tensors are flattened and concatenated. SSD's MultiBoxLoss consumes
+            locs (smooth-L1 localization loss) and confs (cross-entropy classification
+            loss); both are gradient sources during training and neither is auxiliary.
+
+        Why a registry entry was not sufficient:
+            Forward output is a bare tuple — the global registry in training_utils.py
+            keys on output class name and cannot dispatch on plain Python tuples.
+        """
+        locs, confs = fwd_output
+        return torch.cat([locs.flatten(), confs.flatten()], dim=0)

--- a/ssd300_vgg16/pytorch/loader.py
+++ b/ssd300_vgg16/pytorch/loader.py
@@ -22,6 +22,7 @@ from ...config import (
     StrEnum,
 )
 from datasets import load_dataset
+from ...tools.utils import extract_tensors_recursive
 from .src.utils import patched_grid_default_boxes, patched_forward, patched_SSD_forward
 
 
@@ -144,7 +145,39 @@ class ModelLoader(ForgeModel):
             # TODO (@ppadjinTT): remove this when torchvision starts supporting torchvision.ops.nms for bfloat16
             print("NOTE: dtype_override ignored - batched_nms lacks BFloat16 support")
 
-        return batch_t
+        targets = [
+            {
+                "boxes": torch.tensor([[10.0, 10.0, 100.0, 100.0]], dtype=torch.float32),
+                "labels": torch.tensor([1], dtype=torch.int64),
+            }
+            for _ in range(batch_size)
+        ]
+
+        return {"images": batch_t, "targets": targets}
+
+    def unpack_forward_output(self, fwd_output):
+        """Unpack forward pass output to a single differentiable tensor.
+
+        Forward output structure: tuple(head_outputs, anchors) where
+        head_outputs is dict{"bbox_regression": Tensor(B, 8732, 4),
+        "cls_logits": Tensor(B, 8732, 91)} and anchors is list[Tensor(8732, 4)]
+        of length B.
+
+        What is selected and why: only the head_outputs values
+        (bbox_regression and cls_logits) are returned, flattened and
+        concatenated. These are the gradient sources consumed by SSD's
+        classification + localization loss. Anchors are reference geometry
+        produced by the (monkey-patched) DefaultBoxGenerator and carry no
+        gradients.
+
+        Why a registry entry was not sufficient: the model's forward output
+        is a bare tuple, which has no stable class name to key the global
+        unpack registry on.
+        """
+        head_outputs = fwd_output[0]
+        tensors = []
+        extract_tensors_recursive(head_outputs, tensors)
+        return torch.cat(tensors, dim=0)
 
     def postprocess_detections(self, fw_out, co_out):
         """Run post-processing on raw model outputs (head_outputs, anchors) on CPU.

--- a/ssdlite320_mobilenetv3/pytorch/loader.py
+++ b/ssdlite320_mobilenetv3/pytorch/loader.py
@@ -23,6 +23,7 @@ from torchvision import transforms
 import torchvision.models as models
 from torchvision.models.detection.anchor_utils import DefaultBoxGenerator
 from torchvision.models.detection.ssd import SSD
+from ...tools.utils import extract_tensors_recursive
 from ...ssd300_vgg16.pytorch.src.utils import (
     patched_grid_default_boxes,
     patched_forward,
@@ -119,7 +120,7 @@ class ModelLoader(ForgeModel):
 
         return self.model
 
-    def load_inputs(self, dtype_override=None, batch_size=1):
+    def load_inputs(self, dtype_override=None, batch_size=2):
         """Load and return sample inputs for the SSDLite320 MobileNetV3 model with this instance's variant settings.
 
         Args:
@@ -153,7 +154,39 @@ class ModelLoader(ForgeModel):
             print("NOTE: dtype_override ignored - batched_nms lacks BFloat16 support")
             # inputs = inputs.to(dtype_override)
 
-        return inputs
+        targets = [
+            {
+                "boxes": torch.tensor([[10.0, 10.0, 100.0, 100.0]], dtype=torch.float32),
+                "labels": torch.tensor([1], dtype=torch.int64),
+            }
+            for _ in range(batch_size)
+        ]
+
+        return {"images": inputs, "targets": targets}
+
+    def unpack_forward_output(self, fwd_output):
+        """Unpack forward pass output to a single differentiable tensor.
+
+        Forward output structure: tuple(head_outputs, anchors) where
+        head_outputs is dict{"bbox_regression": Tensor(B, 3234, 4),
+        "cls_logits": Tensor(B, 3234, 91)} and anchors is list[Tensor(3234, 4)]
+        of length B.
+
+        What is selected and why: only the head_outputs values
+        (bbox_regression and cls_logits) are returned, flattened and
+        concatenated. These are the gradient sources consumed by SSD's
+        classification + localization loss. Anchors are reference geometry
+        produced by the (monkey-patched) DefaultBoxGenerator and carry no
+        gradients.
+
+        Why a registry entry was not sufficient: the model's forward output
+        is a bare tuple, which has no stable class name to key the global
+        unpack registry on.
+        """
+        head_outputs = fwd_output[0]
+        tensors = []
+        extract_tensors_recursive(head_outputs, tensors)
+        return torch.cat(tensors, dim=0)
 
     def postprocess_detections(self, outputs):
         head_outputs, anchors = outputs

--- a/whisper/pytorch/loader.py
+++ b/whisper/pytorch/loader.py
@@ -207,9 +207,16 @@ class ModelLoader(ForgeModel):
             decoder_input_ids = torch.tensor(
                 [init_tokens], dtype=torch.long, device=device
             )
-            return [input_features, attention_mask, decoder_input_ids]
+            return {
+                "input_features": input_features,
+                "attention_mask": attention_mask,
+                "decoder_input_ids": decoder_input_ids,
+            }
 
         decoder_input_ids = torch.full(
             (1, 2), model_config.decoder_start_token_id, dtype=torch.long, device=device
         )
-        return [input_features, decoder_input_ids]
+        return {
+            "input_features": input_features,
+            "decoder_input_ids": decoder_input_ids,
+        }

--- a/yolox/pytorch/loader.py
+++ b/yolox/pytorch/loader.py
@@ -151,7 +151,9 @@ class ModelLoader(ForgeModel):
             batch_size: Optional batch size to override the default batch size of 1.
 
         Returns:
-            torch.Tensor: Sample input tensor that can be fed to the model.
+            dict: ``{"x": image_tensor, "targets": targets_tensor}`` where ``targets`` has
+            shape ``[B, max_labels, 5]`` with each row encoding ``[class_id, cx, cy, w, h]``.
+            ``targets`` is ignored by the model in eval mode and required in train mode.
         """
         # Deter imports so not required at model discovery time
         from datasets import load_dataset
@@ -181,7 +183,38 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             batch_tensor = batch_tensor.to(dtype_override)
 
-        return batch_tensor
+        # Train mode requires targets so the model can compute losses; we don't
+        # actually train, we just need a forward+backward to run, so a single
+        # fake label is enough. Shape [B, max_labels, 5] with [class_id, cx, cy,
+        # w, h] per row; all-zero rows are treated as padding. Eval mode ignores
+        # targets entirely, so the dict return is safe for inference too.
+        cx = input_shape[1] / 2.0
+        cy = input_shape[0] / 2.0
+        single_label = torch.tensor([[1.0, cx, cy, 50.0, 50.0]])
+        targets = single_label.unsqueeze(0).repeat(batch_size, 1, 1)
+        if dtype_override is not None:
+            targets = targets.to(dtype_override)
+
+        return {"x": batch_tensor, "targets": targets}
+
+    def unpack_forward_output(self, forward_output):
+        """Extract the loss-relevant tensor from YOLOX's training-mode output.
+
+        Forward output structure: bare ``dict`` with keys ``total_loss``,
+        ``iou_loss``, ``l1_loss``, ``conf_loss``, ``cls_loss``, ``num_fg``.
+        ``total_loss`` is a scalar tensor with ``requires_grad=True``; the four
+        ``*_loss`` components are summed into it; ``num_fg`` is a Python float
+        count (not a tensor).
+
+        Selection: ``total_loss``. It is the single scalar that drives the
+        backward pass — gradients flow through all four loss components and back
+        to every model parameter. The component losses are redundant with it,
+        and ``num_fg`` is non-differentiable.
+
+        Why not the registry: the forward output is a bare ``dict`` (no class
+        name to key on), so ``_register_attr`` cannot dispatch on it.
+        """
+        return forward_output["total_loss"]
 
     def post_processing(self, co_out):
         """Post-process the model outputs.


### PR DESCRIPTION
> [!NOTE]
> Stacked on [#641](https://github.com/tenstorrent/tt-forge-models/pull/641) (pattern 2 — bfloat16 dtype). Complements [tt-xla/pull/4609](https://github.com/tenstorrent/tt-xla/pull/4609), which adds the triage skill that produced these loader fixes and updates the test YAMLs to reflect the new failure stages.

### Ticket
Refs: [tenstorrent/tt-xla#4293](https://github.com/tenstorrent/tt-xla/issues/4293) (kept open — this is the third pattern of FE failures being triaged).

### Problem description
A number of training tests in tt-xla were stuck at `FAILED_FE_COMPILATION` with one of these reasons:

- `ValueError: You have to specify either decoder_input_ids or decoder_inputs_embeds.`
- `Model expects targets to be passed while in training mode`
- `AssertionError: targets should not be none when in training mode`
- `AttributeError: 'NoneType' object has no attribute 'max'`
- `ValueError: Expected more than 1 value per channel when training, got input size torch.Size([1, 256, 1, 1])`

All five are the same root cause: the model requires an input in `model.train()` mode that `load_inputs` is not passing. The tt-xla runner calls `load_inputs` once and then sets `model.train()` later, so the loader cannot branch on run mode — any added input must be safe for inference too. The errors fall into three sub-flavors that the companion triage skill handles uniformly.

### What's changed
Per-loader edits — each one minimally adds the input the model needs in train mode, in a form that inference can still ignore.

**Encoder-decoder LM — `decoder_input_ids` (loader return switched to a `dict`):**
- `whisper/pytorch/loader.py` — `load_inputs` now returns `{"input_features": …, "attention_mask": …, "decoder_input_ids": …}` (with-prompt path) or `{"input_features": …, "decoder_input_ids": …}` (default path). Previously the list-form return put `decoder_input_ids` in the `attention_mask` slot, so `WhisperForConditionalGeneration` still raised "You have to specify either decoder_input_ids or decoder_inputs_embeds."

**Torchvision detection — synthetic `targets` + `unpack_forward_output`:**
- `ssd300_resnet50/pytorch/loader.py` — `load_inputs` default `batch_size` raised to 2 (single-image batches crashed downstream); adds an `unpack_forward_output` override that flattens+concats `(locs, confs)` from SSD's bare-tuple forward output so both heads drive backward.
- `ssd300_vgg16/pytorch/loader.py` — `load_inputs` returns `{"images": …, "targets": [{"boxes": …, "labels": …}, …]}` with one synthetic box per image. `unpack_forward_output` selects `head_outputs` (the `bbox_regression` + `cls_logits` dict) from the `(head_outputs, anchors)` tuple; anchors are reference geometry and carry no gradients. Synthetic targets are ignored by `eval()`, so inference is unaffected.
- `ssdlite320_mobilenetv3/pytorch/loader.py` — same pattern as ssd300_vgg16: dict return with synthetic targets, override unpacks `head_outputs` from the `(head_outputs, anchors)` tuple. Default `batch_size` raised to 2.
- `yolox/pytorch/loader.py` — `load_inputs` returns `{"x": image, "targets": labels}` where `targets` is a `[B, max_labels, 5]` tensor of `[class_id, cx, cy, w, h]` rows (single fake label, padded with zeros). YOLOX's train-mode forward returns a `dict` of `total_loss` + four component losses; the new `unpack_forward_output` selects `total_loss` (the single backward sink). Eval mode ignores `targets`, so the dict return is safe for inference too.

**BatchNorm 1-value-per-channel — `batch_size=2`:**
- `mobilenetv2/pytorch/loader.py` — default `batch_size` raised from 1 to 2 so deeplabv3's ASPP global-pool feature maps stop collapsing to `[1, 256, 1, 1]` and BN's variance check passes. Inference YAML for this variant already tolerates `batch_size=2`.

### Checklist
- [x] New/Existing tests provide coverage for changes (existing training tests in tt-xla — they were the ones gating on these failures and now advance past FE compilation; outcomes recorded in the companion tt-xla PR's YAML updates).