### PR TITLE
Add ConvNeXt-V2 image classification model loader

### DIFF
--- a/convnext_v2/__init__.py
+++ b/convnext_v2/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/convnext_v2/pytorch/__init__.py
+++ b/convnext_v2/pytorch/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/convnext_v2/pytorch/loader.py
+++ b/convnext_v2/pytorch/loader.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+ConvNeXt-V2 model loader implementation for image classification
+"""
+import torch
+from transformers import AutoImageProcessor, ConvNextV2ForImageClassification
+from datasets import load_dataset
+from typing import Optional
+
+from ...base import ForgeModel
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available ConvNeXt-V2 model variants."""
+
+    HUGE = "Huge"
+
+
+class ModelLoader(ForgeModel):
+    """ConvNeXt-V2 model loader implementation for image classification tasks."""
+
+    _VARIANTS = {
+        ModelVariant.HUGE: ModelConfig(
+            pretrained_model_name="facebook/convnextv2-huge-22k-512",
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.HUGE
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        super().__init__(variant)
+        self.processor = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        return ModelInfo(
+            model="ConvNeXtV2",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_processor(self):
+        self.processor = AutoImageProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.processor
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.processor is None:
+            self._load_processor()
+
+        model = ConvNextV2ForImageClassification.from_pretrained(
+            pretrained_model_name, **kwargs
+        )
+
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        if self.processor is None:
+            self._load_processor()
+
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        image = dataset[0]["image"]
+
+        inputs = self.processor(images=image, return_tensors="pt")
+
+        if dtype_override is not None:
+            inputs["pixel_values"] = inputs["pixel_values"].to(dtype_override)
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+
+        return inputs


### PR DESCRIPTION
### Github Issue
[Issue Link](https://github.com/tenstorrent/tt-xla/issues/5046)

### Problem description
Add a torch loader for facebook/convnextv2-huge-22k-512 via the standard transformers ConvNextV2ForImageClassification interface, for image classification (CV_IMAGE_CLS) on the Hugging Face source.

### What's changed
Bringup convnextv2 model using E2E pipeline

### Checklist
- [x] New/Existing tests provide coverage for changes

### Logs
[bringup_steps.txt](https://github.com/user-attachments/files/28460579/bringup_steps.txt)
[iter_1_manual.log](https://github.com/user-attachments/files/28460581/iter_1_manual.log)
