### PR TITLE
[hippynn] loader fixes to clear bringup compile blockers on n150

### DIFF
--- a/hippynn/pytorch/loader.py
+++ b/hippynn/pytorch/loader.py
@@ -42,6 +42,66 @@ class ModelLoader(ForgeModel):
             framework=Framework.TORCH,
         )
 
+    @staticmethod
+    def _patch_padding_indexer():
+        # hippynn's PaddingIndexer.forward uses
+        #   torch.nonzero(x, as_tuple=False, out=buf)[:, 0]
+        # which is data-dependent and dynamo-hostile: the fake-tensor pass
+        # infers the output as 1-D (size=(0,)) and the [:, 0] then errors
+        # with "too many indices for tensor of dimension 1". Rewriting it as
+        # torch.nonzero(x, as_tuple=True)[0] yields the same eager value and
+        # traces cleanly.
+        import hippynn.layers.indexers as _indexers
+        import torch as _torch
+
+        if getattr(_indexers.PaddingIndexer.forward, "_tt_xla_patched", False):
+            return
+
+        def forward(self, features, nonblank):
+            dev = features.device
+            n_molecules, n_atoms_max = nonblank.shape
+            n_fictitious_atoms = nonblank.shape[0] * nonblank.shape[1]
+            flat_nonblank = nonblank.reshape(n_fictitious_atoms)
+            real_atoms = _torch.nonzero(flat_nonblank, as_tuple=True)[0]
+            n_real_atoms = real_atoms.shape[0]
+            # Avoid an `inv_real_atoms[real_atoms] = arange(...)` indexed
+            # assignment, which lowers to stablehlo.scatter and tt-mlir
+            # cannot legalize it for this op. Cumsum gives the correct
+            # mapping at every real-atom position; values at blank
+            # positions are unread downstream (only positions selected
+            # via `pair_presence = nonblank_pair & ...` are indexed into
+            # inv_real_atoms — see hippynn/layers/pairs/open.py:47-54).
+            inv_real_atoms = flat_nonblank.long().cumsum(0) - 1
+            indexed_features = features.reshape(n_molecules * n_atoms_max, -1)[
+                real_atoms
+            ]
+            if indexed_features.ndimension() == 1:
+                indexed_features = indexed_features.unsqueeze(1)
+            mol_index_shaped = (
+                _torch.arange(n_molecules, dtype=_torch.long, device=dev)
+                .unsqueeze(1)
+                .expand(-1, n_atoms_max)
+            )
+            atom_index_shaped = (
+                _torch.arange(n_atoms_max, dtype=_torch.long, device=dev)
+                .unsqueeze(0)
+                .expand(n_molecules, -1)
+            )
+            atom_index = atom_index_shaped.reshape(n_fictitious_atoms)[real_atoms]
+            mol_index = mol_index_shaped.reshape(n_fictitious_atoms)[real_atoms]
+            return (
+                indexed_features,
+                real_atoms,
+                inv_real_atoms,
+                mol_index,
+                atom_index,
+                n_molecules,
+                n_atoms_max,
+            )
+
+        forward._tt_xla_patched = True
+        _indexers.PaddingIndexer.forward = forward
+
     def load_model(self, *, dtype_override=None, **kwargs):
         """Load and return the Hippynn model wrapped in a Torch module.
 
@@ -49,7 +109,28 @@ class ModelLoader(ForgeModel):
             dtype_override: Optional torch.dtype to override model precision.
         """
 
+        import hippynn
         from hippynn.graphs import GraphModule, inputs, networks, targets
+        from hippynn.custom_kernels import set_custom_kernels
+
+        # Force the pure-PyTorch envsum/sensesum/featsum implementations.
+        # The numba CPU kernels call `.numpy()` on the input tensor, which
+        # fails for bfloat16 (raised under TT_XLA_ARCH=n150). The env-var
+        # equivalent is read at hippynn import time and would be too late
+        # here, so we call the runtime selector explicitly.
+        set_custom_kernels("pytorch")
+
+        # Disable the low-distance warning code path in SensitivityModule /
+        # InverseSensitivityModule (hippynn/layers/hiplayers.py:60-66 and
+        # :90-99). That path calls `mu, argmin = self.mu.min(dim=1)`, whose
+        # StableHLO lowering produces a 2-output `stablehlo.reduce` with an
+        # ArgMin reducer body. tt-mlir's StableHLOToTTIRPatterns.cpp
+        # handles ArgMax but not ArgMin, so the SHLO->TTIR conversion
+        # fails to legalize the op. The setting is read at forward time,
+        # so flipping it here (before the model traces) is sufficient.
+        hippynn.settings.WARN_LOW_DISTANCES = False
+
+        self._patch_padding_indexer()
 
         network_params = {
             "possible_species": [0, 1, 6, 7, 8, 16],
@@ -61,7 +142,6 @@ class ModelLoader(ForgeModel):
             "n_interaction_layers": 2,
             "n_atom_layers": 3,
         }
-        os.environ["HIPPYNN_USE_CUSTOM_KERNELS"] = "False"
         species = inputs.SpeciesNode(db_name="Z")
         positions = inputs.PositionsNode(db_name="R")
         network = networks.Hipnn(
@@ -79,7 +159,10 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model = model.to(dtype_override)
 
-        return model, henergy.mol_energy
+        return model
+
+    def unpack_forward_output(self, fwd_output):
+        return fwd_output[0]
 
     def load_inputs(self, dtype_override=None):
         """Load and return sample inputs (species and positions) for the model.


### PR DESCRIPTION
### Previous status of hippynn
```
hippynn/pytorch-Default-single_device-inference:
    status: KNOWN_FAILURE_XFAIL
    reason: "AssertionError: assert isinstance(self._model, torch.nn.Module) - https://github.com/tenstorrent/tt-xla/issues/1815"
```
### What's changed
Loader changes (all in hippynn/pytorch/loader.py):

1. `load_model` now returns only the `GraphModule` instead of the `(model, henergy.mol_energy)` tuple. The runner asserts that `self._model` is a `torch.nn.Module`, which the tuple form failed (recorded XFAIL #1815).

2. Added `unpack_forward_output(self, fwd_output) -> fwd_output[0]`. The graph module wraps its single output in a 1-tuple and the global unpack registry has no `tuple` handler.

3. Replaced the late `os.environ["HIPPYNN_USE_CUSTOM_KERNELS"]` write with an explicit `set_custom_kernels("pytorch")` call inside `load_model`. The env var is read at hippynn import time, so the loader was setting it after numba had already been selected — the numba CPU kernel then called `.numpy()` on a bf16 tensor and crashed.

4. Added `_patch_padding_indexer()` monkey-patch invoked from `load_model`. It rebinds `hippynn.layers.indexers.PaddingIndexer.forward` to a version that:
   - Uses `torch.nonzero(flat_nonblank, as_tuple=True)[0]` instead of `torch.nonzero(..., as_tuple=False, out=)[:, 0]`. The original form is data-dependent and dynamo-hostile — the fake-tensor pass infers the output as 1-D (size=(0,)) and the trailing `[:, 0]` errors with "too many indices for tensor of dimension 1".
   - Replaces `inv_real_atoms[real_atoms] = arange(...)` with `inv_real_atoms = flat_nonblank.long().cumsum(0) - 1`. The indexed assignment lowers to `stablehlo.scatter`, which tt-mlir does not legalize for this shape/index pattern. The cumsum formulation is bit-exact at every real-atom position; downstream consumers only index `inv_real_atoms` at real-atom positions (see hippynn/layers/pairs/open.py:47-54 and pairs/indexing.py:120-134), so blank-position values are unread.

5. Set `hippynn.settings.WARN_LOW_DISTANCES = False` in `load_model`. That setting gates the `.min(dim=1)` call in `SensitivityModule.forward` and `InverseSensitivityModule.forward` (hiplayers.py:60-66, :90-99). The two-output `torch.min(x, dim=1)` lowers in StableHLO to a 2-output `stablehlo.reduce` whose reducer body is the ArgMin pattern (`LE` comparator, +inf init, iota index input). tt-mlir's StableHLOToTTIRPatterns.cpp legalizes ArgMax but not ArgMin, so the conversion fails. Flipping the setting before tracing short-circuits the entire ArgMin code path.

### Current stage
After these changes the hippynn/pytorch-Default-single_device-inference model compiles end-to-end and executes on n150 (final residual is a PCC drop from a single-scalar HEnergy output, tracked separately).

### Checklist
- [x] New/Existing tests provide coverage for changes

### Logs
[bringup_steps.txt](https://github.com/user-attachments/files/28148991/bringup_steps.txt) - per-iteration audit trail showing the failure that motivated each individual fix.
[debug_report.md](https://github.com/user-attachments/files/28148992/debug_report.md) - runtime-failure-debugger output identifying the stablehlo.reduce ArgMin gap in tt-mlir (StableHLOToTTIRPatterns.cpp legalizes ArgMax but not ArgMin), which fix #5 (WARN_LOW_DISTANCES=False) works around at the model side until the tt-mlir handler lands.
[iter_7_run.log](https://github.com/user-attachments/files/28148993/iter_7_run.log) - model compiles + runs on n150 with all 5 loader fixes (final failure is PCC=0 from single-scalar output, tracked separately, kept as KNOWN_FAILURE_XFAIL).

