### PR TITLE
Make timm import lazy in tools/utils.py

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -15,9 +15,6 @@ from typing import Optional, Union, List, Callable, Any
 from PIL import Image
 from torchvision import models, transforms
 from transformers import AutoImageProcessor
-import timm
-from timm.data import resolve_data_config
-from timm.data.transforms_factory import create_transform
 
 
 def get_file(path):
@@ -501,6 +498,11 @@ class VisionPreprocessor:
         Returns:
             torch.Tensor: Preprocessed tensor with batch dimension
         """
+
+        import timm
+        from timm.data import resolve_data_config
+        from timm.data.transforms_factory import create_transform
+
         # Use provided model, cached model, or load one
         if model_for_config is None:
             if self._cached_model is not None:


### PR DESCRIPTION
`timm` is only used by `VisionPreprocessor`, but importing it at module level pulled it into `base.ForgeModel`'s import path, forcing every model — including NLP/text models — to require timm at import time (broke timm-less environments like the tt-xla release demo jobs). This moves the import inside the method that uses it.

### Example failing jobs (tt-xla nightly release demos)
All failed with `ModuleNotFoundError: No module named 'timm'`:
- [Demo tt-xla albert_base_v2_jax (p150b, ubuntu)](https://github.com/tenstorrent/tt-xla/actions/runs/26728987456/job/78815597381)
- [Demo tt-xla albert_base_v2_pytorch (n150, ubuntu)](https://github.com/tenstorrent/tt-xla/actions/runs/26728987456/job/78815597488)
- [Demo tt-xla gpt2 (p150b, ubuntu)](https://github.com/tenstorrent/tt-xla/actions/runs/26728987456/job/78815597461)
- [Demo tt-xla opt_jax (n150, ubuntu)](https://github.com/tenstorrent/tt-xla/actions/runs/26728987456/job/78815597618)
- [Demo tt-xla bge_m3 (n150, ubuntu)](https://github.com/tenstorrent/tt-xla/actions/runs/26728987456/job/78815598090)