### PR TITLE
Support sliding-window attention for Gemma3 multimodal

### DIFF
--- a/gemma3/multimodal/pytorch/loader.py
+++ b/gemma3/multimodal/pytorch/loader.py
@@ -8,6 +8,7 @@ Gemma3 model loader implementation for multimodal modeling.
 from typing import Optional, Any
 
 from transformers import (
+    AutoConfig,
     AutoProcessor,
     Gemma3ForConditionalGeneration,
 )
@@ -37,15 +38,24 @@ class ModelVariant(StrEnum):
 class ModelLoader(ForgeModel):
     """Gemma3 model loader implementation for multimodal modeling tasks."""
 
+    _SLIDING_WINDOW_VARIANTS = {
+        ModelVariant.GEMMA_3_4B_IT,
+        ModelVariant.GEMMA_3_12B_IT,
+        ModelVariant.GEMMA_3_27B_IT,
+    }
+
     _VARIANTS = {
         ModelVariant.GEMMA_3_4B_IT: LLMModelConfig(
             pretrained_model_name=str(ModelVariant.GEMMA_3_4B_IT),
+            max_length=512,
         ),
         ModelVariant.GEMMA_3_12B_IT: LLMModelConfig(
             pretrained_model_name=str(ModelVariant.GEMMA_3_12B_IT),
+            max_length=512,
         ),
         ModelVariant.GEMMA_3_27B_IT: LLMModelConfig(
             pretrained_model_name=str(ModelVariant.GEMMA_3_27B_IT),
+            max_length=512,
         ),
     }
 
@@ -57,6 +67,11 @@ class ModelLoader(ForgeModel):
     def __init__(self, variant: Optional[ModelVariant] = None):
         super().__init__(variant)
         self.processor = None
+
+    @property
+    def requires_model_rewrites(self) -> bool:
+        """Sliding-window variants need the TT causal-mask rewrite applied."""
+        return self._variant in self._SLIDING_WINDOW_VARIANTS
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
@@ -105,6 +120,7 @@ class ModelLoader(ForgeModel):
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
         model_kwargs |= kwargs
+
         model = Gemma3ForConditionalGeneration.from_pretrained(
             pretrained_model_name, **model_kwargs
         )
@@ -119,6 +135,7 @@ class ModelLoader(ForgeModel):
         dtype_override=None,
         prompt: Optional[str] = None,
         image_url: Optional[str] = None,
+        batch_size: int = 1,
     ):
         """Load and return sample inputs for the Gemma3 multimodal model with default settings.
 
@@ -155,6 +172,30 @@ class ModelLoader(ForgeModel):
                 inputs["pixel_values"], dtype_override
             )
 
+        # Non-sliding variants: return standard tokenizer output
+        if self._variant not in self._SLIDING_WINDOW_VARIANTS:
+            return inputs
+
+        from tools.utils import prepare_inputs_for_sliding_window_attention
+
+        # The shared helper only forwards the text-side keys (input_ids,
+        # attention_mask, cache, ...). Preserve the multimodal inputs so the
+        # vision tower still receives the image and the image/text token
+        # boundaries are kept.
+        multimodal_inputs = {
+            key: inputs[key]
+            for key in ("pixel_values", "token_type_ids")
+            if key in inputs
+        }
+
+        inputs = prepare_inputs_for_sliding_window_attention(
+            inputs,
+            batch_size=batch_size,
+            max_cache_len=self._variant_config.max_length,
+            dtype_override=dtype_override,
+            config=self.config,
+        )
+        inputs.update(multimodal_inputs)
         return inputs
 
     def get_mesh_config(self, num_devices: int):


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Support sliding-window attention for Gemma3 multimodal

### What's changed
Modified loader.py to support Gemma 3 multimodal models and align the implementation with OLMo 3 and Mistral models.

Logs:
[gemma3_12b.log](https://github.com/user-attachments/files/28693141/gemma3_12b.log)
[gemma3_27b.log](https://github.com/user-attachments/files/28694556/gemma3_27b.log)
[gemma3_4b_0.log](https://github.com/user-attachments/files/28694559/gemma3_4b_0.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
