### PR TITLE
Fix DeepSeek-OCR NaN logits on transformers 5.2 after from_pretrained load

### DIFF
--- a/deepseek/deepseek_ocr/pytorch/loader.py
+++ b/deepseek/deepseek_ocr/pytorch/loader.py
@@ -20,6 +20,7 @@ from ....config import (
 )
 from ....tools.utils import get_file
 from .src.modeling_deepseekocr import DeepseekOCRForCausalLM
+from .src.modeling_deepseekv2 import reinit_llama_rotary_inv_freq_buffers
 from .src.model_utils import preprocess
 from huggingface_hub import snapshot_download
 
@@ -134,6 +135,8 @@ class ModelLoader(ForgeModel):
             trust_remote_code=True,
             **kwargs,
         )
+        # Belt-and-suspenders if a caller bypasses DeepseekV2PreTrainedModel._finalize_model_loading.
+        reinit_llama_rotary_inv_freq_buffers(model)
 
         # Configure model settings
         model.config.return_dict = False

--- a/deepseek/deepseek_ocr/pytorch/src/modeling_deepseekv2.py
+++ b/deepseek/deepseek_ocr/pytorch/src/modeling_deepseekv2.py
@@ -43,6 +43,40 @@ from transformers.models.llama.modeling_llama import (
     LlamaRotaryEmbedding,
 )  # Needed to compute position embeddings
 
+
+def reinit_llama_rotary_inv_freq_buffers(module: nn.Module) -> None:
+    """Recompute ``LlamaRotaryEmbedding`` inverse frequencies after ``from_pretrained``.
+
+    Transformers >=5 meta loading fills non-persistent ``inv_freq`` buffers with
+    ``torch.empty_like`` (uninitialized). DeepSeek-OCR checkpoints do not store
+    ``rotary_emb.inv_freq``, so RoPE cos/sin become NaN without this step.
+    """
+    for rotary in module.modules():
+        if not isinstance(rotary, LlamaRotaryEmbedding):
+            continue
+        if hasattr(rotary, "compute_default_rope_parameters"):
+            rope_type = getattr(rotary, "rope_type", "default")
+            if rope_type != "default":
+                from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+                rope_fn = ROPE_INIT_FUNCTIONS[rope_type]
+            else:
+                rope_fn = rotary.compute_default_rope_parameters
+            inv_freq, _ = rope_fn(rotary.config)
+        elif hasattr(rotary, "rope_init_fn"):
+            inv_freq, _ = rotary.rope_init_fn(
+                rotary.config, None, **getattr(rotary, "rope_kwargs", {})
+            )
+        else:
+            continue
+
+        inv_freq = inv_freq.to(device=rotary.inv_freq.device, dtype=rotary.inv_freq.dtype)
+        with torch.no_grad():
+            rotary.inv_freq.copy_(inv_freq)
+            if hasattr(rotary, "original_inv_freq") and rotary.original_inv_freq is not rotary.inv_freq:
+                rotary.original_inv_freq.copy_(inv_freq)
+
+
 import torch.fx
 
 _prepare_4d_causal_attention_mask = torch.fx.wrap(_prepare_4d_causal_attention_mask)
@@ -561,6 +595,14 @@ class DeepseekV2PreTrainedModel(PreTrainedModel):
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn_2 = True
     _supports_cache_class = True
+
+    @staticmethod
+    def _finalize_model_loading(model, load_config, loading_info):
+        loading_info = PreTrainedModel._finalize_model_loading(
+            model, load_config, loading_info
+        )
+        reinit_llama_rotary_inv_freq_buffers(model)
+        return loading_info
 
     def _init_weights(self, module):
         std = self.config.initializer_range


### PR DESCRIPTION
### Ticket

- [tenstorrent/tt-xla#4703](https://github.com/tenstorrent/tt-xla/issues/4703) — DeepSeek-OCR: NaN logits (CPU forge + TT) with transformers 5.2; 4.46 finite
- Related (separate): [tenstorrent/tt-xla#4849](https://github.com/tenstorrent/tt-xla/issues/4849) — ~0.94 whole-model PCC from cumulative error in the DeepseekV2 decoder stack (not addressed here)

### Problem description
- DeepSeek-OCR in tt-forge-models uses a local modeling_deepseekv2.py fork on top of tt-xla’s transformers 5.2 environment. 
- On 5.2, from_pretrained can leave LlamaRotaryEmbedding.inv_freq uninitialized: Transformers ≥5 meta-loading fills non-persistent inv_freq buffers with torch.empty_like, and DeepSeek-OCR checkpoints do not store rotary_emb.inv_freq. 
- RoPE cos/sin then become NaN, so CPU forge reference and TT runs report pcc=nan instead of a meaningful comparison ([tt-xla#4703](https://github.com/tenstorrent/tt-xla/issues/4703)).

- On transformers 4.46.3, the same forge path produces finite logits. Pinning 4.46.3 per model was explored in [tt-forge-models#684](https://github.com/tenstorrent/tt-forge-models/pull/684) (HF-direct hub load + requirements.txt pin). That path also ended at ~0.94 whole-model PCC (CPU vs TT), matching the cumulative decoder-stack behavior tracked in [tt-xla#4849](https://github.com/tenstorrent/tt-xla/issues/4849). 
- #684 was not merged because per-model downgrade pins are not allowed in the dev environment. This PR fixes the 5.2-specific NaN in the existing local modeling stack without a Transformers downgrade.

Scope: Restores finite logits / non-NaN PCC on 5.2. It does not raise whole-model PCC to 0.99 (~0.94 remains; see [tt-xla#4849](https://github.com/tenstorrent/tt-xla/issues/4849)).

### What's changed
- deepseek/deepseek_ocr/pytorch/src/modeling_deepseekv2.py: Add reinit_llama_rotary_inv_freq_buffers() to recompute LlamaRotaryEmbedding.inv_freq (and original_inv_freq when present) via Transformers 5.x rope init APIs after load.
- Override DeepseekV2PreTrainedModel._finalize_model_loading() to call the helper after PreTrainedModel._finalize_model_loading (covers DeepseekOCRForCausalLM → DeepseekV2ForCausalLM inheritance).
deepseek/deepseek_ocr/pytorch/loader.py
- Call reinit_llama_rotary_inv_freq_buffers(model) after from_pretrained as a belt-and-suspenders path if loading bypasses the hook.
- No change to per-model requirements.txt (no transformers==4.46.3 pin). No HF-direct loader refactor from #684.

### Checklist
- [x] New/Existing tests provide coverage for changes
- Validated via tt-xla deepseek/deepseek_ocr/pytorch-Ocr-single_device-inference: before fix pcc=nan; after fix pcc≈0.944 (finite). test-config update planned in tt-xla after this merges.

### Logs
- Before (transformers 5.2, submodule without this fix): [deepseek_ocr_nan_pcc.log](https://github.com/user-attachments/files/28203789/deepseek_cor_nan_pcc.log)
- After Fix:[deepseek_ocr_nan_pcc_after_fix.log](https://github.com/user-attachments/files/28203787/deepseek_cor_nan_pcc_after_fix.log)
