### PR TITLE
Add HiDream-I1-Fast component loader

### DIFF
--- a/hidream_i1/__init__.py
+++ b/hidream_i1/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/hidream_i1/pytorch/__init__.py
+++ b/hidream_i1/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant

--- a/hidream_i1/pytorch/loader.py
+++ b/hidream_i1/pytorch/loader.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HiDream-I1-Fast component loader.
+
+Each variant corresponds to one independently loadable component:
+  - TextEncoder    → CLIPTextModelWithProjection (CLIP ViT-L/14)         params=0.123 B
+  - TextEncoder2   → CLIPTextModelWithProjection (OpenCLIP ViT-bigG/14)  params=0.695 B
+  - TextEncoder3   → T5EncoderModel (T5 v1.1 XXL encoder)                params=4.6 B
+  - TextEncoder4   → LlamaForCausalLM (Llama-3.1-8B-Instruct)            params=8.0 B
+  - Transformer    → HiDreamImageTransformer2DModel (Sparse-MoE MM-DiT)  params=17 B
+  - Vae            → AutoencoderKL (FLUX-derived 16-channel latent)      params=0.084 B
+
+"""
+
+from typing import Optional
+
+import torch
+
+from ...base import ForgeModel
+from ...config import (
+    Framework,
+    ModelConfig,
+    ModelGroup,
+    ModelInfo,
+    ModelSource,
+    ModelTask,
+    StrEnum,
+)
+from .src.model_utils import (
+    CLIP_VOCAB_SIZE,
+    DTYPE,
+    HIDREAM_REPO_ID,
+    LATENT_CHANNELS,
+    LATENT_H,
+    LATENT_W,
+    LLAMA_HIDDEN,
+    LLAMA_NUM_LAYERS,
+    LLAMA_REPO_ID,
+    LLAMA_VOCAB_SIZE,
+    MAX_SEQ_LEN,
+    MESH_NAMES,
+    MESH_SHAPES,
+    POOLED_TEXT_EMB_DIM,
+    T5_HIDDEN,
+    T5_VOCAB_SIZE,
+    CLIPPooledWrapper,
+    HiDreamTransformerWrapper,
+    LlamaStackedHiddenWrapper,
+    T5EncoderWrapper,
+    VAEDecoderWrapper,
+    load_text_encoder,
+    load_text_encoder_2,
+    load_text_encoder_3,
+    load_text_encoder_4,
+    load_transformer,
+    load_vae,
+    shard_hidream_transformer_specs,
+    shard_llama_specs,
+)
+
+
+class ModelVariant(StrEnum):
+    """Loadable components of the HiDream-I1-Fast pipeline."""
+
+    TEXT_ENCODER = "TextEncoder"
+    TEXT_ENCODER_2 = "TextEncoder2"
+    TEXT_ENCODER_3 = "TextEncoder3"
+    TEXT_ENCODER_4 = "TextEncoder4"
+    TRANSFORMER = "Transformer"
+    VAE = "Vae"
+
+
+class ModelLoader(ForgeModel):
+    """Load individual HiDream-I1-Fast components without pulling the full pipeline.
+
+    text_encoder, text_encoder_2, text_encoder_3, transformer, and vae weights
+    come from HiDream-ai/HiDream-I1-Fast. text_encoder_4 (Llama-3.1-8B) is loaded
+    separately from the Meta repo (HiDream snapshot does not ship Llama).
+    """
+
+    _VARIANTS = {
+        ModelVariant.TEXT_ENCODER: ModelConfig(pretrained_model_name=HIDREAM_REPO_ID),
+        ModelVariant.TEXT_ENCODER_2: ModelConfig(pretrained_model_name=HIDREAM_REPO_ID),
+        ModelVariant.TEXT_ENCODER_3: ModelConfig(pretrained_model_name=HIDREAM_REPO_ID),
+        ModelVariant.TEXT_ENCODER_4: ModelConfig(pretrained_model_name=LLAMA_REPO_ID),
+        ModelVariant.TRANSFORMER: ModelConfig(pretrained_model_name=HIDREAM_REPO_ID),
+        ModelVariant.VAE: ModelConfig(pretrained_model_name=HIDREAM_REPO_ID),
+    }
+    DEFAULT_VARIANT = ModelVariant.TRANSFORMER
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        text_variants = (
+            ModelVariant.TEXT_ENCODER,
+            ModelVariant.TEXT_ENCODER_2,
+            ModelVariant.TEXT_ENCODER_3,
+            ModelVariant.TEXT_ENCODER_4,
+        )
+        task = (
+            ModelTask.NLP_EMBED_GEN
+            if variant in text_variants
+            else ModelTask.CONDITIONAL_GENERATION
+        )
+        return ModelInfo(
+            model="HiDreamI1Fast",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=task,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, *, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Load and return the component for this variant as a torch.nn.Module."""
+        model_name = self._variant_config.pretrained_model_name
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return CLIPPooledWrapper(load_text_encoder(model_name, dtype))
+        if self._variant == ModelVariant.TEXT_ENCODER_2:
+            return CLIPPooledWrapper(load_text_encoder_2(model_name, dtype))
+        if self._variant == ModelVariant.TEXT_ENCODER_3:
+            return T5EncoderWrapper(load_text_encoder_3(model_name, dtype))
+        if self._variant == ModelVariant.TEXT_ENCODER_4:
+            return LlamaStackedHiddenWrapper(load_text_encoder_4(model_name, dtype))
+        if self._variant == ModelVariant.TRANSFORMER:
+            return HiDreamTransformerWrapper(load_transformer(model_name, dtype))
+        if self._variant == ModelVariant.VAE:
+            return VAEDecoderWrapper(load_vae(model_name, dtype))
+
+        raise ValueError(f"Unknown variant: {self._variant}")
+
+    def get_mesh_config(self, num_devices: int):
+        """Return (mesh_shape, mesh_names) for a ("batch", "model") 2D mesh.
+
+        Sharded variants: TEXT_ENCODER_4 and TRANSFORMER. The other four fit on
+        a single chip and always map to (1, 1).
+
+        Supported device counts for sharded variants: 1, 2, 4, 8, 32.
+        """
+        sharded_variants = (ModelVariant.TEXT_ENCODER_4, ModelVariant.TRANSFORMER)
+        if self._variant not in sharded_variants:
+            return (1, 1), MESH_NAMES
+
+        if num_devices not in MESH_SHAPES:
+            raise ValueError(
+                f"Unsupported device count: {num_devices}. "
+                f"Expected one of {sorted(MESH_SHAPES)}."
+            )
+        return MESH_SHAPES[num_devices], MESH_NAMES
+
+    def load_shard_spec(self, model):
+        """Return tensor → partition_spec dict for the active component.
+
+        Expects the same model object returned by load_model():
+          TEXT_ENCODER_4 → LlamaStackedHiddenWrapper (specs built from .llama)
+          TRANSFORMER    → HiDreamTransformerWrapper (specs built from .transformer)
+          Others         → None (single-chip, no sharding)
+        """
+        if self._variant == ModelVariant.TEXT_ENCODER_4:
+            return shard_llama_specs(model.llama)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return shard_hidream_transformer_specs(model.transformer)
+        return None
+
+    def load_inputs(self, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Return a list of synthetic input tensors for the active component.
+
+        TEXT_ENCODER    → [input_ids (1,128) int64]
+        TEXT_ENCODER_2  → [input_ids (1,128) int64]
+        TEXT_ENCODER_3  → [input_ids (1,128) int64, attention_mask (1,128) int64]
+        TEXT_ENCODER_4  → [input_ids (1,128) int64, attention_mask (1,128) int64]
+        TRANSFORMER     → [hidden_states (1,16,128,128), timesteps (1,), enc_t5 (1,128,4096),
+                           enc_llama3 (32,1,128,4096), pooled_embeds (1,2048)]
+        VAE             → [z (1,16,128,128)]
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            input_ids = torch.randint(
+                0, CLIP_VOCAB_SIZE, (1, MAX_SEQ_LEN), dtype=torch.long
+            )
+            return [input_ids]
+
+        if self._variant == ModelVariant.TEXT_ENCODER_2:
+            input_ids = torch.randint(
+                0, CLIP_VOCAB_SIZE, (1, MAX_SEQ_LEN), dtype=torch.long
+            )
+            return [input_ids]
+
+        if self._variant == ModelVariant.TEXT_ENCODER_3:
+            input_ids = torch.randint(
+                0, T5_VOCAB_SIZE, (1, MAX_SEQ_LEN), dtype=torch.long
+            )
+            attention_mask = torch.ones(1, MAX_SEQ_LEN, dtype=torch.long)
+            return [input_ids, attention_mask]
+
+        if self._variant == ModelVariant.TEXT_ENCODER_4:
+            input_ids = torch.randint(
+                0, LLAMA_VOCAB_SIZE, (1, MAX_SEQ_LEN), dtype=torch.long
+            )
+            attention_mask = torch.ones(1, MAX_SEQ_LEN, dtype=torch.long)
+            return [input_ids, attention_mask]
+
+        if self._variant == ModelVariant.TRANSFORMER:
+            hidden_states = torch.randn(
+                1, LATENT_CHANNELS, LATENT_H, LATENT_W, dtype=dtype
+            )
+            timesteps = torch.tensor([1.0], dtype=torch.float32)
+            encoder_hidden_states_t5 = torch.randn(
+                1, MAX_SEQ_LEN, T5_HIDDEN, dtype=dtype
+            )
+            encoder_hidden_states_llama3 = torch.randn(
+                LLAMA_NUM_LAYERS, 1, MAX_SEQ_LEN, LLAMA_HIDDEN, dtype=dtype
+            )
+            pooled_embeds = torch.randn(1, POOLED_TEXT_EMB_DIM, dtype=dtype)
+            return [
+                hidden_states,
+                timesteps,
+                encoder_hidden_states_t5,
+                encoder_hidden_states_llama3,
+                pooled_embeds,
+            ]
+
+        if self._variant == ModelVariant.VAE:
+            z = torch.randn(1, LATENT_CHANNELS, LATENT_H, LATENT_W, dtype=dtype)
+            return [z]
+
+        raise ValueError(f"Unknown variant: {self._variant}")

--- a/hidream_i1/pytorch/src/__init__.py
+++ b/hidream_i1/pytorch/src/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/hidream_i1/pytorch/src/model_utils.py
+++ b/hidream_i1/pytorch/src/model_utils.py
@@ -1,0 +1,387 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Component loaders and wrappers for HiDream-I1-Fast.
+
+Model: HiDream-ai/HiDream-I1-Fast (Sparse-MoE MM-DiT, guidance- + step-distilled)
+Components:
+  - text_encoder    : CLIPTextModelWithProjection (CLIP ViT-L/14, ~0.123 B)
+  - text_encoder_2  : CLIPTextModelWithProjection (OpenCLIP ViT-bigG/14, ~0.695 B)
+  - text_encoder_3  : T5EncoderModel (T5 v1.1 XXL encoder, ~4.6 B)
+  - text_encoder_4  : LlamaForCausalLM (Llama-3.1-8B-Instruct, ~8.0 B)
+  - transformer     : HiDreamImageTransformer2DModel (Sparse-MoE MM-DiT, ~17 B)
+  - vae             : AutoencoderKL (FLUX-derived 16-channel latent, ~0.084 B)
+"""
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Model identity
+# ---------------------------------------------------------------------------
+
+HIDREAM_REPO_ID = "HiDream-ai/HiDream-I1-Fast"
+LLAMA_REPO_ID = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+DTYPE = torch.float32
+
+# ---------------------------------------------------------------------------
+# Inference shape constants (HiDream-I1-Fast @ 1024x1024)
+# ---------------------------------------------------------------------------
+
+HEIGHT = 1024
+WIDTH = 1024
+VAE_SCALE = 8
+
+LATENT_H = HEIGHT // VAE_SCALE  # 128
+LATENT_W = WIDTH // VAE_SCALE  # 128
+LATENT_CHANNELS = 16
+
+MAX_SEQ_LEN = 128  # pipeline truncates all text encoders to 128
+
+# CLIP-L (text_encoder) and CLIP-G (text_encoder_2) — pooled output dims
+CLIP_L_HIDDEN = 768
+CLIP_G_HIDDEN = 1280
+CLIP_VOCAB_SIZE = 49408
+
+# T5 (text_encoder_3) — full token sequence
+T5_HIDDEN = 4096
+T5_VOCAB_SIZE = 32128
+
+# Llama (text_encoder_4) — outputs stacked hidden states from all 32 layers
+LLAMA_HIDDEN = 4096
+LLAMA_NUM_LAYERS = 32
+LLAMA_VOCAB_SIZE = 128256
+
+# Transformer (DiT) — conditioning shapes
+POOLED_TEXT_EMB_DIM = CLIP_L_HIDDEN + CLIP_G_HIDDEN  # 2048
+
+# ---------------------------------------------------------------------------
+# Component loaders
+# ---------------------------------------------------------------------------
+
+
+def load_text_encoder(pretrained_model_name: str, dtype: torch.dtype):
+    """Load CLIP-L (text_encoder subfolder) as CLIPTextModelWithProjection."""
+    from transformers import CLIPTextModelWithProjection
+
+    return CLIPTextModelWithProjection.from_pretrained(
+        pretrained_model_name,
+        subfolder="text_encoder",
+        torch_dtype=dtype,
+    ).eval()
+
+
+def load_text_encoder_2(pretrained_model_name: str, dtype: torch.dtype):
+    """Load CLIP-G (text_encoder_2 subfolder) as CLIPTextModelWithProjection."""
+    from transformers import CLIPTextModelWithProjection
+
+    return CLIPTextModelWithProjection.from_pretrained(
+        pretrained_model_name,
+        subfolder="text_encoder_2",
+        torch_dtype=dtype,
+    ).eval()
+
+
+def load_text_encoder_3(pretrained_model_name: str, dtype: torch.dtype):
+    """Load T5-XXL encoder (text_encoder_3 subfolder)."""
+    from transformers import T5EncoderModel
+
+    return T5EncoderModel.from_pretrained(
+        pretrained_model_name,
+        subfolder="text_encoder_3",
+        torch_dtype=dtype,
+    ).eval()
+
+
+def load_text_encoder_4(pretrained_model_name: str, dtype: torch.dtype):
+    """Load Llama-3.1-8B-Instruct as text_encoder_4.
+
+    Loaded from the standalone Meta repo (HiDream's pipeline expects the user to
+    supply this; the snapshot does not ship Llama weights).
+    """
+    from transformers import LlamaForCausalLM
+
+    return LlamaForCausalLM.from_pretrained(
+        pretrained_model_name,
+        output_hidden_states=True,
+        output_attentions=True,
+        torch_dtype=dtype,
+    ).eval()
+
+
+def load_transformer(pretrained_model_name: str, dtype: torch.dtype):
+    """Load HiDreamImageTransformer2DModel from the transformer subfolder."""
+    from diffusers import HiDreamImageTransformer2DModel
+
+    return HiDreamImageTransformer2DModel.from_pretrained(
+        pretrained_model_name,
+        subfolder="transformer",
+        torch_dtype=dtype,
+    ).eval()
+
+
+def load_vae(pretrained_model_name: str, dtype: torch.dtype):
+    """Load AutoencoderKL from the vae subfolder."""
+    from diffusers import AutoencoderKL
+
+    return AutoencoderKL.from_pretrained(
+        pretrained_model_name,
+        subfolder="vae",
+        torch_dtype=dtype,
+    ).eval()
+
+
+# ---------------------------------------------------------------------------
+# Wrapper modules — simplify component forward signatures to positional tensors.
+# Each wrapper mimics what the HiDream pipeline does at the call site.
+# ---------------------------------------------------------------------------
+
+
+class CLIPPooledWrapper(torch.nn.Module):
+    """Return the pooled CLIP embedding (text_embeds).
+
+    Used for both CLIP-L (text_encoder, hidden=768) and CLIP-G (text_encoder_2,
+    hidden=1280). Mirrors `_get_clip_prompt_embeds` which discards hidden states
+    and keeps only `prompt_embeds[0]` (the projected pooled output of
+    CLIPTextModelWithProjection).
+    """
+
+    def __init__(self, text_encoder):
+        super().__init__()
+        self.text_encoder = text_encoder
+
+    def forward(self, input_ids):
+        out = self.text_encoder(input_ids, output_hidden_states=True)
+        return out[0]
+
+
+class T5EncoderWrapper(torch.nn.Module):
+    """Return T5 last hidden state.
+
+    Mirrors `_get_t5_prompt_embeds`: `self.text_encoder_3(input_ids, attention_mask=...)[0]`.
+    """
+
+    def __init__(self, t5_encoder):
+        super().__init__()
+        self.t5_encoder = t5_encoder
+
+    def forward(self, input_ids, attention_mask):
+        return self.t5_encoder(input_ids, attention_mask=attention_mask)[0]
+
+
+class LlamaStackedHiddenWrapper(torch.nn.Module):
+    """Stack all Llama hidden states (skipping the embedding output).
+
+    Mirrors `_get_llama3_prompt_embeds`: takes `outputs.hidden_states[1:]` and
+    stacks along a new leading dim.
+    """
+
+    def __init__(self, llama):
+        super().__init__()
+        self.llama = llama
+
+    def forward(self, input_ids, attention_mask):
+        outputs = self.llama(
+            input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+            output_attentions=True,
+        )
+        stacked = torch.stack(outputs.hidden_states[1:], dim=0)
+        return stacked
+
+
+class HiDreamTransformerWrapper(torch.nn.Module):
+    """Flatten the DiT forward signature to pure positional tensors.
+
+    Inputs match the pipeline call site exactly. Returns the raw transformer
+    output (noise_pred) before the pipeline's sign flip.
+    """
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+
+    def forward(
+        self,
+        hidden_states,
+        timesteps,
+        encoder_hidden_states_t5,
+        encoder_hidden_states_llama3,
+        pooled_embeds,
+    ):
+        return self.transformer(
+            hidden_states=hidden_states,
+            timesteps=timesteps,
+            encoder_hidden_states_t5=encoder_hidden_states_t5,
+            encoder_hidden_states_llama3=encoder_hidden_states_llama3,
+            pooled_embeds=pooled_embeds,
+            return_dict=False,
+        )[0]
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    """Expose only the decoder half of AutoencoderKL as (z) -> tensor."""
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+# ---------------------------------------------------------------------------
+# SPMD shard specifications
+# ---------------------------------------------------------------------------
+
+# (batch, model) mesh shapes by device count.
+# Matches krea_realtime's convention.
+MESH_SHAPES = {32: (8, 4), 8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
+MESH_NAMES = ("batch", "model")
+
+
+def shard_llama_specs(llama) -> dict:
+    """Shard specs for LlamaForCausalLM (text_encoder_4).
+
+    Mesh axes: ("batch", "model")
+    Column-parallel (Q, K, V, gate, up):  ("model", "batch")
+    Row-parallel   (O, down):             ("batch", "model")
+    LayerNorms (RMSNorm) sharded along batch.
+    """
+    specs = {}
+
+    base = llama.model  # LlamaModel
+    specs[base.embed_tokens.weight] = (None, "batch")
+
+    for layer in base.layers:
+        attn = layer.self_attn
+        specs[attn.q_proj.weight] = ("model", "batch")
+        specs[attn.k_proj.weight] = ("model", "batch")
+        specs[attn.v_proj.weight] = ("model", "batch")
+        specs[attn.o_proj.weight] = ("batch", "model")
+
+        mlp = layer.mlp
+        specs[mlp.gate_proj.weight] = ("model", "batch")
+        specs[mlp.up_proj.weight] = ("model", "batch")
+        specs[mlp.down_proj.weight] = ("batch", "model")
+
+        specs[layer.input_layernorm.weight] = ("batch",)
+        specs[layer.post_attention_layernorm.weight] = ("batch",)
+
+    specs[base.norm.weight] = ("batch",)
+    # lm_head is unused at inference (only hidden_states matter), but keep it
+    # sharded so weight loading is balanced if it ends up materialized.
+    if getattr(llama, "lm_head", None) is not None:
+        specs[llama.lm_head.weight] = ("model", "batch")
+    return specs
+
+
+def shard_hidream_transformer_specs(transformer) -> dict:
+    """Shard specs for HiDreamImageTransformer2DModel.
+
+    Mesh axes: ("batch", "model")
+    Attention: column-parallel Q/K/V (("model", "batch")), row-parallel O.
+    MoE experts: w1, w3 column-parallel; w2 row-parallel.
+    Text-stream FF in double-stream blocks: same as MoE expert pattern.
+    adaLN / RMSNorm / caption_projection sharded along batch.
+    """
+    specs = {}
+
+    # Patch embedder: Linear(in_channels * patch_size^2 -> inner_dim).
+    specs[transformer.x_embedder.proj.weight] = ("model", "batch")
+    specs[transformer.x_embedder.proj.bias] = ("model",)
+
+    # Timestep embedder (TimestepEmbedding has linear_1 + linear_2).
+    t_emb = transformer.t_embedder.timestep_embedder
+    specs[t_emb.linear_1.weight] = ("model", "batch")
+    specs[t_emb.linear_1.bias] = ("model",)
+    specs[t_emb.linear_2.weight] = ("batch", "model")
+    specs[t_emb.linear_2.bias] = ("batch",)
+
+    # Pooled embedder (CLIP-L+G pooled -> inner_dim).
+    p_emb = transformer.p_embedder.pooled_embedder
+    specs[p_emb.linear_1.weight] = ("model", "batch")
+    specs[p_emb.linear_1.bias] = ("model",)
+    specs[p_emb.linear_2.weight] = ("batch", "model")
+    specs[p_emb.linear_2.bias] = ("batch",)
+
+    # Caption projection (T5 + Llama-per-layer -> inner_dim).
+    # TextProjection module has a `linear` submodule based on diffusers source.
+    for proj in transformer.caption_projection:
+        # Each TextProjection wraps a Linear named `linear`.
+        if hasattr(proj, "linear"):
+            specs[proj.linear.weight] = ("model", "batch")
+            if proj.linear.bias is not None:
+                specs[proj.linear.bias] = ("model",)
+
+    def _shard_attention(attn, has_text_stream: bool):
+        # Image stream Q/K/V/O.
+        specs[attn.to_q.weight] = ("model", "batch")
+        specs[attn.to_q.bias] = ("model",)
+        specs[attn.to_k.weight] = ("model", "batch")
+        specs[attn.to_k.bias] = ("model",)
+        specs[attn.to_v.weight] = ("model", "batch")
+        specs[attn.to_v.bias] = ("model",)
+        specs[attn.to_out.weight] = ("batch", "model")
+        specs[attn.to_out.bias] = ("batch",)
+        if attn.q_rms_norm.weight is not None:
+            specs[attn.q_rms_norm.weight] = ("batch",)
+        if attn.k_rms_norm.weight is not None:
+            specs[attn.k_rms_norm.weight] = ("batch",)
+        if has_text_stream:
+            specs[attn.to_q_t.weight] = ("model", "batch")
+            specs[attn.to_q_t.bias] = ("model",)
+            specs[attn.to_k_t.weight] = ("model", "batch")
+            specs[attn.to_k_t.bias] = ("model",)
+            specs[attn.to_v_t.weight] = ("model", "batch")
+            specs[attn.to_v_t.bias] = ("model",)
+            specs[attn.to_out_t.weight] = ("batch", "model")
+            specs[attn.to_out_t.bias] = ("batch",)
+            if attn.q_rms_norm_t.weight is not None:
+                specs[attn.q_rms_norm_t.weight] = ("batch",)
+            if attn.k_rms_norm_t.weight is not None:
+                specs[attn.k_rms_norm_t.weight] = ("batch",)
+
+    def _shard_swiglu(ffn):
+        # HiDreamImageFeedForwardSwiGLU: w1 (gate, up), w3 (up), w2 (down). No bias.
+        specs[ffn.w1.weight] = ("model", "batch")
+        specs[ffn.w3.weight] = ("model", "batch")
+        specs[ffn.w2.weight] = ("batch", "model")
+
+    def _shard_moe(ff):
+        # MOEFeedForwardSwiGLU: .experts (ModuleList of SwiGLU) and .gate (MoEGate).
+        # The MoEGate weight is (n_experts=4, hidden) and drives top-k routing —
+        # every device needs to see all expert scores to pick the same top-2
+        # indices, so it must be replicated (not sharded). It's tiny (~10 KB)
+        # so replication has negligible memory cost.
+        for expert in ff.experts:
+            _shard_swiglu(expert)
+
+    # Double-stream blocks (16): image+text streams, image FF is MoE.
+    for hidream_block in transformer.double_stream_blocks:
+        blk = hidream_block.block
+        # adaLN modulation: SiLU + Linear(dim, 12*dim).
+        specs[blk.adaLN_modulation[1].weight] = ("model", "batch")
+        specs[blk.adaLN_modulation[1].bias] = ("model",)
+        _shard_attention(blk.attn1, has_text_stream=True)
+        # Image FF (MoE) and text FF (dense SwiGLU).
+        _shard_moe(blk.ff_i)
+        _shard_swiglu(blk.ff_t)
+
+    # Single-stream blocks (32): image only, FF is MoE.
+    for hidream_block in transformer.single_stream_blocks:
+        blk = hidream_block.block
+        # adaLN modulation: SiLU + Linear(dim, 6*dim).
+        specs[blk.adaLN_modulation[1].weight] = ("model", "batch")
+        specs[blk.adaLN_modulation[1].bias] = ("model",)
+        _shard_attention(blk.attn1, has_text_stream=False)
+        _shard_moe(blk.ff_i)
+
+    # Final layer: Linear(inner_dim -> patch_size^2 * out_channels) + adaLN(SiLU+Linear).
+    specs[transformer.final_layer.linear.weight] = (None, "batch")
+    specs[transformer.final_layer.linear.bias] = (None,)
+    specs[transformer.final_layer.adaLN_modulation[1].weight] = ("model", "batch")
+    specs[transformer.final_layer.adaLN_modulation[1].bias] = ("model",)
+
+    return specs


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4752


### Problem description

- Add component loaders for the HiDream-I1-Fast text-to-image pipeline

### What's changed

New package: hidream_i1/pytorch/

| File | Purpose |
| --- | --- |
| `loader.py` | `ForgeModel` subclass with six variants (`TextEncoder`, `TextEncoder2`, `TextEncoder3`, `TextEncoder4`, `Transformer`, `Vae`), each loading only its own component via `from_pretrained(subfolder=...)`; includes sharding helpers for the two large components |
| `src/model_utils.py` | Component loaders, wrapper modules, inference shape constants, SPMD shard-spec functions |

Component sources:

| Variant | Class | Source repo | Params |
| --- | --- | --- | --- |
| `TextEncoder` | `CLIPTextModelWithProjection` (CLIP ViT-L/14) via `transformers` | `HiDream-ai/HiDream-I1-Fast` | 0.123 B |
| `TextEncoder2` | `CLIPTextModelWithProjection` (OpenCLIP ViT-bigG/14) via `transformers` | `HiDream-ai/HiDream-I1-Fast` | 0.695 B |
| `TextEncoder3` | `T5EncoderModel` (T5 v1.1 XXL encoder) via `transformers` | `HiDream-ai/HiDream-I1-Fast` | 4.6 B |
| `TextEncoder4` | `LlamaForCausalLM` (Llama-3.1-8B-Instruct) via `transformers` | `meta-llama/Meta-Llama-3.1-8B-Instruct` | 8.0 B |
| `Transformer` | `HiDreamImageTransformer2DModel` (Sparse-MoE MM-DiT) | `HiDream-ai/HiDream-I1-Fast` | 17 B (static) / 14 B activated per token (top-2-of-4 MoE) |
| `Vae` | `AutoencoderKL` (FLUX-derived 16-channel latent) | `HiDream-ai/HiDream-I1-Fast` | 0.084 B |

Each component is loaded independently — no full pipeline is instantiated. `TextEncoder4` is loaded from the Meta repo separately because the HiDream snapshot does not ship Llama weights.

ModelLoader API:

- `load_model(dtype_override)` — returns the component as a `torch.nn.Module`
- `load_inputs(dtype_override)` — returns synthetic input tensors matched to the component's forward signature
- `get_mesh_config(num_devices)` — returns `(mesh_shape, mesh_names)` for the `("batch", "model")` 2D SPMD mesh; sharded variants support 1, 2, 4, 8, 32 devices, unsharded variants always return `(1, 1)`
- `load_shard_spec(model)` — returns tensor → partition-spec dict for the active component; returns `None` for components that fit on a single chip

Sharding helpers (`TextEncoder4` and `Transformer` exceed single-chip memory):

- `shard_llama_specs(llama)` — column-parallel Q/K/V/gate/up, row-parallel O/down on every LlamaDecoderLayer; RMSNorms sharded along the batch axis
- `shard_hidream_transformer_specs(transformer)` — column-parallel Q/K/V (image and text streams), row-parallel O; MoE expert `w1`/`w3` column-parallel, `w2` row-parallel; adaLN-modulation `Linear` column-parallel; caption projections sharded along the model axis. The `MoEGate.weight` is intentionally replicated (top-k routing requires every device to see all expert scores)

Wrapper modules in `src/model_utils.py`:

- `CLIPPooledWrapper` — used for both CLIP-L and CLIP-G; returns the projected pooled `text_embeds` (`out[0]`). Hidden states are discarded — HiDream consumes only the pooled outputs (concatenated into a 2048-dim conditioning vector), not CLIP token sequences
- `T5EncoderWrapper` — returns the last hidden state from `T5EncoderModel(input_ids, attention_mask=...)[0]` as a plain tensor
- `LlamaStackedHiddenWrapper` — runs Llama with `output_hidden_states=True, output_attentions=True`, takes `outputs.hidden_states[1:]` (drops the embedding-output entry), and stacks all 32 transformer-layer hidden states along a new leading dim; matches what the HiDream pipeline feeds to the DiT
- `HiDreamTransformerWrapper` — flattens the DiT forward signature to pure positional tensors (`hidden_states`, `timesteps`, `encoder_hidden_states_t5`, `encoder_hidden_states_llama3`, `pooled_embeds`); pins `return_dict=False` and returns the raw noise prediction (before the pipeline's sign flip)
- `VAEDecoderWrapper` — exposes decoder-only path `(z) → tensor`, bypassing the default encode+decode round-trip

**Note:** Wrappers expose the same input/output contract as the real inference pipeline — returning only the tensors downstream stages consume, and routing each positional input to the correct named kwarg internally (so run_graph_test can pass a flat tensor list without misaligning args against the model's real forward signature).

### Checklist
- [x] Verify changes by local testing in Wormhole

### Logs

- [components_tt_run.zip](https://github.com/user-attachments/files/27965419/tt.zip)

