### PR TITLE
prefill_inputs: fix silent KeyError bypass in get_prefill_texts_for_batch

### DIFF
--- a/prefill_inputs.py
+++ b/prefill_inputs.py
@@ -764,8 +764,13 @@ def get_prefill_texts_for_batch(seq_len: int, batch_size: int) -> list:
 
     Returns:
         List of text strings for the batch.
+
+    Raises:
+        KeyError: If seq_len is not supported.
     """
-    return [
-        get_prefill_text(seq_len, i % len(PREFILL_TEXTS[seq_len]))
-        for i in range(batch_size)
-    ]
+    if seq_len not in PREFILL_TEXTS:
+        raise KeyError(
+            f"seq_len {seq_len} not supported. Available: {list(PREFILL_TEXTS.keys())}"
+        )
+    n = len(PREFILL_TEXTS[seq_len])
+    return [get_prefill_text(seq_len, i % n) for i in range(batch_size)]


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`get_prefill_texts_for_batch` directly accessed `PREFILL_TEXTS[seq_len]`
inside its list comprehension to compute the wrapping modulus, before
delegating to `get_prefill_text`. This meant that passing an unsupported
`seq_len` (e.g. 256) raised a raw, undecorated `KeyError: 256` instead
of the descriptive error message already implemented in `get_prefill_text`:

    KeyError: 'seq_len 256 not supported. Available: [128, 1024, 2048, 4096, 8192]'

The validation guard in `get_prefill_text` was therefore silently bypassed
for every call that went through the batch helper.

### What's changed
Added an explicit `seq_len not in PREFILL_TEXTS` guard at the top of
`get_prefill_texts_for_batch`, mirroring the check already present in
`get_prefill_text`. The modulus `n` is now computed only after the guard
passes, removing the direct `PREFILL_TEXTS[seq_len]` access from the
list comprehension. Valid inputs are completely unaffected.

### Checklist
- [ ] New/Existing tests provide coverage for changes