### PR TITLE
Initialize kimi-k2 correction bias

### DIFF
--- a/kimi_k2/pytorch/modified_modeling_deepseek.py
+++ b/kimi_k2/pytorch/modified_modeling_deepseek.py
@@ -409,6 +409,14 @@ class MoEGate(nn.Module):
         import torch.nn.init as init
 
         init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        # Modified: The e_score_correction_bias is uninitialized as torch.empty(...)
+        # which causes non-determinism in routing topk between pytest invocations.
+        # Initialize it with a uniform distribution to ensure deterministic behavior
+        # under torch.manual_seed when random weights are used.
+        if getattr(self, "e_score_correction_bias", None) is not None:
+            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.e_score_correction_bias, -bound, bound)
 
     def forward(self, hidden_states):
         bsz, seq_len, h = hidden_states.shape


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/4632

### Problem description
The `e_score_correction_bias` for kimi-k2 is uninitialized as `torch.empty(...)` which means that `torch.manual_seed` won't affect it. This causes non-determinism in routing topk between pytest invocations.

### What's changed
Initialize `e_score_correction_bias` with a uniform distribution to ensure deterministic behavior under torch.manual_seed when random weights are used. Follows what is already done in the modified_model for deepseek-v3.2-exp.

### Checklist
- [x] New/Existing tests provide coverage for changes
