### PR TITLE
Bringup the c4ai-command-r-v01

### DIFF
--- a/coherlabs/causal_lm/pytorch/__init__.py
+++ b/coherlabs/causal_lm/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Command R causal language modeling implementation for Tenstorrent projects.
+"""
+# Import from the loader module
+from .loader import ModelLoader

--- a/coherlabs/causal_lm/pytorch/loader.py
+++ b/coherlabs/causal_lm/pytorch/loader.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Command R causal LM model loader implementation.
+"""
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Command R model variants for causal language modeling."""
+
+    C4AI_COMMAND_R_V01 = "c4ai-command-r-v01"
+
+
+class ModelLoader(ForgeModel):
+    """Command R model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.C4AI_COMMAND_R_V01: LLMModelConfig(
+            pretrained_model_name="CohereLabs/c4ai-command-r-v01",
+            max_length=256,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.C4AI_COMMAND_R_V01
+
+    sample_text = "How many r's are there in strawberry?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.model = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="Command_R",
+            variant=variant,
+            group=ModelGroup.RED,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        """Load tokenizer for the current variant.
+        Returns:
+            The loaded tokenizer instance
+        """
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        """Load and return the Command R model for this instance's variant.
+
+        Args:
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The model for causal language modeling.
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+
+        model.eval()
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the Command R model.
+
+        Args:
+            batch_size: Batch size for the inputs.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        max_length = self._variant_config.max_length
+        conversation = [{"role": "user", "content": self.sample_text}]
+        prompt = self.tokenizer.apply_chat_template(
+            conversation, tokenize=False, add_generation_prompt=True
+        )
+        inputs = self.tokenizer(
+            prompt,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+        return inputs


### PR DESCRIPTION
## Summary

Bring up Command R (`CohereLabs/c4ai-command-r-v01`) for the `single_device` inference path on Tenstorrent hardware.

## Changes

- Add `coherlabs/causal_lm/pytorch/__init__.py` — re-exports `ModelLoader`.
- Add `coherlabs/causal_lm/pytorch/loader.py` — `Command R` loader with variant `C4AI_COMMAND_R_V01 = "c4ai-command-r-v01"`, using `AutoTokenizer` + `AutoModelForCausalLM` from `transformers`.

## Test target (in tt-xla)

`tests/runner/test_models.py::test_all_models_torch[coherlabs/causal_lm/pytorch-c4ai-command-r-v01-single_device-inference]`

Generated by the `llm-model-bringup` skill.