### PR TITLE
Fix Janus config loading on transformers 5.5.1

### DIFF
--- a/janus_pro/text_to_image/pytorch/src/model_utils.py
+++ b/janus_pro/text_to_image/pytorch/src/model_utils.py
@@ -56,7 +56,41 @@ def apply_janus_load_patches() -> None:
     were first observed when tt-xla moved to transformers 5.x; the patches remain
     valid for whatever transformers version the forge env provides.
     """
+    apply_janus_config_dataclass_compat()
     apply_multimodality_post_init_patch()
+
+
+def apply_janus_config_dataclass_compat() -> None:
+    """
+    Skip HF ``@dataclass`` wrapping for ``janus.*`` config subclasses.
+
+    Transformers 5.5+ applies ``dataclass(kw_only=True)`` to every ``PretrainedConfig``
+    subclass inside ``__init_subclass__``. Janus configs declare ``params: AttrDict = {}``,
+    which raises::
+
+        ValueError: mutable default <class 'dict'> for field params is not allowed
+
+    before ``MultiModalityCausalLM`` can load.
+    """
+    import transformers.configuration_utils as config_utils
+    from transformers.configuration_utils import PretrainedConfig
+
+    if getattr(PretrainedConfig, "_janus_dataclass_compat_patched", False):
+        return
+
+    _orig_dataclass = config_utils.dataclass
+
+    def _dataclass(cls=None, /, **kwargs):
+        if cls is not None and isinstance(cls, type):
+            module = getattr(cls, "__module__", "") or ""
+            if module.startswith("janus."):
+                return cls
+        if cls is None:
+            return lambda c: _dataclass(c, **kwargs)
+        return _orig_dataclass(cls, **kwargs)
+
+    config_utils.dataclass = _dataclass
+    PretrainedConfig._janus_dataclass_compat_patched = True
 
 
 @contextmanager


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-xla/issues/5038

### Problem description
- Janus-Pro forge tests fail at model import time on transformers 5.5.1 (tt-xla env with Python 3.12). All 8 Janus-Pro tests fail before weights are loaded:[log](https://github.com/user-attachments/files/28489284/janus_failure.log)


```
ValueError: mutable default <class 'dict'> for field params is not allowed: use default_factory
```

- The failure happens when load_mmgpt() calls apply_janus_load_patches() and imports janus.models.modeling_vlm. That triggers definition of Janus config classes that subclass Hugging Face PretrainedConfig.

- Starting in transformers 5.5+, PretrainedConfig.__init_subclass__ automatically wraps every config subclass with @dataclass(repr=False, kw_only=True). Janus configs declare mutable defaults such as params: AttrDict = {}, which Python dataclasses reject. The upstream [deepseek-ai/Janus](https://github.com/deepseek-ai/Janus) package was not written for this behavior, so Janus-Pro cannot load under the transformers version tt-xla uses today.

### What's changed
- Add a load-time compatibility shim in janus_pro/text_to_image/pytorch/src/model_utils.py:

- `apply_janus_config_dataclass_compat() `— patches transformers.configuration_utils.dataclass to skip dataclass wrapping for classes in the janus.* module namespace; all other PretrainedConfig subclasses keep the default HF behavior.
Hook into existing load path — call it from apply_janus_load_patches() before Janus modules are imported, alongside the existing Janus load patches (post_init, linspace meta-device, etc.).
- Idempotent — guarded by `_janus_dataclass_compat_patched` so the patch applies once per process.
Impact: Janus config classes import cleanly under transformers 5.5.1, unblocking model and processor loading. With this fix, Janus-Pro tests pass and weights load successfully. 

### Checklist
- [x] New/Existing tests provide coverage for changes


### Logs
- [janus_log_after_fix.log](https://github.com/user-attachments/files/28489309/janus_after_failure.log)
- [janus_failure_log](https://github.com/user-attachments/files/28489310/janus_failure.log)
