### PR TITLE
Prepare yolox for tt-inference-server

### DIFF
--- a/yolox/pytorch/loader.py
+++ b/yolox/pytorch/loader.py
@@ -100,7 +100,7 @@ class ModelLoader(ForgeModel):
             framework=Framework.TORCH,
         )
 
-    def load_model(self, *, dtype_override=None, **kwargs):
+    def load_model(self, dtype_override=None, **kwargs):
         """Load and return the YOLOX model instance with default settings.
 
         Args:
@@ -142,6 +142,80 @@ class ModelLoader(ForgeModel):
 
         return model
 
+    def input_preprocess(self, dtype_override=None, batch_size=1, image=None):
+        """Preprocess an input image and return a model-ready tensor.
+
+        Args:
+            dtype_override: Optional torch.dtype override (default: float32).
+            batch_size: Batch size (default: 1).
+            image: PIL Image or None. If None, loads a default image from HuggingFace.
+
+        Returns:
+            torch.Tensor: Preprocessed input tensor.
+        """
+        import numpy as np
+        from yolox.data.data_augment import preproc as preprocess
+
+        model_name = self._variant_config.pretrained_model_name
+        input_shape = (
+            (416, 416) if model_name in ["yolox_nano", "yolox_tiny"] else (640, 640)
+        )
+
+        if image is None:
+            from datasets import load_dataset
+
+            ds = load_dataset("mpnikhil/kitchen-classifier", split="train").with_format(
+                "np"
+            )
+            img = ds[200]["image"]
+        else:
+            img = np.array(image)
+
+        img_tensor, ratio = preprocess(img, input_shape)
+        self.ratio = ratio
+        self.input_shape = input_shape
+
+        batch_tensor = (
+            torch.from_numpy(img_tensor)
+            .unsqueeze(0)
+            .repeat_interleave(batch_size, dim=0)
+        )
+
+        if dtype_override is not None:
+            batch_tensor = batch_tensor.to(dtype_override)
+
+        return batch_tensor
+
+    def output_postprocess(self, output, top_k=None):
+        """Post-process raw model output into structured detection results.
+
+        Returns a dict with keys "labels", "probabilities", and "indices" (sorted by
+        descending confidence), compatible with ForgeRunner's _postprocess_model_output.
+
+        Args:
+            output: Model output tensor [batch, n_anchors, 85] or list/tuple thereof.
+            top_k: Maximum number of detections to return. None returns all.
+
+        Returns:
+            dict: {"labels": [...], "probabilities": [...], "indices": [...]}
+        """
+        from .src.utils import get_detections
+
+        if isinstance(output, (list, tuple)):
+            out_np = output[0].cpu().detach().float().numpy()
+        else:
+            out_np = output.cpu().detach().float().numpy()
+
+        detections = get_detections(out_np, self.ratio, self.input_shape)
+        if top_k is not None:
+            detections = detections[:top_k]
+
+        return {
+            "labels": [d["class_name"] for d in detections],
+            "probabilities": [f"{d['score'] * 100:.4f}%" for d in detections],
+            "indices": [d["cls_ind"] for d in detections],
+        }
+
     def load_inputs(self, dtype_override=None, batch_size=1):
         """Load and return sample inputs for the YOLOX model with default settings.
 
@@ -153,35 +227,9 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.Tensor: Sample input tensor that can be fed to the model.
         """
-        # Deter imports so not required at model discovery time
-        from datasets import load_dataset
-        from yolox.data.data_augment import preproc as preprocess
-
-        # Determine input shape based on model variant
-        model_name = self._variant_config.pretrained_model_name
-        if model_name in ["yolox_nano", "yolox_tiny"]:
-            input_shape = (416, 416)
-        else:
-            input_shape = (640, 640)
-
-        ds = load_dataset("mpnikhil/kitchen-classifier", split="train").with_format(
-            "np"
-        )  # to get the image as an numpy array
-        img = ds[200]["image"]
-        img_tensor, ratio = preprocess(img, input_shape)
-        self.ratio = ratio
-        self.input_shape = input_shape  # Store for post_processing
-        img_tensor = torch.from_numpy(img_tensor)
-        batch_tensor = img_tensor.unsqueeze(0)
-
-        # Replicate tensors for batch size
-        batch_tensor = batch_tensor.repeat_interleave(batch_size, dim=0)
-
-        # Only convert dtype if explicitly requested
-        if dtype_override is not None:
-            batch_tensor = batch_tensor.to(dtype_override)
-
-        return batch_tensor
+        return self.input_preprocess(
+            dtype_override=dtype_override, batch_size=batch_size
+        )
 
     def post_processing(self, co_out):
         """Post-process the model outputs.
@@ -192,6 +240,14 @@ class ModelLoader(ForgeModel):
         Returns:
             None: Prints the detection results
         """
-        from .src.utils import print_detection_results
+        from .src.utils import get_detections
 
-        print_detection_results(co_out, self.ratio, self.input_shape)
+        for i in range(len(co_out)):
+            co_out[i] = co_out[i].detach().float().numpy()
+
+        for det in get_detections(co_out[0], self.ratio, self.input_shape):
+            x_min, y_min, x_max, y_max = det["bbox"]
+            print(
+                f"Class: {det['class_name']}, Confidence: {det['score']}, "
+                f"Coordinates: ({x_min}, {y_min}, {x_max}, {y_max})"
+            )

--- a/yolox/pytorch/src/utils.py
+++ b/yolox/pytorch/src/utils.py
@@ -6,20 +6,22 @@ import numpy as np
 import torch
 
 
-def print_detection_results(co_out, ratio, input_shape):
-    """
-    Post-processes raw model outputs and prints detected object information.
+def get_detections(out_np, ratio, input_shape):
+    """Run NMS on raw model output and return a list of detection dicts.
 
-    This function converts model outputs into bounding boxes, applies non-maximum suppression (NMS),
-    and prints the class name, confidence score, and bounding box coordinates for each detected object.
+    Args:
+        out_np: numpy array of shape [batch, n_anchors, 85].
+        ratio: scale ratio from preproc, used to map boxes back to original image size.
+        input_shape: (h, w) tuple used during preprocessing.
+
+    Returns:
+        List of dicts with keys: class_name, score, cls_ind, bbox ([x1,y1,x2,y2]).
+        Sorted by descending confidence.
     """
     from yolox.data.datasets import COCO_CLASSES
     from yolox.utils import demo_postprocess, multiclass_nms
 
-    for i in range(len(co_out)):
-        co_out[i] = co_out[i].detach().float().numpy()
-
-    predictions = demo_postprocess(co_out[0], input_shape)[0]
+    predictions = demo_postprocess(out_np, input_shape)[0]
     boxes = predictions[:, :4]
     scores = predictions[:, 4:5] * predictions[:, 5:]
     boxes_xyxy = np.ones_like(boxes)
@@ -30,14 +32,20 @@ def print_detection_results(co_out, ratio, input_shape):
     boxes_xyxy /= ratio
     dets = multiclass_nms(boxes_xyxy, scores, nms_thr=0.45, score_thr=0.1)
 
+    result = []
     if dets is not None:
         final_boxes, final_scores, final_cls_inds = dets[:, :4], dets[:, 4], dets[:, 5]
         for box, score, cls_ind in zip(final_boxes, final_scores, final_cls_inds):
-            class_name = COCO_CLASSES[int(cls_ind)]
-            x_min, y_min, x_max, y_max = box
-            print(
-                f"Class: {class_name}, Confidence: {score}, Coordinates: ({x_min}, {y_min}, {x_max}, {y_max})"
+            result.append(
+                {
+                    "class_name": COCO_CLASSES[int(cls_ind)],
+                    "score": float(score),
+                    "cls_ind": int(cls_ind),
+                    "bbox": box.tolist(),
+                }
             )
+    result.sort(key=lambda d: d["score"], reverse=True)
+    return result
 
 
 def _forward_patch(self, xin, labels=None, imgs=None):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-inference-server/issues/3578

### Problem description
Yolox through tt-forge-models is missing input_preprocess and output_preprocess that are needed by tt-inference-server.

### What's changed
- Added input_preprocess, output_preprocess
- Refactored code to reduce redundancy

### Checklist
- [x] tests/runner/test_models.py::test_all_models_torch[yolox/pytorch-Nano-single_device-inference]: https://github.com/tenstorrent/tt-xla/actions/runs/26773255807 
- [x] tests/runner/test_models.py::test_all_models_torch[yolox/pytorch-Tiny-single_device-inference]: https://github.com/tenstorrent/tt-xla/actions/runs/26774118970
