### PR TITLE
[Hunyuan_image-2.1] fix Qwen2.5-VL text encoder sharding and drop unused vision tower

### DIFF
--- a/hunyuan_image_2_1/pytorch/src/model_utils.py
+++ b/hunyuan_image_2_1/pytorch/src/model_utils.py
@@ -56,15 +56,21 @@ BYT5_VOCAB_SIZE = 384  # ByT5 text_encoder_2
 
 
 def load_text_encoder(dtype: torch.dtype = DTYPE):
-    """Load Qwen2.5-VL text encoder from the text_encoder subfolder."""
+    """Load Qwen2.5-VL text encoder from the text_encoder subfolder.
+
+    The pipeline only feeds input_ids/attention_mask (no pixel_values), so the
+    vision tower never runs. Return just `.language_model` to avoid uploading
+    the unused ~0.68B-param visual tower (replicated on every chip).
+    """
     from transformers import AutoModel
 
-    return AutoModel.from_pretrained(
+    encoder = AutoModel.from_pretrained(
         REPO_ID,
         subfolder="text_encoder",
         torch_dtype=dtype,
         device_map="cpu",
     ).eval()
+    return getattr(encoder, "language_model", encoder)
 
 
 def load_text_encoder_2(dtype: torch.dtype = DTYPE):
@@ -168,12 +174,19 @@ def shard_text_encoder_specs(encoder) -> dict:
     """
     specs = {}
 
+    # Unwrap Qwen2_5_VLModel -> decoder; else embed_tokens/layers aren't found
+    # and every weight stays replicated on each device -> DRAM OOM.
+    encoder = getattr(encoder, "language_model", encoder)
+
     if hasattr(encoder, "embed_tokens"):
         specs[encoder.embed_tokens.weight] = (None, "batch")
 
     layers = getattr(encoder, "layers", None)
-    if layers is None:
-        return specs
+    if not layers:
+        raise ValueError(
+            f"No decoder layers on {type(encoder).__name__}; refusing to run "
+            "fully replicated (expected `.layers` after unwrapping)."
+        )
 
     for layer in layers:
         sa = layer.self_attn


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/4779

### Problem description
The HunyuanImage 2.1 Qwen2.5-VL text encoder OOM'd on 2, 4, and 8 chips with an *identical* DRAM allocation failure at every mesh size — a sign sharding wasn't taking effect. Two root causes:
1. `shard_text_encoder_specs()` looked for `embed_tokens`/`layers` on the top-level `Qwen2_5_VLModel`, but they live under `.language_model`. It silently returned `{}`, so every weight was replicated on all chips regardless of mesh size.
2. `AutoModel` loads the full multimodal model including the `visual` tower, which the text path never runs, yet it was uploaded to every chip.

**Code evidence the vision tower is never used in the text path:**
- The HunyuanImage pipeline calls the encoder with only `input_ids` / `attention_mask` (no `pixel_values`): [diffusers v0.37.1 — pipeline_hunyuanimage.py#L245-L249](https://github.com/huggingface/diffusers/blob/v0.37.1/src/diffusers/pipelines/hunyuan_image/pipeline_hunyuanimage.py#L245-L249)
- `self.visual` (via `get_image_features`) only runs inside `if pixel_values is not None:`, so with no image input the tower is skipped entirely: [transformers v5.5.1 — modeling_qwen2_5_vl.py#L1301-L1307](https://github.com/huggingface/transformers/blob/a1b90c4fe2e9cf962bcf2e70339c6021293895b9/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py#L1301-L1307)

### What's changed
- **`shard_text_encoder_specs`**: unwrap `.language_model` before building specs so sharding actually applies; raise instead of silently returning `{}` when no decoder layers are found.
- **`load_text_encoder`**: return `.language_model`, dropping the unused ~0.68B-param vision tower (~2.7 GB/chip in fp32).
- Impact: sharding now works — the test **passes on 4 chips** (previously OOM on 2/4/8).

### Checklist
- [x] Verify the changes through local testing in N150

### Logs

- [may29_HunyuanImage_encoder_2_chips.log](https://github.com/user-attachments/files/28398664/may29_HunyuanImage_encoder_2_chips.log)
- [may29_HunyuanImage_encoder_4_chips.log](https://github.com/user-attachments/files/28398666/may29_HunyuanImage_encoder_4_chips.log)
- [may29_HunyuanImage_encoder_8_chips.log](https://github.com/user-attachments/files/28398670/may29_HunyuanImage_encoder_8_chips.log)
- [may29_HunyuanImage_encoder_2_chips_after_fix.log](https://github.com/user-attachments/files/28398661/may29_HunyuanImage_encoder_2_chips_after_final_fix.log)
- [may29_HunyuanImage_encoder_4_chips_after_fix.log](https://github.com/user-attachments/files/28398665/may29_HunyuanImage_encoder_4_chips_after_final_fix.log)


