### PR TITLE
Pin pi0_base variant 

### DIFF
--- a/pi_0/pytorch/loader.py
+++ b/pi_0/pytorch/loader.py
@@ -5,6 +5,7 @@
 Pi-0 model loader implementation for action prediction tasks
 """
 import torch
+from dataclasses import dataclass
 from typing import Optional, Dict, Any
 from ...base import ForgeModel
 from ...config import (
@@ -16,6 +17,13 @@ from ...config import (
     Framework,
     StrEnum,
 )
+
+
+@dataclass
+class Pi0ModelConfig(ModelConfig):
+    """Pi-0 config with an optional pinned HF Hub revision."""
+
+    revision: Optional[str] = None
 
 
 class ModelVariant(StrEnum):
@@ -30,11 +38,14 @@ class ModelLoader(ForgeModel):
 
     # Dictionary of available model variants
     _VARIANTS = {
-        ModelVariant.LIBERO_BASE: ModelConfig(
+        ModelVariant.LIBERO_BASE: Pi0ModelConfig(
             pretrained_model_name="lerobot/pi0_libero_base",
         ),
-        ModelVariant.BASE: ModelConfig(
+        # Pin to the last revision compatible with lerobot==0.4.3; newer
+        # revisions add a processor step the pinned library can't load.
+        ModelVariant.BASE: Pi0ModelConfig(
             pretrained_model_name="lerobot/pi0_base",
+            revision="26b99b9439acb1e352439e34ee9c67af0d76efa3",
         ),
     }
 
@@ -81,7 +92,20 @@ class ModelLoader(ForgeModel):
 
         from .src.model import get_custom_pi0_policy
 
-        self.pretrained_model_name = self._variant_config.pretrained_model_name
+        # When a revision is pinned, snapshot the repo locally and load weights
+        # and processor config from that path (make_pre_post_processors can't
+        # take a revision directly).
+        revision = getattr(self._variant_config, "revision", None)
+        if revision is not None:
+            from huggingface_hub import snapshot_download
+
+            self.pretrained_model_name = snapshot_download(
+                repo_id=self._variant_config.pretrained_model_name,
+                revision=revision,
+            )
+        else:
+            self.pretrained_model_name = self._variant_config.pretrained_model_name
+
         self.pi_0 = get_custom_pi0_policy(self.pretrained_model_name)
         self.pi_0.eval()
         return self.pi_0


### PR DESCRIPTION
### Problem description
The `lerobot/pi0_base` HF repo added a `relative_actions_processor` step to `policy_preprocessor.json` (commit 25c379b). Our pinned `lerobot==0.4.3` doesn't register that step, so loading the processor pipeline fails:
```
KeyError: Processor step 'relative_actions_processor' not found in registry
```
The model card drifted ahead of the pinned library, breaking the [nightly test](https://github.com/tenstorrent/tt-xla/actions/runs/27175829468/job/80224448955).

### What's changed
- Added `Pi0ModelConfig` with an optional revision field.
- Pinned the `pi0_base` variant to revision `26b99b9` (the commit before the breaking change), keeping the downloaded config in sync with `lerobot==0.4.3`.
- load_model now snapshots the repo at the pinned revision and loads weights and the processor config from that local path, since `make_pre_post_processors` can't take a revision directly.
- `pi0_libero_base` left unpinned — its` policy_preprocessor.json` doesn't reference the new step.

### Checklist
Tested on [CI run](https://github.com/tenstorrent/tt-xla/actions/runs/27215835796)
