### PR TITLE
Add HunyuanImage 2.1 component loader

### DIFF
--- a/hunyuan_image_2_1/__init__.py
+++ b/hunyuan_image_2_1/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/hunyuan_image_2_1/pytorch/__init__.py
+++ b/hunyuan_image_2_1/pytorch/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .loader import ModelLoader, ModelVariant

--- a/hunyuan_image_2_1/pytorch/loader.py
+++ b/hunyuan_image_2_1/pytorch/loader.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HunyuanImage 2.1 (Distilled) component loader.
+
+Each variant corresponds to one independently loadable component:
+  - TextEncoder   → Qwen2.5-VL-7B-Instruct encoder (text_encoder)   params=8.29B
+  - TextEncoder2  → ByT5 encoder (text_encoder_2)                    params=0.22B
+  - Transformer   → HunyuanImage21TransformerWrapper (MMDiT)         params=17.45B
+  - Vae           → VAEDecoderWrapper                                params=0.41B
+"""
+
+from typing import Optional
+
+import torch
+
+from ...base import ForgeModel
+from ...config import (
+    Framework,
+    ModelConfig,
+    ModelGroup,
+    ModelInfo,
+    ModelSource,
+    ModelTask,
+    StrEnum,
+)
+from .src.model_utils import (
+    BYT5_VOCAB_SIZE,
+    DTYPE,
+    LATENT_H,
+    LATENT_W,
+    MESH_NAMES,
+    MESH_SHAPES,
+    NUM_CHANNELS_LATENTS,
+    QWEN_VOCAB_SIZE,
+    TEXT_EMBED_2_DIM,
+    TEXT_EMBED_DIM,
+    TEXT_TOKEN_2_MAX_LEN,
+    TEXT_TOKEN_MAX_LEN,
+    TRANSFORMER_IN_CHANNELS,
+    TRANSFORMER_TEXT_2_SEQ,
+    TRANSFORMER_TEXT_SEQ,
+    HunyuanImage21TransformerWrapper,
+    VAEDecoderWrapper,
+    load_text_encoder,
+    load_text_encoder_2,
+    load_transformer,
+    load_vae,
+    shard_text_encoder_specs,
+    shard_transformer_specs,
+)
+
+_REPO_ID = "hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers"
+
+
+class ModelVariant(StrEnum):
+    """Loadable components of the HunyuanImage 2.1 pipeline."""
+
+    TEXT_ENCODER = "TextEncoder"
+    TEXT_ENCODER_2 = "TextEncoder2"
+    TRANSFORMER = "Transformer"
+    VAE = "Vae"
+
+
+class ModelLoader(ForgeModel):
+    """Load individual HunyuanImage 2.1 components without pulling the full pipeline."""
+
+    _VARIANTS = {
+        ModelVariant.TEXT_ENCODER: ModelConfig(pretrained_model_name=_REPO_ID),
+        ModelVariant.TEXT_ENCODER_2: ModelConfig(pretrained_model_name=_REPO_ID),
+        ModelVariant.TRANSFORMER: ModelConfig(pretrained_model_name=_REPO_ID),
+        ModelVariant.VAE: ModelConfig(pretrained_model_name=_REPO_ID),
+    }
+    DEFAULT_VARIANT = ModelVariant.TRANSFORMER
+
+    _TEXT_VARIANTS = (ModelVariant.TEXT_ENCODER, ModelVariant.TEXT_ENCODER_2)
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        task = (
+            ModelTask.NLP_EMBED_GEN
+            if variant in cls._TEXT_VARIANTS
+            else ModelTask.MM_IMAGE_TTI
+        )
+        return ModelInfo(
+            model="HunyuanImage21",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=task,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def load_model(self, *, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Load and return the component for this variant as a torch.nn.Module.
+
+        Returns:
+            TEXT_ENCODER   → Qwen2.5-VL encoder model
+            TEXT_ENCODER_2 → ByT5 encoder model
+            TRANSFORMER    → HunyuanImage21TransformerWrapper
+            VAE            → VAEDecoderWrapper (decoder-only, returns plain tensor)
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return load_text_encoder(dtype)
+        if self._variant == ModelVariant.TEXT_ENCODER_2:
+            return load_text_encoder_2(dtype)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return HunyuanImage21TransformerWrapper(load_transformer(dtype)).eval()
+        if self._variant == ModelVariant.VAE:
+            return VAEDecoderWrapper(load_vae(dtype)).eval()
+
+        raise ValueError(f"Unknown variant: {self._variant}")
+
+    def get_mesh_config(self, num_devices: int):
+        """Return (mesh_shape, mesh_names) for a ("batch", "model") 2D mesh.
+
+        Supported device counts: 1, 2, 4, 8, 32.
+        TEXT_ENCODER_2 and VAE fit on a single chip so any count maps to (1, 1).
+        """
+        if self._variant in (ModelVariant.TEXT_ENCODER_2, ModelVariant.VAE):
+            return (1, 1), MESH_NAMES
+
+        if num_devices not in MESH_SHAPES:
+            raise ValueError(
+                f"Unsupported device count: {num_devices}. "
+                f"Expected one of {sorted(MESH_SHAPES)}."
+            )
+        return MESH_SHAPES[num_devices], MESH_NAMES
+
+    def load_shard_spec(self, model):
+        """Return tensor → partition_spec dict for the active component.
+
+        Expects the same model object returned by load_model():
+          TEXT_ENCODER     → Qwen2.5-VL encoder
+          TEXT_ENCODER_2   → None (single-chip, no sharding)
+          TRANSFORMER      → HunyuanImage21TransformerWrapper (specs from .transformer)
+          VAE              → None (single-chip, no sharding)
+        """
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            return shard_text_encoder_specs(model)
+        if self._variant == ModelVariant.TRANSFORMER:
+            return shard_transformer_specs(model.transformer)
+        return None
+
+    def load_inputs(self, dtype_override: Optional[torch.dtype] = None, **kwargs):
+        """Return a list of synthetic input tensors for the active component.
+
+        TEXT_ENCODER   → [input_ids (1,1034) int64, attention_mask (1,1034) int64]
+        TEXT_ENCODER_2 → [input_ids (1,128) int64,  attention_mask (1,128) float32]
+        TRANSFORMER    → [hidden_states (1,64,64,64), timestep (1,), timestep_r (1,),
+                          guidance (1,),
+                          encoder_hidden_states (1,1000,3584),
+                          encoder_attention_mask (1,1000) int64,
+                          encoder_hidden_states_2 (1,128,1472),
+                          encoder_attention_mask_2 (1,128) int64]
+        VAE            → [z (1,64,64,64)]
+        """
+        dtype = dtype_override if dtype_override is not None else DTYPE
+
+        if self._variant == ModelVariant.TEXT_ENCODER:
+            input_ids = torch.randint(
+                0, QWEN_VOCAB_SIZE, (1, TEXT_TOKEN_MAX_LEN), dtype=torch.long
+            )
+            attention_mask = torch.ones(1, TEXT_TOKEN_MAX_LEN, dtype=torch.long)
+            return [input_ids, attention_mask]
+
+        if self._variant == ModelVariant.TEXT_ENCODER_2:
+            input_ids = torch.randint(
+                0, BYT5_VOCAB_SIZE, (1, TEXT_TOKEN_2_MAX_LEN), dtype=torch.long
+            )
+            # Pipeline calls text_encoder_2 with attention_mask.float()
+            attention_mask = torch.ones(1, TEXT_TOKEN_2_MAX_LEN, dtype=torch.float32)
+            return [input_ids, attention_mask]
+
+        if self._variant == ModelVariant.TRANSFORMER:
+            hidden_states = torch.randn(
+                1, TRANSFORMER_IN_CHANNELS, LATENT_H, LATENT_W, dtype=dtype
+            )
+            timestep = torch.tensor([1000.0], dtype=dtype)
+            timestep_r = torch.tensor([0.0], dtype=dtype)
+            guidance = torch.tensor(
+                [3500.0], dtype=dtype
+            )  # distilled_guidance_scale * 1000
+            encoder_hidden_states = torch.randn(
+                1, TRANSFORMER_TEXT_SEQ, TEXT_EMBED_DIM, dtype=dtype
+            )
+            encoder_attention_mask = torch.ones(
+                1, TRANSFORMER_TEXT_SEQ, dtype=torch.long
+            )
+            encoder_hidden_states_2 = torch.randn(
+                1, TRANSFORMER_TEXT_2_SEQ, TEXT_EMBED_2_DIM, dtype=dtype
+            )
+            encoder_attention_mask_2 = torch.ones(
+                1, TRANSFORMER_TEXT_2_SEQ, dtype=torch.long
+            )
+            return [
+                hidden_states,
+                timestep,
+                timestep_r,
+                guidance,
+                encoder_hidden_states,
+                encoder_attention_mask,
+                encoder_hidden_states_2,
+                encoder_attention_mask_2,
+            ]
+
+        if self._variant == ModelVariant.VAE:
+            z = torch.randn(1, NUM_CHANNELS_LATENTS, LATENT_H, LATENT_W, dtype=dtype)
+            return [z]
+
+        raise ValueError(f"Unknown variant: {self._variant}")

--- a/hunyuan_image_2_1/pytorch/src/__init__.py
+++ b/hunyuan_image_2_1/pytorch/src/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/hunyuan_image_2_1/pytorch/src/model_utils.py
+++ b/hunyuan_image_2_1/pytorch/src/model_utils.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Component loaders and wrappers for HunyuanImage 2.1 (Distilled).
+
+Model: hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers
+Components:
+  - text_encoder:   Qwen2.5-VL-7B-Instruct encoder (8.29B)
+  - text_encoder_2: ByT5 encoder                   (0.22B)
+  - transformer:    HunyuanImageTransformer2DModel (MMDiT) (17.45B)
+  - vae:            AutoencoderKLHunyuanImage      (0.41B)
+"""
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Model identity
+# ---------------------------------------------------------------------------
+
+REPO_ID = "hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers"
+DTYPE = torch.float32
+
+# ---------------------------------------------------------------------------
+# Inference shape constants (2048 x 2048, single image)
+# ---------------------------------------------------------------------------
+
+IMAGE_H = 2048
+IMAGE_W = 2048
+VAE_SCALE_FACTOR = 32  # AutoencoderKLHunyuanImage.spatial_compression_ratio
+LATENT_H = IMAGE_H // VAE_SCALE_FACTOR  # 64
+LATENT_W = IMAGE_W // VAE_SCALE_FACTOR  # 64
+
+NUM_CHANNELS_LATENTS = 64  # transformer.config.in_channels
+TRANSFORMER_IN_CHANNELS = NUM_CHANNELS_LATENTS  # no extra conditioning concat in T2I
+
+# Text encoder hidden dims
+TEXT_EMBED_DIM = 3584  # Qwen2.5-VL hidden_state dim
+TEXT_EMBED_2_DIM = 1472  # ByT5 hidden_state dim
+
+# Tokenizer max lengths driven by the pipeline
+TEXT_TOKEN_MAX_LEN = 1034  # tokenizer_max_length (1000) + drop_idx (34)
+TEXT_TOKEN_2_MAX_LEN = 128
+
+# Sequence lengths landing in the transformer (after pipeline slicing)
+TRANSFORMER_TEXT_SEQ = 1000  # encoder_hidden_states seq dim (post drop_idx)
+TRANSFORMER_TEXT_2_SEQ = 128  # encoder_hidden_states_2 seq dim
+
+# Vocabulary sizes
+QWEN_VOCAB_SIZE = 151936  # Qwen2.5-VL text encoder
+BYT5_VOCAB_SIZE = 384  # ByT5 text_encoder_2
+
+# ---------------------------------------------------------------------------
+# Component loaders
+# ---------------------------------------------------------------------------
+
+
+def load_text_encoder(dtype: torch.dtype = DTYPE):
+    """Load Qwen2.5-VL text encoder from the text_encoder subfolder."""
+    from transformers import AutoModel
+
+    return AutoModel.from_pretrained(
+        REPO_ID,
+        subfolder="text_encoder",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_text_encoder_2(dtype: torch.dtype = DTYPE):
+    """Load ByT5 text encoder from the text_encoder_2 subfolder."""
+    from transformers import T5EncoderModel
+
+    return T5EncoderModel.from_pretrained(
+        REPO_ID,
+        subfolder="text_encoder_2",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_transformer(dtype: torch.dtype = DTYPE):
+    """Load HunyuanImageTransformer2DModel from the transformer subfolder."""
+    from diffusers import HunyuanImageTransformer2DModel
+
+    return HunyuanImageTransformer2DModel.from_pretrained(
+        REPO_ID,
+        subfolder="transformer",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+def load_vae(dtype: torch.dtype = DTYPE):
+    """Load AutoencoderKLHunyuanImage from the vae subfolder."""
+    from diffusers import AutoencoderKLHunyuanImage
+
+    return AutoencoderKLHunyuanImage.from_pretrained(
+        REPO_ID,
+        subfolder="vae",
+        torch_dtype=dtype,
+        device_map="cpu",
+    ).eval()
+
+
+# ---------------------------------------------------------------------------
+# Wrapper modules — keep forward signatures tensor-in / tensor-out for the
+# tt-xla graph runner.
+# ---------------------------------------------------------------------------
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    """Expose only AutoencoderKLHunyuanImage decoder as (z) -> tensor."""
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z):
+        return self.vae.decode(z, return_dict=False)[0]
+
+
+class HunyuanImage21TransformerWrapper(torch.nn.Module):
+    """Simplify HunyuanImageTransformer2DModel forward to tensor-only inputs/outputs."""
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+
+    def forward(
+        self,
+        hidden_states,
+        timestep,
+        timestep_r,
+        guidance,
+        encoder_hidden_states,
+        encoder_attention_mask,
+        encoder_hidden_states_2,
+        encoder_attention_mask_2,
+    ):
+        return self.transformer(
+            hidden_states=hidden_states,
+            timestep=timestep,
+            timestep_r=timestep_r,
+            guidance=guidance,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            encoder_hidden_states_2=encoder_hidden_states_2,
+            encoder_attention_mask_2=encoder_attention_mask_2,
+            return_dict=False,
+        )[0]
+
+
+# ---------------------------------------------------------------------------
+# SPMD shard specifications
+# ---------------------------------------------------------------------------
+
+# (batch, model) mesh shapes by device count
+MESH_SHAPES = {32: (8, 4), 8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
+MESH_NAMES = ("batch", "model")
+
+
+def shard_text_encoder_specs(encoder) -> dict:
+    """Shard specs for Qwen2.5-VL text encoder.
+
+    Column-parallel (q, k, v, gate, up): ("model", "batch")
+    Row-parallel   (o, down):            ("batch", "model")
+    """
+    specs = {}
+
+    if hasattr(encoder, "embed_tokens"):
+        specs[encoder.embed_tokens.weight] = (None, "batch")
+
+    layers = getattr(encoder, "layers", None)
+    if layers is None:
+        return specs
+
+    for layer in layers:
+        sa = layer.self_attn
+        specs[sa.q_proj.weight] = ("model", "batch")
+        if sa.q_proj.bias is not None:
+            specs[sa.q_proj.bias] = ("model",)
+        specs[sa.k_proj.weight] = ("model", "batch")
+        if sa.k_proj.bias is not None:
+            specs[sa.k_proj.bias] = ("model",)
+        specs[sa.v_proj.weight] = ("model", "batch")
+        if sa.v_proj.bias is not None:
+            specs[sa.v_proj.bias] = ("model",)
+        specs[sa.o_proj.weight] = ("batch", "model")
+
+        mlp = layer.mlp
+        specs[mlp.gate_proj.weight] = ("model", "batch")
+        specs[mlp.up_proj.weight] = ("model", "batch")
+        specs[mlp.down_proj.weight] = ("batch", "model")
+
+        specs[layer.input_layernorm.weight] = ("batch",)
+        specs[layer.post_attention_layernorm.weight] = ("batch",)
+
+    if hasattr(encoder, "norm"):
+        specs[encoder.norm.weight] = ("batch",)
+
+    return specs
+
+
+# text_encoder_2 (ByT5, 0.22B params) fits on a single chip — no sharding.
+
+
+def shard_transformer_specs(transformer) -> dict:
+    """Shard specs for HunyuanImageTransformer2DModel.
+
+    HunyuanImage uses a hybrid MMDiT design with two block lists:
+      - transformer_blocks: dual-stream (image + text streams with cross attention)
+      - single_transformer_blocks: single-stream (concatenated tokens)
+
+    Column-parallel (Q, K, V, FFN up): ("model", "batch")
+    Row-parallel   (O, FFN down):      ("batch", "model")
+    """
+    specs = {}
+
+    if hasattr(transformer, "x_embedder") and hasattr(transformer.x_embedder, "proj"):
+        # patch-embed conv weight: (out_C, in_C, kH, kW)
+        specs[transformer.x_embedder.proj.weight] = ("batch", None, None, None)
+        if transformer.x_embedder.proj.bias is not None:
+            specs[transformer.x_embedder.proj.bias] = ("batch",)
+
+    def _shard_attn(attn):
+        for proj_name in (
+            "to_q",
+            "to_k",
+            "to_v",
+            "add_q_proj",
+            "add_k_proj",
+            "add_v_proj",
+        ):
+            if hasattr(attn, proj_name) and getattr(attn, proj_name) is not None:
+                proj = getattr(attn, proj_name)
+                specs[proj.weight] = ("model", "batch")
+                if proj.bias is not None:
+                    specs[proj.bias] = ("model",)
+        for proj_name in ("to_out", "to_add_out"):
+            if hasattr(attn, proj_name) and getattr(attn, proj_name) is not None:
+                out = getattr(attn, proj_name)
+                target = (
+                    out[0]
+                    if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
+                    else out
+                )
+                specs[target.weight] = ("batch", "model")
+                if target.bias is not None:
+                    specs[target.bias] = ("batch",)
+
+    def _shard_ff(ff):
+        # diffusers FeedForward = Sequential(GEGLU, Dropout, Linear)
+        if hasattr(ff, "net"):
+            if hasattr(ff.net[0], "proj"):
+                specs[ff.net[0].proj.weight] = ("model", "batch")
+                if ff.net[0].proj.bias is not None:
+                    specs[ff.net[0].proj.bias] = ("model",)
+            specs[ff.net[2].weight] = ("batch", "model")
+            if ff.net[2].bias is not None:
+                specs[ff.net[2].bias] = ("batch",)
+
+    # Dual-stream MMDiT blocks
+    for block in getattr(transformer, "transformer_blocks", []):
+        for norm_name in ("norm1", "norm1_context"):
+            if hasattr(block, norm_name) and hasattr(
+                getattr(block, norm_name), "linear"
+            ):
+                lin = getattr(block, norm_name).linear
+                specs[lin.weight] = ("model", "batch")
+                if lin.bias is not None:
+                    specs[lin.bias] = ("model",)
+        if hasattr(block, "attn"):
+            _shard_attn(block.attn)
+        for ff_name in ("ff", "ff_context"):
+            if hasattr(block, ff_name):
+                _shard_ff(getattr(block, ff_name))
+
+    # Single-stream blocks (fused QKV + FFN in one projection in some variants)
+    for block in getattr(transformer, "single_transformer_blocks", []):
+        if hasattr(block, "norm") and hasattr(block.norm, "linear"):
+            lin = block.norm.linear
+            specs[lin.weight] = ("model", "batch")
+            if lin.bias is not None:
+                specs[lin.bias] = ("model",)
+        if hasattr(block, "attn"):
+            _shard_attn(block.attn)
+        # single block typically has its own proj_out after concat(attn || mlp)
+        if hasattr(block, "proj_out"):
+            specs[block.proj_out.weight] = ("batch", "model")
+            if block.proj_out.bias is not None:
+                specs[block.proj_out.bias] = ("batch",)
+
+    if hasattr(transformer, "proj_out"):
+        specs[transformer.proj_out.weight] = (None, "batch")
+        if transformer.proj_out.bias is not None:
+            specs[transformer.proj_out.bias] = (None,)
+
+    return specs


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4774

### Problem description

- Add component loaders for the HunyuanImage-2.1-Distilled text-to-image pipeline

### What's changed

New package: `hunyuan_image_2_1/pytorch/`

| File | Purpose |
| --- | --- |
| `loader.py` | `ForgeModel` subclass with four variants (`TextEncoder`, `TextEncoder2`, `Transformer`, `Vae`), each loading only its own component via `from_pretrained(subfolder=...)`; includes sharding helpers for the two large components |
| `src/model_utils.py` | Component loaders, wrapper modules, inference shape constants, SPMD shard-spec functions |

Component sources:

| Variant | Class | Source repo | Params |
| --- | --- | --- | --- |
| `TextEncoder` | `Qwen2_5_VLForConditionalGeneration` (Qwen2.5-VL-7B-Instruct) via `transformers.AutoModel` | `hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers` | 8.29 B |
| `TextEncoder2` | `T5EncoderModel` (ByT5 glyph encoder) via `transformers` | `hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers` | 0.22 B |
| `Transformer` | `HunyuanImageTransformer2DModel` (hybrid MM-DiT: dual-stream + single-stream blocks) | `hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers` | 17.45 B |
| `Vae` | `AutoencoderKLHunyuanImage` (32× spatial-compression image VAE) | `hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers` | 0.41 B |

Each component is loaded independently — no full pipeline is instantiated. All four components ship in the same HunyuanImage repo, so no auxiliary repo lookups are required.

ModelLoader API:

- `load_model(dtype_override)` — returns the component as a `torch.nn.Module`
- `load_inputs(dtype_override)` — returns synthetic input tensors matched to the component's forward signature
- `get_mesh_config(num_devices)` — returns `(mesh_shape, mesh_names)` for the `("batch", "model")` 2D SPMD mesh; sharded variants support 1, 2, 4, 8, 32 devices, unsharded variants always return `(1, 1)`
- `load_shard_spec(model)` — returns tensor → partition-spec dict for the active component; returns `None` for components that fit on a single chip

Sharding helpers (`TextEncoder` and `Transformer` exceed single-chip memory):

- `shard_text_encoder_specs(encoder)` — column-parallel Q/K/V/gate/up, row-parallel O/down on every Qwen2.5-VL decoder layer; input layernorm / post-attention layernorm sharded along the batch axis
- `shard_transformer_specs(transformer)` — covers both block lists of the hybrid MMDiT. Column-parallel Q/K/V (including `add_q_proj`/`add_k_proj`/`add_v_proj` for the dual-stream cross-attention), row-parallel O (`to_out`, `to_add_out`); FeedForward `net[0].proj` column-parallel, `net[2]` row-parallel; adaLN-modulation `Linear` (`norm1`, `norm1_context`, `norm`) column-parallel; patch-embed conv replicated; `single_transformer_blocks.*.proj_out` row-parallel

Wrapper modules in `src/model_utils.py`:

- `HunyuanImage21TransformerWrapper` — flattens the DiT forward signature to pure positional tensors (`hidden_states`, `timestep`, `timestep_r`, `guidance`, `encoder_hidden_states`, `encoder_attention_mask`, `encoder_hidden_states_2`, `encoder_attention_mask_2`); pins `return_dict=False` and returns the noise prediction tensor
- `VAEDecoderWrapper` — exposes decoder-only path `(z) → tensor`, bypassing the default encode+decode round-trip

**Note:** Wrappers expose the same input/output contract as the real inference pipeline — returning only the tensors downstream stages consume, and routing each positional input to the correct named kwarg internally (so `run_graph_test` can pass a flat tensor list without misaligning args against the model's real forward signature).

### Checklist
- [x] Verify changes by local testing in Wormhole

### Logs

- [hunyuanimage_2_1_tt.zip](https://github.com/user-attachments/files/28021002/hunyuanimage_2_1_tt.zip)

