### PR TITLE
[Perceiverio_vision] Use named_parameters() in dtype/device to fix Dynamo tracing failure

### DIFF
--- a/perceiverio_vision/pytorch/loader.py
+++ b/perceiverio_vision/pytorch/loader.py
@@ -31,6 +31,39 @@ from .src.utils import MathShim
 pm.np = MathShim()
 
 
+def _install_dynamo_safe_param_props(module: torch.nn.Module) -> None:
+    """Override module.dtype/.device on a single instance to iterate named_parameters().
+
+    Dynamo (torch 2.10.0) has a bug in nn_module.wrap_values that returns an
+    undefined ``named_children`` symbol when tracing module.parameters() /
+    .children() / .buffers() / .modules(). The named_parameters() branch has
+    its own local list and is unaffected.
+
+    Implemented as a per-instance __class__ swap (one fresh subclass per call
+    site) so no transformers/torch package state is mutated globally.
+    """
+    cls = type(module)
+    if getattr(cls, "_tt_xla_dynamo_safe", False):
+        return
+
+    class _DynamoSafe(cls):
+        _tt_xla_dynamo_safe = True
+
+        @property
+        def dtype(self):
+            return next(
+                p.dtype for _, p in self.named_parameters() if p.is_floating_point()
+            )
+
+        @property
+        def device(self):
+            return next(p.device for _, p in self.named_parameters())
+
+    _DynamoSafe.__name__ = cls.__name__
+    _DynamoSafe.__qualname__ = cls.__qualname__
+    module.__class__ = _DynamoSafe
+
+
 class ModelVariant(StrEnum):
     """Available PerceiverIO Vision model variants."""
 
@@ -110,6 +143,11 @@ class ModelLoader(ForgeModel):
 
         # Load the model using the appropriate class
         model = model_class.from_pretrained(pretrained_model_name, **kwargs)
+        # PerceiverModel.forward calls self.invert_attention_mask -> self.dtype,
+        # which triggers a dynamo bug when tracing self.parameters() under
+        # torch.compile. Swap the inner perceiver's class to one whose dtype/
+        # device properties iterate named_parameters() instead.
+        _install_dynamo_safe_param_props(model.perceiver)
         model.eval()
 
         # Initialize image processor for this variant


### PR DESCRIPTION
### Ticket

Fixes [#4657](https://github.com/tenstorrent/tt-xla/issues/4657)

### Problem description
Perceiverio vision variants fail with `torch._dynamo.exc.InternalTorchDynamoError: NameError: cannot access free variable 'named_children' where it is not associated with a value in enclosing scope`

### What's changed

- A workaround was implemented in loader.py via _install_dynamo_safe_param_props, where the model.perceiver instance was reassigned onto a dynamically generated subclass. In this subclass, the dtype and device properties were overridden to iterate over self.named_parameters() instead of self.parameters(). A _tt_xla_dynamo_safe guard was added to prevent double wrapping. 

- The fix works because named_parameters() followed a different Dynamo lowering path that maintained its own local symbol list and did not emit the invalid named_children reference. Functional behavior remained unchanged, since both implementations ultimately selected the first floating-point parameter’s dtype/device. 

-  The workaround was applied only to the specific model instance through a per-instance __class__ swap, ensuring that neither the global transformers nor torch package state was modified.After this patch model successfully passes end-to-end execution. 

### Checklist
- [x] Verify changes by local testing in Wormhole

### Logs
[perceiverio_vision_conv_before_fix.log](https://github.com/user-attachments/files/27719272/perceiverio_vision_conv_before_fix.log)
[perceiverio_vision_conv_after_fix.log](https://github.com/user-attachments/files/27719275/perceiverio_vision_conv_after_fix.log)
