### PR TITLE
Adding support for sliding attention.

### DIFF
--- a/mistral/pytorch/loader.py
+++ b/mistral/pytorch/loader.py
@@ -224,10 +224,6 @@ class ModelLoader(ForgeModel):
                 pretrained_model_name, **model_kwargs
             ).eval()
 
-        if self._variant == ModelVariant.MINISTRAL_8B:
-            model.config.layer_types = ["full_attention"] * len(
-                model.config.layer_types
-            )
         self.config = model.config
 
         self.model = model
@@ -322,14 +318,6 @@ class ModelLoader(ForgeModel):
 
         else:
             inputs = self.tokenizer(test_input, return_tensors="pt")
-
-        if (
-            hasattr(self.model.config, "sliding_window")
-            and self.model.config.sliding_window is not None
-        ):
-            # if the model uses sliding window attention, match sliding window value to input size so it
-            # does not go out of bounds when updating the cache
-            self.model.config.sliding_window = inputs["input_ids"].shape[1]
 
         # Add batch dimension
         for key in inputs:

--- a/olmo3/causal_lm/pytorch/loader.py
+++ b/olmo3/causal_lm/pytorch/loader.py
@@ -134,10 +134,7 @@ class ModelLoader(ForgeModel):
         model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name, **model_kwargs
         )
-        if getattr(model.config, "use_cache", True):
-            model.config.layer_types = [
-                "full_attention"
-            ] * model.config.num_hidden_layers
+
         model.eval()
 
         self.config = model.config


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Added the generic form to support sliding attention in this PR.https://github.com/tenstorrent/tt-xla/pull/4635

### What's changed
So, I removed the code that was hardcoded for full attention in the OLMo3 and Mistral loaders.
### Checklist
- [ ] New/Existing tests provide coverage for changes
