### PR TITLE
vovnet: partial revert of #435 — re-enable pretrained weights on OSMR + TIMM source variants

### DIFF
--- a/vovnet/pytorch/loader.py
+++ b/vovnet/pytorch/loader.py
@@ -155,8 +155,7 @@ class ModelLoader(ForgeModel):
         source = cfg.source
 
         if source == ModelSource.OSMR:
-            # Use randomly initialized weights (no pretrained download)
-            model = ptcv_get_model(model_name, pretrained=False)
+            model = ptcv_get_model(model_name, pretrained=True)
         elif source == ModelSource.TIMM:
             model, _ = download_model(preprocess_timm_model, model_name)
         elif source == ModelSource.TORCH_HUB:

--- a/vovnet/pytorch/src/utils.py
+++ b/vovnet/pytorch/src/utils.py
@@ -18,7 +18,10 @@ from ....tools.utils import get_file
 
 
 def preprocess_steps(model_type):
-    # Use randomly initialized weights (no pretrained download)
+    # TORCH_HUB path only: vovnet39_th / vovnet57_th pretrained weights are
+    # hosted on dl.dropbox.com URLs in src_vovnet_stigma.py (model_urls dict)
+    # which return 403. Random init as workaround until upstream URLs migrate.
+    # See tt-xla#2390. OSMR and TIMM paths are unaffected and use pretrained.
     model = model_type(False, True).eval()
     config = resolve_data_config({}, model=model)
     transform = create_transform(**config)
@@ -37,8 +40,7 @@ def preprocess_steps(model_type):
 
 
 def preprocess_timm_model(model_name):
-    # Use randomly initialized weights (no pretrained download)
-    use_pretrained_weights = False
+    use_pretrained_weights = True
     if model_name == "ese_vovnet99b":
         use_pretrained_weights = False
     model = timm.create_model(model_name, pretrained=use_pretrained_weights)


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/2390 (root cause of #435)

### Problem description

- vovnet27s would fail in tt-inference-server when uplifting tt-forge-models since random weights used, if not for this PR
- #435 disabled pretrained weights on **all three** vovnet weight-source branches (OSMR, TIMM, TORCH_HUB) to work around a Dropbox 403.
- Only the **TORCH_HUB** path actually uses Dropbox URLs (in `src_vovnet_stigma.py:model_urls`). OSMR pulls from `github.com/osmr/imgclsmob/releases` and TIMM pulls from `huggingface.co/timm` — both healthy.
- Verified `grep -ri dropbox` across `pytorchcv/` returns zero hits — OSMR was not affected.
- Net effect of #435: downstream accuracy tests broken on variants that didn't need to be touched.

### What's changed

- Restore `pretrained=True` on the OSMR branch in `vovnet/pytorch/loader.py`.
- Restore `use_pretrained_weights = True` default in `preprocess_timm_model` in `vovnet/pytorch/src/utils.py`.
- Leave the TORCH_HUB path (`preprocess_steps`) at `model_type(False, True)` — Dropbox URLs still return 403.
- Preserve the pre-existing `ese_vovnet99b` special-case (pretrained ckpt never published upstream).
- Sharpen the comment on `preprocess_steps` so it's clear *which* path it applies to.

### Variant matrix

| Variant | Source | Weights |
|---|---|---|
| `vovnet27s` (default) | OSMR | **Pretrained ✅** (restored) |
| `vovnet39` | OSMR | **Pretrained ✅** (restored) |
| `vovnet57` | OSMR | **Pretrained ✅** (restored) |
| `ese_vovnet19b_dw` | TIMM | **Pretrained ✅** (restored) |
| `ese_vovnet39b` | TIMM | **Pretrained ✅** (restored) |
| `ese_vovnet19b_dw.ra_in1k` | TIMM | **Pretrained ✅** (restored) |
| `vovnet39_th` | TORCH_HUB | Random (Dropbox 403 — tt-xla#2390) |
| `vovnet57_th` | TORCH_HUB | Random (Dropbox 403 — tt-xla#2390) |
| `ese_vovnet99b` | TIMM | Random (no upstream ckpt — predates #435) |

### Testing

- [x] vovnet27s pass in tt-inference-server again w/ this change
- [x] All vovnet single_chip +inference variants passed locally on p150 9/9 
[vovnet_p150_tests.log](https://github.com/user-attachments/files/28564735/vovnet_p150_tests.log)
- [x] tt-xla n150 CI vovnet tests: https://github.com/tenstorrent/tt-xla/actions/runs/26903654666
