### PR TITLE
Add Mochi-1 full-res input helpers and transformer shard specs

### DIFF
--- a/mochi/pytorch/loader.py
+++ b/mochi/pytorch/loader.py
@@ -30,6 +30,8 @@ from ...config import (
     StrEnum,
 )
 from .src.utils import (
+    MESH_NAMES,
+    MESH_SHAPES,
     load_pipeline,
     load_vae,
     load_transformer,
@@ -38,6 +40,8 @@ from .src.utils import (
     load_vae_decoder_inputs,
     load_transformer_inputs,
     load_text_encoder_inputs,
+    shard_transformer_specs,
+    shard_vae_decoder_specs,
 )
 
 # Supported subfolders for loading individual components
@@ -183,6 +187,36 @@ class ModelLoader(ForgeModel):
             raise RuntimeError(
                 "Full pipeline is currently not supported for input loading"
             )
+
+    def get_mesh_config(self, num_devices: int):
+        """Return ((batch, model) mesh shape, mesh names) for the active component.
+
+        transformer and vae use the supported shapes in MESH_SHAPES.
+        text_encoder runs on a single chip.
+        """
+        if self._subfolder == "text_encoder":
+            return (1, 1), MESH_NAMES
+
+        if num_devices not in MESH_SHAPES:
+            raise ValueError(
+                f"Unsupported device count: {num_devices}. "
+                f"Expected one of {sorted(MESH_SHAPES)}."
+            )
+        return MESH_SHAPES[num_devices], MESH_NAMES
+
+    def load_shard_spec(self, model):
+        """Return tensor -> partition_spec dict for the active component.
+
+        Expects whatever the test passes to run_graph_test:
+          transformer → MochiTransformer3DModel
+          vae         → MochiDecoder3D (vae.decoder)
+          text_encoder → None (single-chip, no sharding)
+        """
+        if self._subfolder == "transformer":
+            return shard_transformer_specs(model)
+        if self._subfolder == "vae":
+            return shard_vae_decoder_specs(model)
+        return None
 
     def unpack_forward_output(self, output: Any) -> torch.Tensor:
         """

--- a/mochi/pytorch/src/utils.py
+++ b/mochi/pytorch/src/utils.py
@@ -274,3 +274,171 @@ def load_text_encoder_inputs(dtype: torch.dtype = torch.bfloat16) -> dict:
         "input_ids": torch.randint(0, 32000, (batch_size, seq_len)),
         "attention_mask": torch.ones(batch_size, seq_len, dtype=torch.long),
     }
+
+
+# ============================================================================
+# Original-resolution input helpers
+# ============================================================================
+
+ORIGINAL_LATENT_HEIGHT = 60  # 480 / 8
+ORIGINAL_LATENT_WIDTH = 106  # 848 / 8
+ORIGINAL_LATENT_DEPTH = 14  # (num_frames=84 - 1) // 6 + 1
+ORIGINAL_MAX_SEQ_LEN = 256
+ORIGINAL_TEXT_EMBED_DIM = 4096
+ORIGINAL_LATENT_CHANNELS = 12
+ORIGINAL_T5_VOCAB_SIZE = 32128
+
+
+def load_transformer_inputs_full_res(
+    dtype: torch.dtype = torch.bfloat16,
+) -> list:
+    """Original-resolution positional inputs for MochiTransformer3DModel."""
+    hidden_states = torch.randn(
+        1,
+        ORIGINAL_LATENT_CHANNELS,
+        ORIGINAL_LATENT_DEPTH,
+        ORIGINAL_LATENT_HEIGHT,
+        ORIGINAL_LATENT_WIDTH,
+        dtype=dtype,
+    )
+    encoder_hidden_states = torch.randn(
+        1, ORIGINAL_MAX_SEQ_LEN, ORIGINAL_TEXT_EMBED_DIM, dtype=dtype
+    )
+    timestep = torch.tensor([500], dtype=dtype)
+    encoder_attention_mask = torch.ones(1, ORIGINAL_MAX_SEQ_LEN, dtype=torch.bool)
+    return [hidden_states, encoder_hidden_states, timestep, encoder_attention_mask]
+
+
+def load_vae_decoder_inputs_full_res(
+    dtype: torch.dtype = torch.bfloat16,
+) -> list:
+    """Original-resolution latent for the Mochi VAE decoder."""
+    latent = torch.randn(
+        1,
+        ORIGINAL_LATENT_CHANNELS,
+        ORIGINAL_LATENT_DEPTH,
+        ORIGINAL_LATENT_HEIGHT,
+        ORIGINAL_LATENT_WIDTH,
+        dtype=dtype,
+    )
+    return [latent]
+
+
+def load_text_encoder_inputs_full_res(
+    dtype: torch.dtype = torch.bfloat16,
+) -> list:
+    """Original-resolution positional inputs for T5-XXL text encoder."""
+    input_ids = torch.randint(
+        0, ORIGINAL_T5_VOCAB_SIZE, (1, ORIGINAL_MAX_SEQ_LEN), dtype=torch.long
+    )
+    attention_mask = torch.ones(1, ORIGINAL_MAX_SEQ_LEN, dtype=torch.long)
+    return [input_ids, attention_mask]
+
+
+# ============================================================================
+# SPMD shard specifications (transformer)
+# ============================================================================
+
+# (batch, model) mesh shapes by device count.
+MESH_SHAPES = {1: (1, 1), 2: (1, 2), 4: (1, 4), 8: (1, 8), 32: (8, 4)}
+MESH_NAMES = (None, "model")
+
+
+def shard_transformer_specs(transformer) -> dict:
+    """Build tensor -> partition_spec dict for MochiTransformer3DModel.
+
+    Mesh axes: ("batch", "model"). Only "model" is used as a real shard axis
+    here; "batch" is the data-parallel axis and stays replicated, so any dim
+    that shouldn't be sharded is marked None rather than "batch".
+
+    Column-parallel (Q/K/V, FF up):  ("model", None)
+    Row-parallel    (out, FF down):  (None, "model"), bias replicated (None,)
+    patch_embed / proj_out / norms:  replicated (not in specs).
+    """
+    specs: dict = {}
+
+    # patch_embed.proj and proj_out run replicated.
+
+    # Per-block sharding.
+    for block in transformer.transformer_blocks:
+        attn = block.attn1
+
+        # Q/K/V image stream (column-parallel, bias=False in Mochi).
+        specs[attn.to_q.weight] = ("model", None)
+        specs[attn.to_k.weight] = ("model", None)
+        specs[attn.to_v.weight] = ("model", None)
+
+        # Q/K/V text stream (column-parallel, added_proj_bias=False in Mochi).
+        if attn.add_q_proj is not None:
+            specs[attn.add_q_proj.weight] = ("model", None)
+        specs[attn.add_k_proj.weight] = ("model", None)
+        specs[attn.add_v_proj.weight] = ("model", None)
+
+        # Output projections (row-parallel). Bias is replicated: the all-reduce
+        # after row-parallel matmul produces the full output on every chip, so
+        # each chip adds the full bias once.
+        specs[attn.to_out[0].weight] = (None, "model")
+        if attn.to_out[0].bias is not None:
+            specs[attn.to_out[0].bias] = (None,)
+        if not attn.context_pre_only and hasattr(attn, "to_add_out"):
+            specs[attn.to_add_out.weight] = (None, "model")
+            if attn.to_add_out.bias is not None:
+                specs[attn.to_add_out.bias] = (None,)
+
+        # FeedForward (SwiGLU): net[0].proj is Linear(dim, 2*inner) -> column-parallel,
+        # net[2] is Linear(inner, dim) -> row-parallel. Mochi FF bias=False.
+        specs[block.ff.net[0].proj.weight] = ("model", None)
+        specs[block.ff.net[2].weight] = (None, "model")
+        if block.ff_context is not None:
+            specs[block.ff_context.net[0].proj.weight] = ("model", None)
+            specs[block.ff_context.net[2].weight] = (None, "model")
+
+    return specs
+
+
+def shard_vae_decoder_specs(decoder) -> dict:
+    """Build tensor -> partition_spec dict for MochiDecoder3D.
+
+    Megatron-style pairing on each ResBlock's two convs:
+      conv1 (CogVideoXCausalConv3d): column-parallel on out_channels
+      conv2 (CogVideoXCausalConv3d): row-parallel on in_channels, bias replicated
+      norm2 (MochiChunkedGroupNorm3D): channel-sharded
+    norm1, top-level conv_in, proj_out, and per-up-block proj are left replicated.
+    """
+    specs: dict = {}
+
+    def shard_resnet(resnet):
+        # conv1: column-parallel (shard out channels = dim 0 of [O, I, kD, kH, kW])
+        specs[resnet.conv1.conv.weight] = ("model", None, None, None, None)
+        if resnet.conv1.conv.bias is not None:
+            specs[resnet.conv1.conv.bias] = ("model",)
+
+        # GroupNorm between conv1 and conv2 — channel-sharded to match conv1's
+        # output sharding. norm1 sees the (replicated) ResBlock input, so its
+        # weights stay replicated.
+        if resnet.norm2.norm_layer.weight is not None:
+            specs[resnet.norm2.norm_layer.weight] = ("model",)
+        if resnet.norm2.norm_layer.bias is not None:
+            specs[resnet.norm2.norm_layer.bias] = ("model",)
+
+        # conv2: row-parallel; bias is replicated (added after the implicit
+        # all-reduce that follows row-parallel matmul).
+        specs[resnet.conv2.conv.weight] = (None, "model", None, None, None)
+        if resnet.conv2.conv.bias is not None:
+            specs[resnet.conv2.conv.bias] = (None,)
+
+    # block_in (MochiMidBlock3D) — resnets only; attentions are None in decoder.
+    for resnet in decoder.block_in.resnets:
+        shard_resnet(resnet)
+
+    # up_blocks (MochiUpBlock3D) — resnets per block; up_block.proj
+    # (unpatchify linear) is left replicated.
+    for up_block in decoder.up_blocks:
+        for resnet in up_block.resnets:
+            shard_resnet(resnet)
+
+    # block_out (MochiMidBlock3D).
+    for resnet in decoder.block_out.resnets:
+        shard_resnet(resnet)
+
+    return specs


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4640

### Problem description

- The Mochi loader only exposed a small synthetic input shape (`2×12×12`) and had no SPMD shard specs for the transformer, which needs to be extended to bring up Mochi-1 at its original resolution (480×848, 84 frames, ~10B-param transformer) 

### What's changed

- **`utils.py`**: full-resolution input helpers (`load_{transformer,vae_decoder,text_encoder}_inputs_full_res`) driven by `ORIGINAL_LATENT_*` / `ORIGINAL_MAX_SEQ_LEN` constants matching Mochi-1's real 480×848 / 84-frame shape.

- **`utils.py`**: `MESH_SHAPES`, `MESH_NAMES`, and `shard_transformer_specs` for `MochiTransformer3DModel` — column-parallel Q/K/V + FF-up, row-parallel out-projs + FF-down with replicated biases; `patch_embed` / `proj_out` / norms run replicated; handles `context_pre_only` and `add_q_proj is None`.

- **`utils.py`**: `shard_vae_decoder_specs` for `MochiDecoder3D` — Megatron column–row sharding on each ResBlock's two convs (`conv1` column-parallel, `conv2` row-parallel with replicated bias) and channel-sharded `norm2`; `norm1`, top-level `conv_in`, `proj_out`, and per-up-block `proj` left replicated.

- **`loader.py`**: exposes the above via `get_mesh_config()` and `load_shard_spec()`. Text encoder stays single-chip; transformer and VAE decoder use the same mesh shapes. Partition specs use `None` for non-sharded dims (not `"batch"`), so they're correct on any mesh shape, not just `(1, N)`.


### Checklist
- [x] Verified the changes through local testing in WH

### Logs

- [may12_mochi_encoder.log](https://github.com/user-attachments/files/27654716/may12_mochi_encoder.log)
- [may23_mochi_transformer_8_chips.log](https://github.com/user-attachments/files/28176543/may23_mochi_transformer_8_chips_re.log)
- [may23_mochi_vae_decoder_8_chips.log](https://github.com/user-attachments/files/28176546/may23_mochi_vae_decoder_8_chips_re.log)




