### PR TITLE
Fix hunyuan_image_2_1 loader: use existing MM_IMAGE_TTT enum

### DIFF
--- a/hunyuan_image_2_1/pytorch/loader.py
+++ b/hunyuan_image_2_1/pytorch/loader.py
@@ -83,7 +83,7 @@ class ModelLoader(ForgeModel):
         task = (
             ModelTask.NLP_EMBED_GEN
             if variant in cls._TEXT_VARIANTS
-            else ModelTask.MM_IMAGE_TTI
+            else ModelTask.MM_IMAGE_TTT
         )
         return ModelInfo(
             model="HunyuanImage21",


### PR DESCRIPTION
## Problem

PR #672 introduced `hunyuan_image_2_1/pytorch/loader.py`, which references `ModelTask.MM_IMAGE_TTI`. That enum value does not exist in `config.py` (only `MM_IMAGE_TTT` is defined), so importing the loader raises `AttributeError` and breaks downstream test collection (e.g. in tt-xla).

## What's changed

- `hunyuan_image_2_1/pytorch/loader.py`: `MM_IMAGE_TTI` → `MM_IMAGE_TTT`, matching every other text-to-image loader (flux, sana, lumina_image, omnigen, stable_diffusion_*, wan).

## Checklist

- [x] Verified no other references to `MM_IMAGE_TTI` exist in the repo
- [x] Loader import no longer raises `AttributeError`