### PR TITLE
Hidream_i1: add shard spec for T5 encoder(text_encoder_3)

### DIFF
--- a/hidream_i1/pytorch/loader.py
+++ b/hidream_i1/pytorch/loader.py
@@ -58,6 +58,7 @@ from .src.model_utils import (
     load_vae,
     shard_hidream_transformer_specs,
     shard_llama_specs,
+    shard_t5_encoder_specs,
 )
 
 
@@ -142,7 +143,11 @@ class ModelLoader(ForgeModel):
 
         Supported device counts for sharded variants: 1, 2, 4, 8, 32.
         """
-        sharded_variants = (ModelVariant.TEXT_ENCODER_4, ModelVariant.TRANSFORMER)
+        sharded_variants = (
+            ModelVariant.TEXT_ENCODER_3,
+            ModelVariant.TEXT_ENCODER_4,
+            ModelVariant.TRANSFORMER,
+        )
         if self._variant not in sharded_variants:
             return (1, 1), MESH_NAMES
 
@@ -157,10 +162,13 @@ class ModelLoader(ForgeModel):
         """Return tensor → partition_spec dict for the active component.
 
         Expects the same model object returned by load_model():
+          TEXT_ENCODER_3 → T5EncoderWrapper (specs built from .t5_encoder)
           TEXT_ENCODER_4 → LlamaStackedHiddenWrapper (specs built from .llama)
           TRANSFORMER    → HiDreamTransformerWrapper (specs built from .transformer)
           Others         → None (single-chip, no sharding)
         """
+        if self._variant == ModelVariant.TEXT_ENCODER_3:
+            return shard_t5_encoder_specs(model.t5_encoder)
         if self._variant == ModelVariant.TEXT_ENCODER_4:
             return shard_llama_specs(model.llama)
         if self._variant == ModelVariant.TRANSFORMER:

--- a/hidream_i1/pytorch/src/model_utils.py
+++ b/hidream_i1/pytorch/src/model_utils.py
@@ -277,6 +277,44 @@ def shard_llama_specs(llama) -> dict:
     return specs
 
 
+def shard_t5_encoder_specs(t5_encoder) -> dict:
+    """Shard specs for T5EncoderModel (text_encoder_3, T5 v1.1 XXL).
+
+    Mesh axes: ("batch", "model")
+    Column-parallel (Q, K, V, wi_0, wi_1):  ("model", "batch")
+    Row-parallel   (O, wo):                 ("batch", "model")
+    T5LayerNorm weights sharded along batch.
+    Token embedding sharded along d_model on the batch axis (matches Llama).
+    relative_attention_bias (32 buckets x 64 heads) is tiny; left replicated.
+    """
+    specs = {}
+
+    # Token embedding (tied: t5_encoder.shared and encoder.embed_tokens share weight).
+    specs[t5_encoder.shared.weight] = (None, "batch")
+
+    stack = t5_encoder.encoder  # T5Stack
+    for block in stack.block:
+        # layer[0]: T5LayerSelfAttention.
+        attn_layer = block.layer[0]
+        attn = attn_layer.SelfAttention
+        specs[attn.q.weight] = ("model", "batch")
+        specs[attn.k.weight] = ("model", "batch")
+        specs[attn.v.weight] = ("model", "batch")
+        specs[attn.o.weight] = ("batch", "model")
+        specs[attn_layer.layer_norm.weight] = ("batch",)
+
+        # layer[1]: T5LayerFF with T5DenseGatedActDense (v1.1).
+        ff_layer = block.layer[1]
+        dense = ff_layer.DenseReluDense
+        specs[dense.wi_0.weight] = ("model", "batch")
+        specs[dense.wi_1.weight] = ("model", "batch")
+        specs[dense.wo.weight] = ("batch", "model")
+        specs[ff_layer.layer_norm.weight] = ("batch",)
+
+    specs[stack.final_layer_norm.weight] = ("batch",)
+    return specs
+
+
 def shard_hidream_transformer_specs(transformer) -> dict:
     """Shard specs for HiDreamImageTransformer2DModel.
 


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4760

### Problem description

- T5-XXL needs ~12 GB just for its FF weights; a single chip has ~1 GB of DRAM. OOM hits on the 7th of 72 FF weight transfers — the model is simply too big for one chip.
- For complete details, please checkout the attached ticket

### What's changed

- Added `shard_t5_encoder_specs` for T5EncoderModel (T5 v1.1 XXL): column-parallel Q/K/V/wi_0/wi_1, row-parallel O/wo, layer-norm and embedding sharded along the batch axis, `relative_attention_bias` left replicated.
- Wired the new spec through `ModelLoader.load_shard_spec` and added `TEXT_ENCODER_3` to the sharded variants in `get_mesh_config`.


### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [may22_hidream_text_encoder3_1_chip.log](https://github.com/user-attachments/files/28142211/may22_hidream_text_encoder3.log)
- [may22_hidream_text_encoder3_2_chips.log](https://github.com/user-attachments/files/28142207/may22_hidream_text_encoder3_2_chips.log)

