### PR TITLE
Fix Qwen2.5-VL inference: add mm_token_type_ids input to wrapper forward

### DIFF
--- a/qwen_2_5_vl/pytorch/src/model.py
+++ b/qwen_2_5_vl/pytorch/src/model.py
@@ -14,12 +14,20 @@ class Wrapper(torch.nn.Module):
         super().__init__()
         self.model = model
 
-    def forward(self, input_ids, attention_mask, pixel_values, image_grid_thw):
+    def forward(
+        self,
+        input_ids,
+        attention_mask,
+        pixel_values,
+        image_grid_thw,
+        mm_token_type_ids=None,
+    ):
         inputs = {
             "input_ids": input_ids,
             "attention_mask": attention_mask,
             "pixel_values": pixel_values,
             "image_grid_thw": image_grid_thw,
+            "mm_token_type_ids": mm_token_type_ids,
         }
         outputs = self.model(**inputs)
         return outputs.logits


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The transformers 5.5.1 uplift changed the Qwen2.5-VL processor to emit an additional mm_token_type_ids input. The Wrapper.forward signature in qwen_2_5_vl/pytorch/src/model.py only declared the four original inputs (input_ids, attention_mask, pixel_values, image_grid_thw), so the tt-xla inference test now fails:
`FAILED tests/runner/test_models.py::test_all_models_torch[qwen_2_5_vl/pytorch-3B_Instruct-single_device-inference]
TypeError: Wrapper.forward() got an unexpected keyword argument 'mm_token_type_ids'`

### What's changed

- Added mm_token_type_ids as an explicit parameter to Wrapper.forward and pass it through to the underlying model.
- This is the correct fix because Qwen2_5_VLForConditionalGeneration.forward consumes mm_token_type_ids in transformers 5.5.1, so the input is used by the model.

### Checklist
- [ ] New/Existing tests provide coverage for changes
