### PR TITLE
Add Playground v2.5 component loader (TextEncoder, TextEncoder2, Unet, Vae)

### DIFF
--- a/playground_v2_5/__init__.py
+++ b/playground_v2_5/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/playground_v2_5/pytorch/__init__.py
+++ b/playground_v2_5/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant

--- a/playground_v2_5/pytorch/loader.py
+++ b/playground_v2_5/pytorch/loader.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Playground v2.5 (SDXL-based) component loader.
+
+Each variant corresponds to one independently loadable component:
+  - TextEncoder   → CLIPTextModel                params=0.123B
+  - TextEncoder2  → CLIPTextModelWithProjection  params=0.695B
+  - Unet          → UNet2DConditionModel         params=2.567B
+  - Vae           → VAEDecoderWrapper            params=0.084B
+"""
+
+from typing import Optional
+
+import torch
+
+from ...base import ForgeModel
+from ...config import (
+    Framework,
+    ModelConfig,
+    ModelGroup,
+    ModelInfo,
+    ModelSource,
+    ModelTask,
+    StrEnum,
+)
+from .src.model_utils import (
+    CROSS_ATTN_DIM,
+    CLIP_VOCAB_SIZE,
+    DTYPE,
+    LATENT_CHANNELS,
+    LATENT_H,
+    LATENT_W,
+    PLAYGROUND_REPO_ID,
+    POOLED_TEXT_EMBED_DIM,
+    TEXT_SEQ_LEN,
+    TIME_IDS_DIM,
+    TextEncoder2Wrapper,
+    TextEncoderWrapper,
+    UNet2DConditionWrapper,
+    VAEDecoderWrapper,
+    load_text_encoder,
+    load_text_encoder_2,
+    load_unet,
+    load_vae,
+)
+
+
+class ModelVariant(StrEnum):
+    """Loadable components of the Playground v2.5 pipeline."""
+
+    TEXT_ENCODER = "TextEncoder"
+    TEXT_ENCODER_2 = "TextEncoder2"
+    UNET = "Unet"
+    VAE = "Vae"
+
+
+class ModelLoader(ForgeModel):
+    """Load individual Playground v2.5 components without pulling the full pipeline.
+
+    All weights come from playgroundai/playground-v2.5-1024px-aesthetic.
+    """
+
+    _VARIANTS = {
+        ModelVariant.TEXT_ENCODER: ModelConfig(
+            pretrained_model_name=PLAYGROUND_REPO_ID
+        ),
+        ModelVariant.TEXT_ENCODER_2: ModelConfig(
+            pretrained_model_name=PLAYGROUND_REPO_ID
+        ),
+        ModelVariant.UNET: ModelConfig(pretrained_model_name=PLAYGROUND_REPO_ID),
+        ModelVariant.VAE: ModelConfig(pretrained_model_name=PLAYGROUND_REPO_ID),
+    }
+    DEFAULT_VARIANT = ModelVariant.UNET
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        task = (
+            ModelTask.NLP_EMBED_GEN
+            if variant in (ModelVariant.TEXT_ENCODER, ModelVariant.TEXT_ENCODER_2)
+            else ModelTask.CONDITIONAL_GENERATION
+        )
+        return ModelInfo(
+            model="PlaygroundV2_5",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=task,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, *, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Load and return the component for this variant as a torch.nn.Module.
+
+        Returns:
+            TEXT_ENCODER    → TextEncoderWrapper        (returns hidden_states[-2])
+            TEXT_ENCODER_2  → TextEncoder2Wrapper       (returns (hidden_states[-2], text_embeds))
+            UNET            → UNet2DConditionWrapper    (returns noise_pred)
+            VAE             → VAEDecoderWrapper         (returns decoded image)
+        """
+        model_name = self._variant_config.pretrained_model_name
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return TextEncoderWrapper(load_text_encoder(model_name, dtype))
+        if self._variant == ModelVariant.TEXT_ENCODER_2:
+            return TextEncoder2Wrapper(load_text_encoder_2(model_name, dtype))
+        if self._variant == ModelVariant.UNET:
+            return UNet2DConditionWrapper(load_unet(model_name, dtype))
+        if self._variant == ModelVariant.VAE:
+            return VAEDecoderWrapper(load_vae(model_name, dtype))
+
+        raise ValueError(f"Unknown variant: {self._variant}")
+
+    def load_inputs(self, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Return a list of synthetic input tensors for the active component.
+
+        TEXT_ENCODER    → [input_ids (1,77) int64]
+        TEXT_ENCODER_2  → [input_ids (1,77) int64]
+        UNET            → [sample (2,4,128,128), timestep scalar, encoder_hidden_states (2,77,2048),
+                           text_embeds (2,1280), time_ids (2,6)]
+        VAE             → [z (1,4,128,128)]
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant in (ModelVariant.TEXT_ENCODER, ModelVariant.TEXT_ENCODER_2):
+            input_ids = torch.randint(
+                0, CLIP_VOCAB_SIZE, (1, TEXT_SEQ_LEN), dtype=torch.long
+            )
+            return [input_ids]
+
+        if self._variant == ModelVariant.UNET:
+            sample = torch.randn(2, LATENT_CHANNELS, LATENT_H, LATENT_W, dtype=dtype)
+            timestep = torch.tensor(1.0, dtype=dtype)
+            encoder_hidden_states = torch.randn(
+                2, TEXT_SEQ_LEN, CROSS_ATTN_DIM, dtype=dtype
+            )
+            text_embeds = torch.randn(2, POOLED_TEXT_EMBED_DIM, dtype=dtype)
+            time_ids = torch.randn(2, TIME_IDS_DIM, dtype=dtype)
+            return [sample, timestep, encoder_hidden_states, text_embeds, time_ids]
+
+        if self._variant == ModelVariant.VAE:
+            z = torch.randn(1, LATENT_CHANNELS, LATENT_H, LATENT_W, dtype=dtype)
+            return [z]
+
+        raise ValueError(f"Unknown variant: {self._variant}")

--- a/playground_v2_5/pytorch/src/__init__.py
+++ b/playground_v2_5/pytorch/src/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/playground_v2_5/pytorch/src/model_utils.py
+++ b/playground_v2_5/pytorch/src/model_utils.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Shape constants, component loaders, and wrappers for Playground v2.5."""
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Model identity
+# ---------------------------------------------------------------------------
+
+PLAYGROUND_REPO_ID = "playgroundai/playground-v2.5-1024px-aesthetic"
+DTYPE = torch.float32
+
+# ---------------------------------------------------------------------------
+# Inference shape constants
+# ---------------------------------------------------------------------------
+
+HEIGHT = 1024
+WIDTH = 1024
+VAE_SCALE = 8
+
+LATENT_H = HEIGHT // VAE_SCALE  # 128
+LATENT_W = WIDTH // VAE_SCALE  # 128
+LATENT_CHANNELS = 4
+
+TEXT_SEQ_LEN = 77  # CLIP model_max_length
+CLIP_VOCAB_SIZE = 49408
+
+# Hidden sizes (per text_encoder)
+TEXT_ENCODER_1_HIDDEN = 768
+TEXT_ENCODER_2_HIDDEN = 1280
+
+# Concatenated cross-attention dim seen by UNet (768 + 1280)
+CROSS_ATTN_DIM = TEXT_ENCODER_1_HIDDEN + TEXT_ENCODER_2_HIDDEN  # 2048
+
+# SDXL added conditioning: pooled text_embeds (1280) + time_ids (6 features)
+POOLED_TEXT_EMBED_DIM = TEXT_ENCODER_2_HIDDEN  # 1280
+TIME_IDS_DIM = 6
+
+
+# ---------------------------------------------------------------------------
+# Component loaders
+# ---------------------------------------------------------------------------
+
+
+def load_text_encoder(pretrained_model_name: str, dtype: torch.dtype):
+    """Load the primary CLIPTextModel from the text_encoder subfolder."""
+    from transformers import CLIPTextModel
+
+    return CLIPTextModel.from_pretrained(
+        pretrained_model_name,
+        subfolder="text_encoder",
+        torch_dtype=dtype,
+    ).eval()
+
+
+def load_text_encoder_2(pretrained_model_name: str, dtype: torch.dtype):
+    """Load the secondary CLIPTextModelWithProjection from text_encoder_2."""
+    from transformers import CLIPTextModelWithProjection
+
+    return CLIPTextModelWithProjection.from_pretrained(
+        pretrained_model_name,
+        subfolder="text_encoder_2",
+        torch_dtype=dtype,
+    ).eval()
+
+
+def load_unet(pretrained_model_name: str, dtype: torch.dtype):
+    """Load the UNet2DConditionModel from the unet subfolder."""
+    from diffusers import UNet2DConditionModel
+
+    return UNet2DConditionModel.from_pretrained(
+        pretrained_model_name,
+        subfolder="unet",
+        torch_dtype=dtype,
+    ).eval()
+
+
+def load_vae(pretrained_model_name: str, dtype: torch.dtype):
+    """Load the AutoencoderKL from the vae subfolder."""
+    from diffusers import AutoencoderKL
+
+    return AutoencoderKL.from_pretrained(
+        pretrained_model_name,
+        subfolder="vae",
+        torch_dtype=dtype,
+    ).eval()
+
+
+# ---------------------------------------------------------------------------
+# Wrapper modules
+# ---------------------------------------------------------------------------
+
+
+class TextEncoderWrapper(torch.nn.Module):
+    """Return the penultimate hidden state.
+
+    The pipeline consumes `prompt_embeds.hidden_states[-2]` for cross-attention.
+    """
+
+    def __init__(self, text_encoder):
+        super().__init__()
+        self.text_encoder = text_encoder
+
+    def forward(self, input_ids):
+        out = self.text_encoder(input_ids, output_hidden_states=True)
+        return out.hidden_states[-2]
+
+
+class TextEncoder2Wrapper(torch.nn.Module):
+    """Return (penultimate hidden state, pooled text_embeds).
+
+    Pipeline uses hidden_states[-2] for cross-attention and text_embeds for the
+    SDXL `added_cond_kwargs["text_embeds"]` input.
+    """
+
+    def __init__(self, text_encoder_2):
+        super().__init__()
+        self.text_encoder_2 = text_encoder_2
+
+    def forward(self, input_ids):
+        out = self.text_encoder_2(input_ids, output_hidden_states=True)
+        return out.hidden_states[-2], out.text_embeds
+
+
+class UNet2DConditionWrapper(torch.nn.Module):
+    """Flatten UNet2DConditionModel inputs (no dict kwargs) and return noise_pred.
+
+    Reassembles `added_cond_kwargs={"text_embeds", "time_ids"}` internally so
+    the wrapper signature is pure tensor positional args.
+    """
+
+    def __init__(self, unet):
+        super().__init__()
+        self.unet = unet
+
+    def forward(self, sample, timestep, encoder_hidden_states, text_embeds, time_ids):
+        added_cond_kwargs = {"text_embeds": text_embeds, "time_ids": time_ids}
+        return self.unet(
+            sample,
+            timestep,
+            encoder_hidden_states=encoder_hidden_states,
+            added_cond_kwargs=added_cond_kwargs,
+            return_dict=False,
+        )[0]
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    """Expose only the decoder half of AutoencoderKL."""
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        return self.vae.decode(z, return_dict=False)[0]


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4704


### Problem description

- Add component loaders for the Playground v2.5 (1024px aesthetic) pipeline

### What's changed

New package: playground_v2_5/pytorch/

| File | Purpose |
| --- | --- |
| `loader.py` | `ForgeModel` subclass with four variants (`TextEncoder`, `TextEncoder2`, `Unet`, `Vae`), each loading only its own component via `from_pretrained(subfolder=...)` |
| `src/model_utils.py` | Component loaders, wrapper modules, inference shape constants |

Component sources (all from `playgroundai/playground-v2.5-1024px-aesthetic`):

| Variant | Class | Params |
| --- | --- | --- |
| `TextEncoder` | `CLIPTextModel` (ViT-L/14) via `transformers` | 0.123 B |
| `TextEncoder2` | `CLIPTextModelWithProjection` (OpenCLIP ViT-bigG/14) via `transformers` | 0.695 B |
| `Unet` | `UNet2DConditionModel` | 2.567 B |
| `Vae` | `AutoencoderKL` | 0.084 B |

Each component is loaded independently — no full pipeline is instantiated.

ModelLoader API:

- `load_model(dtype_override)` — returns the component as a `torch.nn.Module`
- `load_inputs(dtype_override)` — returns synthetic input tensors matched to the component's forward signature

No sharding helpers (no `get_mesh_config` / `load_shard_spec`): each component can fit on a single chip.

Wrapper modules in `src/model_utils.py`:

- `TextEncoderWrapper` — returns `hidden_states[-2]` only (the penultimate hidden state SDXL feeds to UNet cross-attention; the pooled output is discarded for TE1)
- `TextEncoder2Wrapper` — returns `(hidden_states[-2], text_embeds)` so both the cross-attention input and the SDXL `added_cond_kwargs["text_embeds"]` pooled input are exposed as plain tensors
- `UNet2DConditionWrapper` — flattens the UNet forward to tensor-only positional inputs (`sample`, `timestep`, `encoder_hidden_states`, `text_embeds`, `time_ids`); rebuilds `added_cond_kwargs` dict internally → `noise_pred`
- `VAEDecoderWrapper` — exposes decoder-only path `(z) → tensor`, bypassing the default encode+decode round-trip

**Note:** Wrappers expose the same input/output contract as the real inference pipeline - returning only the tensors downstream stages consume, and routing each positional input to the correct named kwarg internally (so run_graph_test can pass a flat tensor list without misaligning args against the model's real forward signature).

### Checklist
- [x] Verify changes by local testing in Wormhole

### Logs

- [component_logs.zip](https://github.com/user-attachments/files/27772128/component_logs.zip)
