### PR TITLE
Fix Gemma3 multimodal shard spec for nested submodule layout

### DIFF
--- a/gemma3/multimodal/pytorch/loader.py
+++ b/gemma3/multimodal/pytorch/loader.py
@@ -192,7 +192,9 @@ class ModelLoader(ForgeModel):
 
         shard_specs = {}
 
-        for layer in model.vision_tower.vision_model.encoder.layers:
+        base = getattr(model, "model", model)
+
+        for layer in base.vision_tower.vision_model.encoder.layers:
             shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
             shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
             shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
@@ -201,7 +203,7 @@ class ModelLoader(ForgeModel):
             shard_specs[layer.mlp.fc1.weight] = ("model", "batch")
             shard_specs[layer.mlp.fc2.weight] = ("batch", "model")
 
-        for layer in model.language_model.layers:
+        for layer in base.language_model.layers:
             shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
             shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
             shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
@@ -210,5 +212,8 @@ class ModelLoader(ForgeModel):
             shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
             shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
             shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
+
+        shard_specs[model.model.language_model.embed_tokens.weight] = ("model", "batch")
+        shard_specs[model.lm_head.weight] = ("model", "batch")
 
         return shard_specs


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
While running the 27B model with tensor parallelism, we encountered the following error:

```
tests/infra/runners/device_runner.py:38: in run_on_device
    device_workload = self._put_on_device(workload, device=device)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/infra/runners/device_runner.py:54: in _put_on_device
    return self._safely_put_workload_on_device(workload, device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/infra/runners/torch_device_runner.py:201: in _safely_put_workload_on_device
    shard_specs = workload.shard_spec_fn(workload.model)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
third_party/tt_forge_models/gemma3/multimodal/pytorch/loader.py:195: in load_shard_spec
    for layer in model.vision_tower.vision_model.encoder.layers:
                 ^^^^^^^^^^^^^^^^^^
venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1965: in __getattr__
    raise AttributeError(
E   AttributeError: 'Gemma3ForConditionalGeneration' object has no attribute 'vision_tower'
```


### What's changed
Resolve the base module via `getattr(model, "model", model)` so load_shard_spec works on both the new and old module layouts.

Logs:
Before:
[gemma3_27.log](https://github.com/user-attachments/files/28543056/gemma3_27.log)
After:
[gemma3_27_pass.log](https://github.com/user-attachments/files/28553042/gemma3_27_pass.log)






### Checklist
- [ ] New/Existing tests provide coverage for changes
