### PR TITLE
Add Hiera image classification model loader

### DIFF
--- a/hiera/__init__.py
+++ b/hiera/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/hiera/pytorch/__init__.py
+++ b/hiera/pytorch/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from .loader import ModelLoader, ModelVariant

--- a/hiera/pytorch/loader.py
+++ b/hiera/pytorch/loader.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Hiera model loader implementation for image classification
+"""
+import torch
+from transformers import AutoImageProcessor, HieraForImageClassification
+from datasets import load_dataset
+from typing import Optional
+
+from ...base import ForgeModel
+from ...config import (
+    ModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Hiera model variants."""
+
+    BASE_224_IN1K = "Base_224_In1k"
+
+
+class ModelLoader(ForgeModel):
+    """Hiera model loader implementation for image classification tasks."""
+
+    _VARIANTS = {
+        ModelVariant.BASE_224_IN1K: ModelConfig(
+            pretrained_model_name="facebook/hiera-base-224-in1k-hf",
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.BASE_224_IN1K
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        super().__init__(variant)
+        self.processor = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        return ModelInfo(
+            model="Hiera",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.CV_IMAGE_CLS,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_processor(self):
+        self.processor = AutoImageProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.processor
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.processor is None:
+            self._load_processor()
+
+        model = HieraForImageClassification.from_pretrained(
+            pretrained_model_name, **kwargs
+        )
+
+        if dtype_override is not None:
+            model = model.to(dtype_override)
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        if self.processor is None:
+            self._load_processor()
+
+        dataset = load_dataset("huggingface/cats-image")["test"]
+        image = dataset[0]["image"]
+
+        inputs = self.processor(images=image, return_tensors="pt")
+
+        if dtype_override is not None:
+            inputs["pixel_values"] = inputs["pixel_values"].to(dtype_override)
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+
+        return inputs


### PR DESCRIPTION


### Problem description
Add a torch loader for facebook/hiera-base-224-in1k-hf via the standard transformers HieraForImageClassification interface, for image classification (CV_IMAGE_CLS) on the Hugging Face source.

### What's changed
Bringup facebook/hiera-base-224-in1k-hf model using E2E model bringup pipeline

### Checklist
- [x] New/Existing tests provide coverage for changes

### Current status
`KNOWN_FAILURE_XFAIL — bringup_status: FAILED_TTMLIR_COMPILATION`
**Reason:** The TTIRToTTNNCommon pipeline failed with ValueError: Error code: 13 at _xla_warm_up_cache. The verbose log did not surface a specific failing op.

The E2E pipeline escalated this issue, mentioning human intervention needed

### Logs
[bringup_steps.txt](https://github.com/user-attachments/files/28461361/bringup_steps.txt)
[escalation_report.md](https://github.com/user-attachments/files/28461363/escalation_report.md)
[iter_1_run.log](https://github.com/user-attachments/files/28461364/iter_1_run.log)

