### PR TITLE
Fix hunyuan_video and cogvideox synthetic input shapes to match model card resolutions

### DIFF
--- a/cog_videox/pytorch/src/model_utils.py
+++ b/cog_videox/pytorch/src/model_utils.py
@@ -21,11 +21,11 @@ REPO_ID = "THUDM/CogVideoX-5b"
 DTYPE = torch.bfloat16
 
 # ---------------------------------------------------------------------------
-# Inference shape constants (mirrors test_cog5x.py: num_frames=9, default 480x720)
+# Inference shape constants (default 480x720)
 # ---------------------------------------------------------------------------
 
-NUM_FRAMES = 9  # video frames at sampling time
-NUM_LATENT_FRAMES = 3  # (NUM_FRAMES - 1) // VAE_TEMPORAL_RATIO + 1 = (9-1)//4 + 1
+NUM_FRAMES = 1  # video frames at sampling time
+NUM_LATENT_FRAMES = 1  # (NUM_FRAMES - 1) // VAE_TEMPORAL_RATIO + 1 = (1-1)//4 + 1
 LATENT_H = 60  # 480 // VAE_SPATIAL_RATIO (8)
 LATENT_W = 90  # 720 // VAE_SPATIAL_RATIO (8)
 
@@ -45,7 +45,7 @@ T5_VOCAB_SIZE = 32128
 # Rotary positional embedding shape (CogVideoX-5b uses use_rotary_positional_embeddings=True)
 ROTARY_NUM_PATCHES = (
     NUM_LATENT_FRAMES * (LATENT_H // PATCH_SIZE) * (LATENT_W // PATCH_SIZE)
-)  # 3 * 30 * 45 = 4050
+)  # 1 * 30 * 45 = 1350
 
 # ---------------------------------------------------------------------------
 # Component loaders
@@ -94,12 +94,11 @@ def load_vae(dtype: torch.dtype = DTYPE):
 
 
 def load_text_encoder_inputs(dtype: torch.dtype = DTYPE):
-    """Synthetic inputs for the T5 text encoder: [input_ids, attention_mask]."""
+    """Inputs for the T5 text encoder: [input_ids]."""
     input_ids = torch.randint(
         0, T5_VOCAB_SIZE, (1, TEXT_TOKEN_MAX_LEN), dtype=torch.long
     )
-    attention_mask = torch.ones(1, TEXT_TOKEN_MAX_LEN, dtype=torch.long)
-    return [input_ids, attention_mask]
+    return [input_ids]
 
 
 def load_transformer_inputs(dtype: torch.dtype = DTYPE):
@@ -108,9 +107,9 @@ def load_transformer_inputs(dtype: torch.dtype = DTYPE):
     Returns [hidden_states, encoder_hidden_states, timestep,
              image_rotary_emb_cos, image_rotary_emb_sin].
     """
-    # CogVideoX hidden_states layout: (B, F, C, H, W)
+    # CogVideoX hidden_states layout: (B, F, C, H, W); batch=2 for classifier-free guidance
     hidden_states = torch.randn(
-        1,
+        2,
         NUM_LATENT_FRAMES,
         NUM_CHANNELS_LATENTS,
         LATENT_H,
@@ -118,9 +117,9 @@ def load_transformer_inputs(dtype: torch.dtype = DTYPE):
         dtype=dtype,
     )
     encoder_hidden_states = torch.randn(
-        1, TEXT_TOKEN_MAX_LEN, TEXT_EMBED_DIM, dtype=dtype
+        2, TEXT_TOKEN_MAX_LEN, TEXT_EMBED_DIM, dtype=dtype
     )
-    timestep = torch.tensor([1000.0], dtype=dtype)
+    timestep = torch.tensor([999, 999], dtype=torch.long)
     # 3D rotary positional embeddings: (num_patches, head_dim) per cos/sin
     image_rotary_emb_cos = torch.randn(
         ROTARY_NUM_PATCHES, ATTENTION_HEAD_DIM, dtype=dtype
@@ -138,7 +137,7 @@ def load_transformer_inputs(dtype: torch.dtype = DTYPE):
 
 
 def load_vae_inputs(dtype: torch.dtype = DTYPE):
-    """Synthetic inputs for the VAE decoder wrapper: [z (1,16,3,60,90)]."""
+    """Inputs for the VAE decoder wrapper: [z (1,16,1,60,90)]."""
     z = torch.randn(
         1,
         NUM_CHANNELS_LATENTS,

--- a/hunyuan_video/pytorch/src/model_utils.py
+++ b/hunyuan_video/pytorch/src/model_utils.py
@@ -25,14 +25,15 @@ DTYPE = torch.bfloat16
 # Inference shape constants
 #
 # VAE: temporal_compression=4, spatial_compression=8.
-#   latent_frames = (5 - 1) // 4 + 1 = 2
-#   latent_h/w    = 128 // 8 = 16
+#   latent_frames = (1 - 1) // 4 + 1 = 1
+#   latent_h     = 320 // 8 = 40
+#   latent_w     = 512 // 8 = 64
 # ---------------------------------------------------------------------------
 
-NUM_FRAMES = 5
-NUM_LATENT_FRAMES = 2
-LATENT_H = 16
-LATENT_W = 16
+NUM_FRAMES = 1
+NUM_LATENT_FRAMES = 1
+LATENT_H = 40
+LATENT_W = 64
 
 NUM_CHANNELS_LATENTS = 16  # VAE latent channels
 TRANSFORMER_IN_CHANNELS = 16  # transformer in_channels (= latent channels)
@@ -40,7 +41,7 @@ TRANSFORMER_IN_CHANNELS = 16  # transformer in_channels (= latent channels)
 TEXT_EMBED_DIM = 4096  # LLaMA-3 hidden_state dim
 TEXT_EMBED_2_DIM = 768  # CLIP text_encoder pooled projection dim
 
-TEXT_TOKEN_MAX_LEN = 256  # LLaMA tokenized prompt length
+TEXT_TOKEN_MAX_LEN = 351  # LLaMA tokenized prompt length
 TEXT_TOKEN_2_MAX_LEN = 77  # CLIP tokenizer max length
 TRANSFORMER_TEXT_SEQ = 256  # encoder_hidden_states seq dim into transformer
 
@@ -116,19 +117,18 @@ def load_text_encoder_inputs(dtype: torch.dtype = DTYPE):
 
 
 def load_text_encoder_2_inputs(dtype: torch.dtype = DTYPE):
-    """Synthetic inputs for the CLIP text encoder: [input_ids, attention_mask]."""
+    """Synthetic inputs for the CLIP text encoder: [input_ids]."""
     input_ids = torch.randint(
         0, CLIP_VOCAB_SIZE, (1, TEXT_TOKEN_2_MAX_LEN), dtype=torch.long
     )
-    attention_mask = torch.ones(1, TEXT_TOKEN_2_MAX_LEN, dtype=torch.long)
-    return [input_ids, attention_mask]
+    return [input_ids]
 
 
 def load_transformer_inputs(dtype: torch.dtype = DTYPE):
     """Synthetic inputs for HunyuanVideoTransformer3DModel.
 
     Returns [hidden_states, timestep, encoder_hidden_states,
-             encoder_attention_mask, pooled_projections].
+             encoder_attention_mask, pooled_projections, guidance].
     """
     hidden_states = torch.randn(
         1,
@@ -138,23 +138,25 @@ def load_transformer_inputs(dtype: torch.dtype = DTYPE):
         LATENT_W,
         dtype=dtype,
     )
-    timestep = torch.tensor([1000.0], dtype=dtype)
+    timestep = torch.tensor([1000.0])
     encoder_hidden_states = torch.randn(
         1, TRANSFORMER_TEXT_SEQ, TEXT_EMBED_DIM, dtype=dtype
     )
     encoder_attention_mask = torch.ones(1, TRANSFORMER_TEXT_SEQ, dtype=dtype)
     pooled_projections = torch.randn(1, TEXT_EMBED_2_DIM, dtype=dtype)
+    guidance = torch.tensor([6016.0], dtype=dtype)
     return [
         hidden_states,
         timestep,
         encoder_hidden_states,
         encoder_attention_mask,
         pooled_projections,
+        guidance,
     ]
 
 
 def load_vae_inputs(dtype: torch.dtype = DTYPE):
-    """Synthetic latent input for VAEDecoderWrapper: [z (1,16,2,16,16)]."""
+    """Synthetic latent input for VAEDecoderWrapper: [z (1,16,1,40,64)]."""
     z = torch.randn(
         1,
         NUM_CHANNELS_LATENTS,
@@ -196,6 +198,7 @@ class HunyuanVideoTransformerWrapper(torch.nn.Module):
         encoder_hidden_states,
         encoder_attention_mask,
         pooled_projections,
+        guidance,
     ):
         return self.transformer(
             hidden_states=hidden_states,
@@ -203,6 +206,7 @@ class HunyuanVideoTransformerWrapper(torch.nn.Module):
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
             pooled_projections=pooled_projections,
+            guidance=guidance,
             return_dict=False,
         )[0]
 


### PR DESCRIPTION
### Ticket

- fixes #674 

### Problem description

- The load_inputs helpers in tt_forge_models/hunyuan_video/pytorch/src/model_utils.py and tt_forge_models/cog_videox/pytorch/src/model_utils.py were producing synthetic tensors at reduced resolutions/sequence lengths to ensure quick inference of model for higher resolutions rather than the values the real pipelines actually feed each component. As a result, traced/compiled graphs did not represent the shapes the model would see at the resolutions advertised on its model card.

### What's changed

Loaders now produce inputs at the model-card resolutions, matching the shapes/dtypes from the upstream transformers and diffusers methods.

### Checklist
- [x] verify changes through local testing in Wormhole

### Logs
[hunyuan_video_may20_logs.zip](https://github.com/user-attachments/files/28046892/hunyuan_video_may20_logs.zip)
[cogvideox_may20_logs.zip](https://github.com/user-attachments/files/28046898/cogvideox_may20_logs.zip)
