### PR TITLE
Add Donut (DocVQA) vision-encoder-decoder model loader

### DIFF
--- a/donut/__init__.py
+++ b/donut/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/donut/pytorch/__init__.py
+++ b/donut/pytorch/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/donut/pytorch/loader.py
+++ b/donut/pytorch/loader.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Donut (Document Understanding Transformer) model loader for DocVQA.
+
+Donut is a vision-encoder-decoder model: DonutSwin (vision) + MBart (text).
+Loaded as a VisionEncoderDecoderModel; forward returns Seq2SeqLMOutput
+(default `unpack_forward_output` handler resolves to `.logits`).
+"""
+import torch
+from transformers import DonutProcessor, VisionEncoderDecoderModel
+from datasets import load_dataset
+from typing import Optional
+
+from ...base import ForgeModel
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Donut model variants."""
+
+    BASE_FINETUNED_DOCVQA = "Base_Finetuned_DocVQA"
+
+
+class ModelLoader(ForgeModel):
+    """Donut model loader for document understanding (DocVQA)."""
+
+    _VARIANTS = {
+        ModelVariant.BASE_FINETUNED_DOCVQA: ModelConfig(
+            pretrained_model_name="naver-clova-ix/donut-base-finetuned-docvqa",
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.BASE_FINETUNED_DOCVQA
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        super().__init__(variant)
+        self.processor = None
+        self.model = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        return ModelInfo(
+            model="Donut",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_QA,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_processor(self):
+        self.processor = DonutProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.processor
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.processor is None:
+            self._load_processor()
+
+        self.model = VisionEncoderDecoderModel.from_pretrained(
+            pretrained_model_name, **kwargs
+        )
+
+        if dtype_override is not None:
+            self.model = self.model.to(dtype_override)
+        return self.model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        if self.model is None:
+            self.load_model(dtype_override=dtype_override)
+
+        # Sample image — DonutProcessor will resize/pad to the encoder's
+        # configured input size (2560x1920 for the docvqa checkpoint).
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        image = dataset[0]["image"]
+
+        pixel_values = self.processor(images=image, return_tensors="pt").pixel_values
+
+        if dtype_override is not None:
+            pixel_values = pixel_values.to(dtype_override)
+
+        if batch_size != 1:
+            pixel_values = pixel_values.repeat_interleave(batch_size, dim=0)
+
+        # DocVQA task prompt format:
+        #   "<s_docvqa><s_question>{q}</s_question><s_answer>"
+        # For a forward-pass test we tokenize the task prompt header (without
+        # any specific question) so the decoder sees a valid sequence start.
+        task_prompt = "<s_docvqa>"
+        decoder_input_ids = self.processor.tokenizer(
+            task_prompt, add_special_tokens=False, return_tensors="pt"
+        ).input_ids
+        if batch_size != 1:
+            decoder_input_ids = decoder_input_ids.repeat_interleave(batch_size, dim=0)
+
+        return [pixel_values, decoder_input_ids]


### PR DESCRIPTION


### Problem description
Add a torch loader for naver-clova-ix/donut-base-finetuned-docvqa via the transformers VisionEncoderDecoderModel interface (DonutSwin vision encoder + MBart text decoder) for document visual question answering.


### What's changed
Bringup donut-base-finetuned-docvqa via E2E model bringup pipeline

### Checklist
- [x] New/Existing tests provide coverage for changes

### Current Status
The final status of donut/pytorch-Base_Finetuned_DocVQA-single_device-inference is:

  ```
KNOWN_FAILURE_XFAIL

  Reason: PCC = 0.8997 vs required 0.99.
```
  

-  Root-caused via the runtime-failure-debugger: bf16 numerical drift accumulating through DonutSwin stage 2 (14 identical blocks), with block 9 the largest single contributor (−0.0356 PCC). It's not a frontend/loader bug — it likely needs a tt-mlir-level fix (fp32 softmax in window attention). Details are in claude_logs_donut/debug_report.md.
- So it was diagnosed but not fixed at the tt-xla layer — it's to be marked as xfail or lower pcc threshold. 
- Unable to replicate pcc drop in sanity

### Logs
[bringup_steps.txt](https://github.com/user-attachments/files/28460868/bringup_steps.txt)
[debug_report.md](https://github.com/user-attachments/files/28460869/debug_report.md)
[iter_1_run.log](https://github.com/user-attachments/files/28460871/iter_1_run.log)
