### PR TITLE
Modify Sharding of Hunyuan video Model

### DIFF
--- a/hunyuan_video/pytorch/src/model_utils.py
+++ b/hunyuan_video/pytorch/src/model_utils.py
@@ -469,14 +469,21 @@ def shard_transformer_specs(transformer) -> dict:
             specs[transformer.x_embedder.proj.bias] = ("batch",)
 
     for block in transformer.transformer_blocks:
+        # AdaLayerNorm modulation linears (norm1 / norm1_context). Their output
+        # (6*inner_dim) is immediately chunk-sliced into the six modulation
+        # params, so sharding the OUTPUT dim makes chunk boundaries straddle
+        # shards -> sdy.collective_permute (verifier failure / tt-mlir #3370).
+        # But fully replicating them is also bad: the weight is large and gets
+        # upcast to f32 for the matmul, blowing the per-device DRAM budget.
+        # Instead shard the CONTRACTING (input) dim by "model": row-parallel, so
+        # the weight shrinks 4x, the output stays replicated (chunk-slices are
+        # local, no reshard), and the matmul just needs an all-reduce.
         for norm_name in ("norm1", "norm1_context"):
             if hasattr(block, norm_name) and hasattr(
                 getattr(block, norm_name), "linear"
             ):
                 lin = getattr(block, norm_name).linear
-                specs[lin.weight] = ("model", "batch")
-                if lin.bias is not None:
-                    specs[lin.bias] = ("model",)
+                specs[lin.weight] = (None, "model")
 
         if hasattr(block, "attn"):
             attn = block.attn
@@ -515,6 +522,53 @@ def shard_transformer_specs(transformer) -> dict:
                 specs[ff.net[2].weight] = ("batch", "model")
                 if ff.net[2].bias is not None:
                     specs[ff.net[2].bias] = ("batch",)
+
+    # Single-stream blocks (HunyuanVideoSingleTransformerBlock). These must be
+    # sharded with the SAME column-/row-parallel scheme as the dual blocks --
+    # leaving them unspecified lets Shardy infer layouts that conflict with the
+    # dual blocks, and the reshard between them is materialized as a gather
+    # ttnn.concat whose per-core page exceeds L1 (OOM at runtime). The attn here
+    # is pre_only=True (no to_out); proj_out fuses the output projection of
+    # concat([attn(hidden), mlp(mlp_dim)]) -> hidden, so:
+    #   QKV + proj_mlp : column-parallel ("model", "batch")
+    #   proj_out       : row-parallel    ("batch", "model")
+    #   norm.linear    : replicated (modulation output is chunk-sliced; see above)
+    for block in getattr(transformer, "single_transformer_blocks", []):
+        # Modulation linear (norm.linear): shard contracting dim, see dual-block
+        # note above (output is chunk-sliced; replicating it OOMs in f32).
+        if hasattr(block, "norm") and hasattr(block.norm, "linear"):
+            specs[block.norm.linear.weight] = (None, "model")
+
+        if hasattr(block, "attn"):
+            attn = block.attn
+            for proj_name in (
+                "to_q",
+                "to_k",
+                "to_v",
+                "add_q_proj",
+                "add_k_proj",
+                "add_v_proj",
+            ):
+                proj = getattr(attn, proj_name, None)
+                if proj is not None:
+                    specs[proj.weight] = ("model", "batch")
+                    if proj.bias is not None:
+                        specs[proj.bias] = ("model",)
+
+        if hasattr(block, "proj_mlp"):
+            specs[block.proj_mlp.weight] = ("model", "batch")
+            if block.proj_mlp.bias is not None:
+                specs[block.proj_mlp.bias] = ("model",)
+
+        if hasattr(block, "proj_out"):
+            specs[block.proj_out.weight] = ("batch", "model")
+            if block.proj_out.bias is not None:
+                specs[block.proj_out.bias] = ("batch",)
+
+    # Final AdaLayerNormContinuous modulation (norm_out.linear, 2*inner_dim out,
+    # chunk-sliced into scale/shift). Same contracting-dim sharding as above.
+    if hasattr(transformer, "norm_out") and hasattr(transformer.norm_out, "linear"):
+        specs[transformer.norm_out.linear.weight] = (None, "model")
 
     if hasattr(transformer, "proj_out"):
         specs[transformer.proj_out.weight] = (None, "batch")


### PR DESCRIPTION
### Ticket
Fixes [#4790](https://github.com/tenstorrent/tt-xla/issues/4790)

### Problem description

- The sharded `HunyuanVideoTransformer3DModel` test (test_transformer_sharded, 8-device (2,4) ("batch","model") mesh) failed to run end-to-end. The shard spec in shard_transformer_specs had two structural defects that surfaced as a cascade of three distinct failures, each unblocking the next:

- `sdy.collective_permute` verifier crash (compile-time): `loc("slice.3536"): error: 'sdy.collective_permute' op requires the same type for all operands and results`. Root cause: the AdaLayerNorm modulation linears (norm1/norm1_context) were sharded on their output dimension via ("model","batch"). That output (6×3072 = 18432) is immediately chunk-sliced into the six modulation params (shift/scale/gate × msa/mlp). With the output dim split across the 4-device "model" axis (4608/device), the 3072-aligned slice boundaries straddled shard boundaries, so Shardy inserted reshard collective_permutes — with uneven, type-mismatched operands/results. Diagnostics confirmed the split: 706 of 720 erroring slices were the 1x18432 modulation slices.

- ttnn.concat L1 OOM (runtime): required CB page size (1990656 B) exceeds per-core L1 capacity (1395360 B). The 2 MB page matched no model concat (the largest, 1x896x15360, has a ~30 KB page), so it was a reshard/all-gather concat introduced by tt-mlir's sharding lowering. Root cause: shard_transformer_specs only iterated transformer.transformer_blocks (the 20 dual-stream blocks) and never touched the 40 single_transformer_blocks, so Shardy inferred conflicting layouts across the dual↔single boundary and materialized the reshard as an oversized gather-concat.

- DRAM OOM (runtime): Not enough space to allocate 226492416 B DRAM buffer, on a typecast. The size equals 3072 × 18432 × 4 — the norm1.linear weight in f32. The interim workaround of replicating the modulation linears (to dodge defect 1) meant every device held the full weight, which XLA upcasts to f32 for the matmul → 226 MB/device, with DRAM already ~full (46 MB free).


### What's changed

- All changes are in `shard_transformer_specs` (hunyuan_video loader). The fix threads a single principle: modulation/AdaLN linears must neither be sharded on their output dim (chunk-sliced → collective_permute) nor replicated (large + f32-upcast → DRAM OOM).

- Modulation linears now shard the contracting (input) dim: norm1/norm1_context (dual blocks), norm (single blocks), and the final norm_out (AdaLayerNormContinuous) use spec (None, "model"). For a [out, in] weight this is row-parallel — the weight shrinks 4×, the output stays replicated so the shift/scale/gate chunk-slices are local (no collective_permute), and the matmul lowers to an all-reduce. This replaces the earlier output-dim sharding and the replication workaround in one step, resolving defects 1 and 3.

- single_transformer_blocks are now sharded with the same Megatron scheme as the dual blocks, eliminating the dual↔single layout discontinuity (defect 2). The single-block attention is pre_only=True (no to_out), and the fused proj_out projects concat([attn(hidden), mlp(mlp_dim)]) → hidden, so: to_q/k/v and proj_mlp are column-parallel ("model","batch"); proj_out is row-parallel ("batch","model"). Both operands of the concat([attn, mlp], dim=2) are then "model"-sharded along the concat dim, so the result stays sharded with no gather.

- Null-projection guard: the single-block attention is built with cross_attention_dim=None, so add_q_proj/add_k_proj/add_v_proj exist as attributes but are None. The projection loop uses getattr(attn, name, None) with an explicit is not None check so only the real to_q/k/v weights are sharded.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs
[hunyuan_transformer_sdy_error_before_fix.log](https://github.com/user-attachments/files/28741064/hunyuan_transformer_sdy_error_before_fix.log)
[hunyuan_transformer_pcc_drop_after_fix.zip](https://github.com/user-attachments/files/28741101/hunyuan_transformer_pcc_drop_after_fix.zip)
