### PR TITLE
Add Gemma2TextEncoderWrapper for Lumina Image Text Encoder

### DIFF
--- a/lumina_image/pytorch/loader.py
+++ b/lumina_image/pytorch/loader.py
@@ -29,6 +29,7 @@ from .src.model_utils import (
     LUMINA_REPO_ID,
     MESH_NAMES,
     MESH_SHAPES,
+    Gemma2TextEncoderWrapper,
     Lumina2TransformerWrapper,
     VAEDecoderWrapper,
     load_text_encoder,
@@ -87,7 +88,7 @@ class ModelLoader(ForgeModel):
         """Load and return the component for this variant as a torch.nn.Module.
 
         Returns:
-            TEXT_ENCODER → Gemma2Model
+            TEXT_ENCODER → Gemma2TextEncoderWrapper (plain-tensor forward)
             TRANSFORMER  → Lumina2TransformerWrapper (plain-tensor forward)
             VAE          → VAEDecoderWrapper (decoder-only, returns plain tensor)
         """
@@ -95,7 +96,7 @@ class ModelLoader(ForgeModel):
         dtype = dtype_override if dtype_override is not None else DTYPE
 
         if self._variant == ModelVariant.TEXT_ENCODER:
-            return load_text_encoder(model_name, dtype)
+            return Gemma2TextEncoderWrapper(load_text_encoder(model_name, dtype))
         if self._variant == ModelVariant.TRANSFORMER:
             return Lumina2TransformerWrapper(load_transformer(model_name, dtype))
         if self._variant == ModelVariant.VAE:
@@ -119,12 +120,12 @@ class ModelLoader(ForgeModel):
         """Return tensor → partition_spec dict for the active component.
 
         Expects the same model object returned by load_model():
-          TEXT_ENCODER → Gemma2Model
+          TEXT_ENCODER → Gemma2TextEncoderWrapper  (specs built from .encoder)
           TRANSFORMER  → Lumina2TransformerWrapper  (specs built from .transformer)
           VAE          → VAEDecoderWrapper          (specs built from .vae)
         """
         if self._variant == ModelVariant.TEXT_ENCODER:
-            return shard_text_encoder_specs(model)
+            return shard_text_encoder_specs(model.encoder)
         if self._variant == ModelVariant.TRANSFORMER:
             return shard_transformer_specs(model.transformer)
         if self._variant == ModelVariant.VAE:

--- a/lumina_image/pytorch/src/model_utils.py
+++ b/lumina_image/pytorch/src/model_utils.py
@@ -133,6 +133,31 @@ def load_vae_inputs(dtype: torch.dtype):
 # ---------------------------------------------------------------------------
 
 
+class Gemma2TextEncoderWrapper(torch.nn.Module):
+    """Run Gemma2Model as a stateless text encoder returning a plain tensor.
+
+    Pins use_cache=False so no KV cache is built. With a cache, Gemma-2's
+    sliding-window layer slices the value states with
+    full_value_states[:, :, -sliding_window + 1 :, :] (sliding_window=4096),
+    producing slice index -4095 which exceeds the tt-mlir slice bound of
+    [-256, 255] (tenstorrent/tt-xla#4900). A single encode pass needs no
+    cache, so disabling it removes the offending slice entirely. Also pins
+    return_dict=False so graph capture sees a pure tensor (last_hidden_state).
+    """
+
+    def __init__(self, encoder):
+        super().__init__()
+        self.encoder = encoder
+
+    def forward(self, input_ids, attention_mask):
+        return self.encoder(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+            return_dict=False,
+        )[0]
+
+
 class Lumina2TransformerWrapper(torch.nn.Module):
     """Simplify Lumina2Transformer2DModel forward to return a plain tensor.
 


### PR DESCRIPTION
### Ticket

- Fixes [#4900](https://github.com/tenstorrent/tt-xla/issues/4900)

### Problem description

tests/torch/models/lumina_image/test_text_encoder.py::test_text_encoder_sharded fails with 
```
RuntimeError: Value out of range (expected to be in range of [-256, 255], but got -4095)
```
### What's changed

1. A new wrapper class Gemma2TextEncoderWrapper was added in model_utils.py, consistent with the existing transformer/VAE wrappers.
2. Within the wrapper's forward, use_cache=False was pinned and return_dict=False was also pinned in the wrapper so that a plain tensor (last_hidden_state) is returned for graph capture.
3. In loader.py, Gemma2TextEncoderWrapper was imported alongside the other wrappers.
4. The load_model method was updated so the text encoder is now returned wrapped: Gemma2TextEncoderWrapper(load_text_encoder(...)).
5. The load_shard_spec method was updated so the underlying model is unwrapped via model.encoder when building shard specs (mirroring how model.transformer is used for the TRANSFORMER variant).
6. Sliding window attention support will be added later for this model. 
7. Post this change, model passes e2e.

### Logs

[lumina_text_encoder_before_fix.log](https://github.com/user-attachments/files/28823425/lumina_text_encoder_before_fix.log)
[lumina_text_encoder_after_fix.log](https://github.com/user-attachments/files/28823423/lumina_text_encoder_after_fix.log)