### PR TITLE
Add text-to-image pipeline implementations (SD1.5 / SD3 / BRIA 2.3)

### DIFF
--- a/bria_2_3/pytorch/__init__.py
+++ b/bria_2_3/pytorch/__init__.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-
+"""
+BRIA 2.3 PyTorch pipeline implementation for Tenstorrent projects.
+"""
 from .loader import ModelLoader, ModelVariant

--- a/bria_2_3/pytorch/pipeline.py
+++ b/bria_2_3/pytorch/pipeline.py
@@ -20,6 +20,7 @@ benchmarks; callers construct ``Bria23Pipeline`` and drive it through
 ``generate``.
 """
 
+import time
 from typing import Optional
 
 import torch
@@ -79,6 +80,18 @@ class Bria23Pipeline:
         crops_coords_top_left = (0, 0)
         original_size = target_size = (self.height, self.width)
 
+        # Per-component forward+sync times for the benchmark harness (reset
+        # every generate() call). ``components`` holds scalar per-stage seconds,
+        # ``steps`` holds per-UNet-step seconds; the cpu cast after each TT
+        # forward forces a device sync, so the timer captures real device work.
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "unet_step",
+            "total": None,
+        }
+        t_total_start = time.perf_counter()
+
         tt_cast = lambda x: (
             x.to(dtype=torch.bfloat16).to(device=xm.xla_device())
             if x.device == torch.device("cpu")
@@ -94,6 +107,7 @@ class Bria23Pipeline:
                 generator.seed()
 
             # --- Text encoding (CLIP x2) on CPU ---
+            t0 = time.perf_counter()
             (
                 prompt_embeds,
                 negative_prompt_embeds,
@@ -106,6 +120,7 @@ class Bria23Pipeline:
                 device=self.device,
                 num_images_per_prompt=1,
             )
+            self._perf["components"]["text_encode"] = time.perf_counter() - t0
 
             # --- Prepare timesteps (CPU) ---
             timesteps, num_inference_steps = retrieve_timesteps(
@@ -159,6 +174,7 @@ class Bria23Pipeline:
                 )
 
                 # CPU -> TT
+                t0 = time.perf_counter()
                 noise_pred = self.unet(
                     tt_cast(latent_model_input),
                     tt_cast(t.unsqueeze(0)),
@@ -170,8 +186,9 @@ class Bria23Pipeline:
                     return_dict=False,
                 )[0]
 
-                # TT -> CPU
+                # TT -> CPU (cpu cast forces sync — timer ends after this)
                 noise_pred = cpu_cast(noise_pred)
+                self._perf["steps"].append(time.perf_counter() - t0)
 
                 if do_cfg:
                     noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
@@ -211,8 +228,11 @@ class Bria23Pipeline:
             else:
                 latents = latents / pipe.vae.config.scaling_factor
 
+            t0 = time.perf_counter()
             images = pipe.vae.decode(latents, return_dict=False)[0]
+            self._perf["components"]["vae"] = time.perf_counter() - t0
 
+            self._perf["total"] = time.perf_counter() - t_total_start
             return images
 
 

--- a/bria_2_3/pytorch/pipeline.py
+++ b/bria_2_3/pytorch/pipeline.py
@@ -33,11 +33,10 @@ from PIL import Image
 
 
 class Bria23Config:
-    def __init__(self, device="cpu"):
+    def __init__(self):
         self.model_id = "briaai/BRIA-2.3"
         self.height = 1024
         self.width = 1024
-        self.device = device
 
 
 class Bria23Pipeline:
@@ -45,7 +44,6 @@ class Bria23Pipeline:
 
     def __init__(self, config: Bria23Config):
         self.config = config
-        self.device = config.device
         self.model_id = config.model_id
         self.height = config.height
         self.width = config.width
@@ -117,14 +115,14 @@ class Bria23Pipeline:
                 prompt=prompt,
                 negative_prompt=negative_prompt,
                 do_classifier_free_guidance=do_cfg,
-                device=self.device,
+                device="cpu",
                 num_images_per_prompt=1,
             )
             self._perf["components"]["text_encode"] = time.perf_counter() - t0
 
             # --- Prepare timesteps (CPU) ---
             timesteps, num_inference_steps = retrieve_timesteps(
-                pipe.scheduler, num_inference_steps, self.device
+                pipe.scheduler, num_inference_steps, "cpu"
             )
 
             # --- Prepare latents (CPU) ---
@@ -135,7 +133,7 @@ class Bria23Pipeline:
                 self.height,
                 self.width,
                 prompt_embeds.dtype,
-                self.device,
+                "cpu",
                 generator,
                 None,
             )
@@ -164,6 +162,13 @@ class Bria23Pipeline:
                 )
                 add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0)
 
+            # The conditioning (prompt embeds + SDXL added conds) is constant
+            # across the denoising loop, so cast it to the TT device once here
+            # instead of every iteration.
+            prompt_embeds_tt = tt_cast(prompt_embeds)
+            add_text_embeds_tt = tt_cast(add_text_embeds)
+            add_time_ids_tt = tt_cast(add_time_ids)
+
             # --- Denoising loop (UNet on TT) ---
             for i, t in enumerate(timesteps):
                 print(f"Step {i + 1} of {num_inference_steps}")
@@ -173,15 +178,15 @@ class Bria23Pipeline:
                     latent_model_input, t
                 )
 
-                # CPU -> TT
+                # CPU -> TT (sample + timestep change per step; embeds hoisted above)
                 t0 = time.perf_counter()
                 noise_pred = self.unet(
                     tt_cast(latent_model_input),
                     tt_cast(t.unsqueeze(0)),
-                    encoder_hidden_states=tt_cast(prompt_embeds),
+                    encoder_hidden_states=prompt_embeds_tt,
                     added_cond_kwargs={
-                        "text_embeds": tt_cast(add_text_embeds),
-                        "time_ids": tt_cast(add_time_ids),
+                        "text_embeds": add_text_embeds_tt,
+                        "time_ids": add_time_ids_tt,
                     },
                     return_dict=False,
                 )[0]

--- a/bria_2_3/pytorch/pipeline.py
+++ b/bria_2_3/pytorch/pipeline.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""BRIA 2.3 text-to-image pipeline running end-to-end on TT.
+
+BRIA 2.3 (``briaai/BRIA-2.3``) is an SDXL-class text-to-image model: it reuses
+the ``StableDiffusionXLPipeline``, the SDXL UNet and the SDXL preprocessing
+path. As in the SDXL / SD 1.5 pipelines, the heavy net (the UNet) runs on the
+Tenstorrent backend via ``torch.compile(backend="tt")`` while the two CLIP text
+encoders, the scheduler and the VAE run on CPU.
+
+The prompt encoding, latent preparation, denoising step and VAE decode reuse
+the diffusers pipeline helper methods directly, so the numerics match upstream;
+only the per-step UNet call is redirected to the TT device. The one BRIA-
+specific tweak is ``force_zeros_for_empty_prompt = False`` (required per the
+BRIA 2.3 model card).
+
+This is the reusable pipeline implementation shared by the tt-xla examples and
+benchmarks; callers construct ``Bria23Pipeline`` and drive it through
+``generate``.
+"""
+
+from typing import Optional
+
+import torch
+import torch_xla.core.xla_model as xm
+from diffusers import DiffusionPipeline
+from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import (
+    retrieve_timesteps,
+)
+from PIL import Image
+
+
+class Bria23Config:
+    def __init__(self, device="cpu"):
+        self.model_id = "briaai/BRIA-2.3"
+        self.height = 1024
+        self.width = 1024
+        self.device = device
+
+
+class Bria23Pipeline:
+    """Text-to-image generation with BRIA 2.3 (SDXL-class UNet on TT)."""
+
+    def __init__(self, config: Bria23Config):
+        self.config = config
+        self.device = config.device
+        self.model_id = config.model_id
+        self.height = config.height
+        self.width = config.width
+
+    def setup(self):
+        # Text encoders, scheduler and VAE stay on CPU in fp32; only the UNet
+        # is compiled for and moved to the TT device.
+        self.pipe = DiffusionPipeline.from_pretrained(
+            self.model_id, torch_dtype=torch.float32
+        )
+        # Required by BRIA 2.3: the empty prompt must not be zeroed out.
+        self.pipe.force_zeros_for_empty_prompt = False
+        self.pipe.to("cpu")
+
+        self.unet = self.pipe.unet
+        self.unet = self.unet.to(dtype=torch.bfloat16)
+        self.unet.compile(backend="tt")
+        self.unet = self.unet.to(xm.xla_device())
+
+    def generate(
+        self,
+        prompt: str,
+        negative_prompt: str = "",
+        guidance_scale: float = 5.0,
+        num_inference_steps: int = 50,
+        seed: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Generate an image from a text prompt. Returns tensor (B, 3, H, W) in [-1, 1]."""
+
+        pipe = self.pipe
+        do_cfg = guidance_scale > 1.0
+        crops_coords_top_left = (0, 0)
+        original_size = target_size = (self.height, self.width)
+
+        tt_cast = lambda x: (
+            x.to(dtype=torch.bfloat16).to(device=xm.xla_device())
+            if x.device == torch.device("cpu")
+            else x.to(dtype=torch.bfloat16)
+        )
+        cpu_cast = lambda x: x.to("cpu").to(dtype=torch.float32)
+
+        with torch.no_grad():
+            generator = torch.Generator(device="cpu")
+            if seed is not None:
+                generator.manual_seed(seed)
+            else:
+                generator.seed()
+
+            # --- Text encoding (CLIP x2) on CPU ---
+            (
+                prompt_embeds,
+                negative_prompt_embeds,
+                pooled_prompt_embeds,
+                negative_pooled_prompt_embeds,
+            ) = pipe.encode_prompt(
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                do_classifier_free_guidance=do_cfg,
+                device=self.device,
+                num_images_per_prompt=1,
+            )
+
+            # --- Prepare timesteps (CPU) ---
+            timesteps, num_inference_steps = retrieve_timesteps(
+                pipe.scheduler, num_inference_steps, self.device
+            )
+
+            # --- Prepare latents (CPU) ---
+            num_channels_latents = pipe.unet.config.in_channels
+            latents = pipe.prepare_latents(
+                1,
+                num_channels_latents,
+                self.height,
+                self.width,
+                prompt_embeds.dtype,
+                self.device,
+                generator,
+                None,
+            )
+
+            # --- SDXL additional conditioning (time ids + pooled text embeds) ---
+            if pipe.text_encoder_2 is None:
+                text_encoder_projection_dim = int(pooled_prompt_embeds.shape[-1])
+            else:
+                text_encoder_projection_dim = pipe.text_encoder_2.config.projection_dim
+
+            add_time_ids = pipe._get_add_time_ids(
+                original_size,
+                crops_coords_top_left,
+                target_size,
+                dtype=prompt_embeds.dtype,
+                text_encoder_projection_dim=text_encoder_projection_dim,
+            )
+            add_text_embeds = pooled_prompt_embeds
+
+            if do_cfg:
+                prompt_embeds = torch.cat(
+                    [negative_prompt_embeds, prompt_embeds], dim=0
+                )
+                add_text_embeds = torch.cat(
+                    [negative_pooled_prompt_embeds, add_text_embeds], dim=0
+                )
+                add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0)
+
+            # --- Denoising loop (UNet on TT) ---
+            for i, t in enumerate(timesteps):
+                print(f"Step {i + 1} of {num_inference_steps}")
+
+                latent_model_input = torch.cat([latents] * 2) if do_cfg else latents
+                latent_model_input = pipe.scheduler.scale_model_input(
+                    latent_model_input, t
+                )
+
+                # CPU -> TT
+                noise_pred = self.unet(
+                    tt_cast(latent_model_input),
+                    tt_cast(t.unsqueeze(0)),
+                    encoder_hidden_states=tt_cast(prompt_embeds),
+                    added_cond_kwargs={
+                        "text_embeds": tt_cast(add_text_embeds),
+                        "time_ids": tt_cast(add_time_ids),
+                    },
+                    return_dict=False,
+                )[0]
+
+                # TT -> CPU
+                noise_pred = cpu_cast(noise_pred)
+
+                if do_cfg:
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                    noise_pred = noise_pred_uncond + guidance_scale * (
+                        noise_pred_text - noise_pred_uncond
+                    )
+
+                latents = pipe.scheduler.step(
+                    noise_pred, t, latents, return_dict=False
+                )[0]
+
+            # --- VAE decode (CPU) ---
+            has_latents_mean = (
+                hasattr(pipe.vae.config, "latents_mean")
+                and pipe.vae.config.latents_mean is not None
+            )
+            has_latents_std = (
+                hasattr(pipe.vae.config, "latents_std")
+                and pipe.vae.config.latents_std is not None
+            )
+            latents = latents.to(dtype=torch.float32)
+            if has_latents_mean and has_latents_std:
+                latents_mean = (
+                    torch.tensor(pipe.vae.config.latents_mean)
+                    .view(1, 4, 1, 1)
+                    .to(latents.device, latents.dtype)
+                )
+                latents_std = (
+                    torch.tensor(pipe.vae.config.latents_std)
+                    .view(1, 4, 1, 1)
+                    .to(latents.device, latents.dtype)
+                )
+                latents = (
+                    latents * latents_std / pipe.vae.config.scaling_factor
+                    + latents_mean
+                )
+            else:
+                latents = latents / pipe.vae.config.scaling_factor
+
+            images = pipe.vae.decode(latents, return_dict=False)[0]
+
+            return images
+
+
+def save_image(image: torch.Tensor, filepath: str = "output.png"):
+    """Rescale, reshape and save the image from pipeline output."""
+    image = (
+        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
+    )
+    image_np = image.cpu().squeeze().numpy()
+    assert image_np.ndim == 3, "Image must be 3D"
+    if image_np.shape[0] == 3:
+        image_np = image_np.transpose(1, 2, 0)
+    Image.fromarray(image_np).save(filepath)

--- a/stable_diffusion_1_5/pytorch/pipeline.py
+++ b/stable_diffusion_1_5/pytorch/pipeline.py
@@ -25,14 +25,16 @@ from transformers import CLIPTextModel, CLIPTokenizer
 
 
 class SD15Config:
-    def __init__(self, device="cpu", vae_on_tt=False, clip_on_tt=True):
+    def __init__(self, vae_on_tt=False, clip_on_tt=False):
         self.model_id = "stable-diffusion-v1-5/stable-diffusion-v1-5"
         self.width = 512
         self.height = 512
         self.latents_width = self.width // 8
         self.latents_height = self.height // 8
-        self.device = device
         self.vae_on_tt = vae_on_tt
+        # CLIP text embeddings are precision-sensitive: running CLIP on TT in
+        # bf16 can wash out the prompt conditioning, so it stays on CPU unless
+        # explicitly opted in.
         self.clip_on_tt = clip_on_tt
 
 
@@ -41,7 +43,6 @@ class SD15Pipeline:
 
     def __init__(self, config: SD15Config):
         self.config = config
-        self.device = config.device
         self.model_id = config.model_id
         self.latents_width = config.latents_width
         self.latents_height = config.latents_height
@@ -58,7 +59,7 @@ class SD15Pipeline:
             self.model_id,
             subfolder="vae",
             torch_dtype=torch.float32,
-            device_map=self.device,
+            device_map="cpu",
         )
         if self.vae_on_tt:
             self.vae.compile(backend="tt")
@@ -68,7 +69,7 @@ class SD15Pipeline:
             self.model_id,
             subfolder="unet",
             torch_dtype=torch.bfloat16,
-            device_map=self.device,
+            device_map="cpu",
         )
         self.unet.compile(backend="tt")
         self.unet = self.unet.to(xm.xla_device())
@@ -77,7 +78,7 @@ class SD15Pipeline:
             self.model_id,
             subfolder="text_encoder",
             torch_dtype=torch.bfloat16 if self.clip_on_tt else torch.float16,
-            device_map=self.device,
+            device_map="cpu",
         )
 
         if self.clip_on_tt:
@@ -105,6 +106,9 @@ class SD15Pipeline:
         """Generate an image from a text prompt. Returns tensor (B, 3, H, W)."""
 
         batch_size = 1 if isinstance(prompt, str) else len(prompt)
+        assert (
+            batch_size == 1
+        ), "Only single-prompt generation (batch_size=1) is supported"
 
         # Per-component forward+sync times for the benchmark harness (reset
         # every generate() call). ``components`` holds scalar per-stage seconds,
@@ -142,11 +146,9 @@ class SD15Pipeline:
                 [negative_prompt], padding="max_length", max_length=77
             ).input_ids
 
-            cond_tokens = torch.tensor(cond_tokens, dtype=torch.long).to(
-                device=self.device
-            )
+            cond_tokens = torch.tensor(cond_tokens, dtype=torch.long).to(device="cpu")
             uncond_tokens = torch.tensor(uncond_tokens, dtype=torch.long).to(
-                device=self.device
+                device="cpu"
             )
 
             if self.clip_on_tt:
@@ -167,6 +169,10 @@ class SD15Pipeline:
                 [uncond_hidden_state, cond_hidden_state], dim=0
             )  # (2B, 77, 768)
 
+            # encoder_hidden_states is constant across the denoising loop, so
+            # cast it to the TT device once here instead of every iteration.
+            encoder_hidden_states = tt_cast(encoder_hidden_states)
+
             # --- Prepare timesteps ---
             self.scheduler.set_timesteps(num_inference_steps)
 
@@ -174,7 +180,7 @@ class SD15Pipeline:
             latent_shape = (batch_size, 4, self.latents_height, self.latents_width)
             latents = torch.randn(
                 latent_shape, generator=generator, dtype=torch.float16
-            ).to(device=self.device)
+            ).to(device="cpu")
             latents = latents * self.scheduler.init_noise_sigma
 
             # --- Denoising loop (UNet on TT) ---
@@ -183,10 +189,9 @@ class SD15Pipeline:
                 model_input = torch.cat([latents] * 2)
                 model_input = self.scheduler.scale_model_input(model_input, timestep)
 
-                # CPU → TT
+                # CPU → TT (sample + timestep change per step; embeds hoisted above)
                 model_input = tt_cast(model_input)
                 timestep_tt = tt_cast(timestep.unsqueeze(0))
-                encoder_hidden_states = tt_cast(encoder_hidden_states)
 
                 t0 = time.perf_counter()
                 unet_output = self.unet(
@@ -199,12 +204,16 @@ class SD15Pipeline:
                 unet_output = cpu_cast(unet_output)
                 self._perf["steps"].append(time.perf_counter() - t0)
 
-                # CFG blending (CPU)
+                # CFG blending (CPU). The blend is a cheap elementwise op on the
+                # small noise-pred tensors; running it on CPU between TT UNet
+                # forwards avoids round-tripping tiny tensors to the device.
                 uncond_output, cond_output = unet_output.chunk(2)
                 model_output = uncond_output + (cond_output - uncond_output) * cfg_scale
 
-                # Scheduler step (CPU)
-                latents = cpu_cast(latents)
+                # Scheduler step (CPU). The diffusers scheduler is stateful and
+                # runs on CPU; ``step`` consumes the current latents to produce
+                # the next sample. ``latents`` already stays CPU/float16 here, so
+                # no extra cast is needed.
                 latents = self.scheduler.step(
                     model_output, timestep, latents
                 ).prev_sample

--- a/stable_diffusion_1_5/pytorch/pipeline.py
+++ b/stable_diffusion_1_5/pytorch/pipeline.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end Stable Diffusion 1.5 text-to-image pipeline for Tenstorrent.
+
+The UNet (the heavy net) runs on the Tenstorrent backend via
+``torch.compile(backend="tt")``; the precision-sensitive CLIP text encoder,
+the scheduler and the VAE run on CPU. CLIP text embeddings are precision
+sensitive, so running the text encoder on TT in bf16 can wash out the prompt
+conditioning; ``clip_on_tt`` is therefore opt-in.
+
+This is the reusable pipeline implementation shared by the tt-xla examples and
+benchmarks; callers construct ``SD15Pipeline`` and drive it through
+``generate``.
+"""
+
+from typing import Optional
+
+import torch
+import torch_xla.core.xla_model as xm
+from diffusers import AutoencoderKL, PNDMScheduler, UNet2DConditionModel
+from PIL import Image
+from transformers import CLIPTextModel, CLIPTokenizer
+
+
+class SD15Config:
+    def __init__(self, device="cpu", vae_on_tt=False, clip_on_tt=True):
+        self.model_id = "stable-diffusion-v1-5/stable-diffusion-v1-5"
+        self.width = 512
+        self.height = 512
+        self.latents_width = self.width // 8
+        self.latents_height = self.height // 8
+        self.device = device
+        self.vae_on_tt = vae_on_tt
+        self.clip_on_tt = clip_on_tt
+
+
+class SD15Pipeline:
+    """Pipeline for text-to-image generation with Stable Diffusion 1.5."""
+
+    def __init__(self, config: SD15Config):
+        self.config = config
+        self.device = config.device
+        self.model_id = config.model_id
+        self.latents_width = config.latents_width
+        self.latents_height = config.latents_height
+        self.vae_on_tt = config.vae_on_tt
+        self.clip_on_tt = config.clip_on_tt
+
+    def setup(self):
+        self.load_models()
+        self.load_scheduler()
+        self.load_tokenizer()
+
+    def load_models(self):
+        self.vae = AutoencoderKL.from_pretrained(
+            self.model_id,
+            subfolder="vae",
+            torch_dtype=torch.float32,
+            device_map=self.device,
+        )
+        if self.vae_on_tt:
+            self.vae.compile(backend="tt")
+            self.vae = self.vae.to(xm.xla_device())
+
+        self.unet = UNet2DConditionModel.from_pretrained(
+            self.model_id,
+            subfolder="unet",
+            torch_dtype=torch.bfloat16,
+            device_map=self.device,
+        )
+        self.unet.compile(backend="tt")
+        self.unet = self.unet.to(xm.xla_device())
+
+        self.text_encoder = CLIPTextModel.from_pretrained(
+            self.model_id,
+            subfolder="text_encoder",
+            torch_dtype=torch.bfloat16 if self.clip_on_tt else torch.float16,
+            device_map=self.device,
+        )
+
+        if self.clip_on_tt:
+            self.text_encoder.compile(backend="tt")
+            self.text_encoder = self.text_encoder.to(xm.xla_device())
+
+    def load_scheduler(self):
+        self.scheduler = PNDMScheduler.from_pretrained(
+            self.model_id, subfolder="scheduler"
+        )
+
+    def load_tokenizer(self):
+        self.tokenizer = CLIPTokenizer.from_pretrained(
+            self.model_id, subfolder="tokenizer"
+        )
+
+    def generate(
+        self,
+        prompt: str,
+        negative_prompt: str = "",
+        cfg_scale: float = 7.5,
+        num_inference_steps: int = 50,
+        seed: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Generate an image from a text prompt. Returns tensor (B, 3, H, W)."""
+
+        batch_size = 1 if isinstance(prompt, str) else len(prompt)
+
+        tt_cast = lambda x: (
+            x.to(dtype=torch.bfloat16).to(device=xm.xla_device())
+            if x.device == torch.device("cpu")
+            else x.to(dtype=torch.bfloat16)
+        )
+        cpu_cast = lambda x: x.to("cpu").to(dtype=torch.float16)
+
+        with torch.no_grad():
+            generator = torch.Generator(device="cpu")
+            if seed is not None:
+                generator.manual_seed(seed)
+            else:
+                generator.seed()
+
+            # --- Text encoding (CLIP) ---
+            negative_prompt = negative_prompt or ""
+
+            cond_tokens = self.tokenizer(
+                [prompt], padding="max_length", max_length=77
+            ).input_ids
+            uncond_tokens = self.tokenizer(
+                [negative_prompt], padding="max_length", max_length=77
+            ).input_ids
+
+            cond_tokens = torch.tensor(cond_tokens, dtype=torch.long).to(
+                device=self.device
+            )
+            uncond_tokens = torch.tensor(uncond_tokens, dtype=torch.long).to(
+                device=self.device
+            )
+
+            if self.clip_on_tt:
+                cond_tokens = cond_tokens.to(device=xm.xla_device())
+                uncond_tokens = uncond_tokens.to(device=xm.xla_device())
+
+            cond_hidden_state = self.text_encoder(cond_tokens)[0]  # (B, 77, 768)
+            uncond_hidden_state = self.text_encoder(uncond_tokens)[0]  # (B, 77, 768)
+
+            if self.clip_on_tt:
+                cond_hidden_state = cpu_cast(cond_hidden_state)
+                uncond_hidden_state = cpu_cast(uncond_hidden_state)
+
+            encoder_hidden_states = torch.cat(
+                [uncond_hidden_state, cond_hidden_state], dim=0
+            )  # (2B, 77, 768)
+
+            # --- Prepare timesteps ---
+            self.scheduler.set_timesteps(num_inference_steps)
+
+            # --- Prepare latents ---
+            latent_shape = (batch_size, 4, self.latents_height, self.latents_width)
+            latents = torch.randn(
+                latent_shape, generator=generator, dtype=torch.float16
+            ).to(device=self.device)
+            latents = latents * self.scheduler.init_noise_sigma
+
+            # --- Denoising loop (UNet on TT) ---
+            for i, timestep in enumerate(self.scheduler.timesteps):
+
+                model_input = torch.cat([latents] * 2)
+                model_input = self.scheduler.scale_model_input(model_input, timestep)
+
+                # CPU → TT
+                model_input = tt_cast(model_input)
+                timestep_tt = tt_cast(timestep.unsqueeze(0))
+                encoder_hidden_states = tt_cast(encoder_hidden_states)
+
+                unet_output = self.unet(
+                    model_input,
+                    timestep_tt,
+                    encoder_hidden_states,
+                ).sample
+
+                # TT → CPU
+                unet_output = cpu_cast(unet_output)
+
+                # CFG blending (CPU)
+                uncond_output, cond_output = unet_output.chunk(2)
+                model_output = uncond_output + (cond_output - uncond_output) * cfg_scale
+
+                # Scheduler step (CPU)
+                latents = cpu_cast(latents)
+                latents = self.scheduler.step(
+                    model_output, timestep, latents
+                ).prev_sample
+
+            # --- VAE decode ---
+            latents = latents / self.vae.config.scaling_factor
+            latents = latents.to(dtype=torch.float32)
+            if self.vae_on_tt:
+                latents = latents.to(device=xm.xla_device())
+            images = self.vae.decode(latents).sample
+            if self.vae_on_tt:
+                images = cpu_cast(images)
+
+            return images
+
+
+def save_image(image: torch.Tensor, filepath: str = "output.png"):
+    """Rescale, reshape and save the image from pipeline output."""
+    image = (
+        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
+    )
+    image_np = image.cpu().squeeze().numpy()
+    assert image_np.ndim == 3, "Image must be 3D"
+    if image_np.shape[0] == 3:
+        image_np = image_np.transpose(1, 2, 0)
+    Image.fromarray(image_np).save(filepath)

--- a/stable_diffusion_1_5/pytorch/pipeline.py
+++ b/stable_diffusion_1_5/pytorch/pipeline.py
@@ -14,6 +14,7 @@ benchmarks; callers construct ``SD15Pipeline`` and drive it through
 ``generate``.
 """
 
+import time
 from typing import Optional
 
 import torch
@@ -105,6 +106,18 @@ class SD15Pipeline:
 
         batch_size = 1 if isinstance(prompt, str) else len(prompt)
 
+        # Per-component forward+sync times for the benchmark harness (reset
+        # every generate() call). ``components`` holds scalar per-stage seconds,
+        # ``steps`` holds per-UNet-step seconds; the cpu cast after each TT
+        # forward forces a device sync, so the timer captures real device work.
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "unet_step",
+            "total": None,
+        }
+        t_total_start = time.perf_counter()
+
         tt_cast = lambda x: (
             x.to(dtype=torch.bfloat16).to(device=xm.xla_device())
             if x.device == torch.device("cpu")
@@ -140,12 +153,15 @@ class SD15Pipeline:
                 cond_tokens = cond_tokens.to(device=xm.xla_device())
                 uncond_tokens = uncond_tokens.to(device=xm.xla_device())
 
+            t0 = time.perf_counter()
             cond_hidden_state = self.text_encoder(cond_tokens)[0]  # (B, 77, 768)
             uncond_hidden_state = self.text_encoder(uncond_tokens)[0]  # (B, 77, 768)
 
             if self.clip_on_tt:
+                # TT → CPU (cpu cast forces sync — timer ends after this)
                 cond_hidden_state = cpu_cast(cond_hidden_state)
                 uncond_hidden_state = cpu_cast(uncond_hidden_state)
+            self._perf["components"]["text_encoder"] = time.perf_counter() - t0
 
             encoder_hidden_states = torch.cat(
                 [uncond_hidden_state, cond_hidden_state], dim=0
@@ -172,14 +188,16 @@ class SD15Pipeline:
                 timestep_tt = tt_cast(timestep.unsqueeze(0))
                 encoder_hidden_states = tt_cast(encoder_hidden_states)
 
+                t0 = time.perf_counter()
                 unet_output = self.unet(
                     model_input,
                     timestep_tt,
                     encoder_hidden_states,
                 ).sample
 
-                # TT → CPU
+                # TT → CPU (cpu cast forces sync — timer ends after this)
                 unet_output = cpu_cast(unet_output)
+                self._perf["steps"].append(time.perf_counter() - t0)
 
                 # CFG blending (CPU)
                 uncond_output, cond_output = unet_output.chunk(2)
@@ -196,10 +214,14 @@ class SD15Pipeline:
             latents = latents.to(dtype=torch.float32)
             if self.vae_on_tt:
                 latents = latents.to(device=xm.xla_device())
+            t0 = time.perf_counter()
             images = self.vae.decode(latents).sample
             if self.vae_on_tt:
+                # TT → CPU (cpu cast forces sync — timer ends after this)
                 images = cpu_cast(images)
+            self._perf["components"]["vae"] = time.perf_counter() - t0
 
+            self._perf["total"] = time.perf_counter() - t_total_start
             return images
 
 

--- a/stable_diffusion_3/pytorch/__init__.py
+++ b/stable_diffusion_3/pytorch/__init__.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-
+"""
+Stable Diffusion 3 Medium PyTorch pipeline implementation for Tenstorrent projects.
+"""
 from .loader import ModelLoader, ModelVariant

--- a/stable_diffusion_3/pytorch/pipeline.py
+++ b/stable_diffusion_3/pytorch/pipeline.py
@@ -32,11 +32,10 @@ from PIL import Image
 
 
 class SD3Config:
-    def __init__(self, device="cpu"):
+    def __init__(self):
         self.model_id = "stabilityai/stable-diffusion-3-medium-diffusers"
         self.height = 1024
         self.width = 1024
-        self.device = device
 
 
 class SD3Pipeline:
@@ -44,7 +43,6 @@ class SD3Pipeline:
 
     def __init__(self, config: SD3Config):
         self.config = config
-        self.device = config.device
         self.model_id = config.model_id
         self.height = config.height
         self.width = config.width
@@ -115,7 +113,7 @@ class SD3Pipeline:
                 prompt_3=None,
                 negative_prompt=negative_prompt,
                 do_classifier_free_guidance=do_cfg,
-                device=self.device,
+                device="cpu",
                 num_images_per_prompt=1,
                 max_sequence_length=max_sequence_length,
             )
@@ -137,7 +135,7 @@ class SD3Pipeline:
                 self.height,
                 self.width,
                 prompt_embeds.dtype,
-                self.device,
+                "cpu",
                 generator,
                 None,
             )
@@ -164,6 +162,12 @@ class SD3Pipeline:
                 **scheduler_kwargs,
             )
 
+            # The conditioning embeddings are constant across the denoising
+            # loop, so cast them to the TT device once here instead of every
+            # iteration.
+            prompt_embeds_tt = tt_cast(prompt_embeds)
+            pooled_prompt_embeds_tt = tt_cast(pooled_prompt_embeds)
+
             # --- Denoising loop (transformer on TT) ---
             for i, t in enumerate(timesteps):
                 print(f"Step {i + 1} of {num_inference_steps}")
@@ -171,13 +175,13 @@ class SD3Pipeline:
                 latent_model_input = torch.cat([latents] * 2) if do_cfg else latents
                 timestep = t.expand(latent_model_input.shape[0])
 
-                # CPU -> TT
+                # CPU -> TT (sample + timestep change per step; embeds hoisted above)
                 t0 = time.perf_counter()
                 noise_pred = self.transformer(
                     hidden_states=tt_cast(latent_model_input),
                     timestep=tt_cast(timestep),
-                    encoder_hidden_states=tt_cast(prompt_embeds),
-                    pooled_projections=tt_cast(pooled_prompt_embeds),
+                    encoder_hidden_states=prompt_embeds_tt,
+                    pooled_projections=pooled_prompt_embeds_tt,
                     return_dict=False,
                 )[0]
 

--- a/stable_diffusion_3/pytorch/pipeline.py
+++ b/stable_diffusion_3/pytorch/pipeline.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Stable Diffusion 3 Medium text-to-image pipeline running end-to-end on TT.
+
+The MMDiT transformer (the heavy net) runs on the Tenstorrent backend via
+``torch.compile(backend="tt")``; the three text encoders (two CLIP + T5),
+the scheduler and the VAE run on CPU. This mirrors the SD 1.5 / SDXL pipelines:
+precision-sensitive text encoding and the VAE stay on CPU while the dominant
+compute (the transformer) is offloaded to TT.
+
+The denoising loop, prompt encoding, latent preparation and VAE decode reuse
+the diffusers ``StableDiffusion3Pipeline`` helper methods directly, so the
+numerics match upstream; only the per-step transformer call is redirected to
+the TT device.
+
+This is the reusable pipeline implementation shared by the tt-xla examples and
+benchmarks; callers construct ``SD3Pipeline`` and drive it through ``generate``.
+"""
+
+from typing import Optional
+
+import torch
+import torch_xla.core.xla_model as xm
+from diffusers import StableDiffusion3Pipeline
+from diffusers.pipelines.stable_diffusion_3.pipeline_stable_diffusion_3 import (
+    calculate_shift,
+    retrieve_timesteps,
+)
+from PIL import Image
+
+
+class SD3Config:
+    def __init__(self, device="cpu"):
+        self.model_id = "stabilityai/stable-diffusion-3-medium-diffusers"
+        self.height = 1024
+        self.width = 1024
+        self.device = device
+
+
+class SD3Pipeline:
+    """Text-to-image generation with Stable Diffusion 3 Medium (MMDiT on TT)."""
+
+    def __init__(self, config: SD3Config):
+        self.config = config
+        self.device = config.device
+        self.model_id = config.model_id
+        self.height = config.height
+        self.width = config.width
+
+    def setup(self):
+        # The text encoders, scheduler and VAE stay on CPU in fp32; only the
+        # transformer is compiled for and moved to the TT device.
+        self.pipe = StableDiffusion3Pipeline.from_pretrained(
+            self.model_id, torch_dtype=torch.float32
+        )
+        self.pipe.to("cpu")
+
+        self.transformer = self.pipe.transformer
+        self.transformer = self.transformer.to(dtype=torch.bfloat16)
+        self.transformer.compile(backend="tt")
+        self.transformer = self.transformer.to(xm.xla_device())
+
+    def generate(
+        self,
+        prompt: str,
+        negative_prompt: str = "",
+        guidance_scale: float = 7.0,
+        num_inference_steps: int = 28,
+        max_sequence_length: int = 256,
+        seed: Optional[int] = None,
+    ) -> torch.Tensor:
+        """Generate an image from a text prompt. Returns tensor (B, 3, H, W) in [-1, 1]."""
+
+        pipe = self.pipe
+        do_cfg = guidance_scale > 1.0
+
+        tt_cast = lambda x: (
+            x.to(dtype=torch.bfloat16).to(device=xm.xla_device())
+            if x.device == torch.device("cpu")
+            else x.to(dtype=torch.bfloat16)
+        )
+        cpu_cast = lambda x: x.to("cpu").to(dtype=torch.float32)
+
+        with torch.no_grad():
+            generator = torch.Generator(device="cpu")
+            if seed is not None:
+                generator.manual_seed(seed)
+            else:
+                generator.seed()
+
+            # --- Text encoding (CLIP x2 + T5) on CPU ---
+            (
+                prompt_embeds,
+                negative_prompt_embeds,
+                pooled_prompt_embeds,
+                negative_pooled_prompt_embeds,
+            ) = pipe.encode_prompt(
+                prompt=prompt,
+                prompt_2=None,
+                prompt_3=None,
+                negative_prompt=negative_prompt,
+                do_classifier_free_guidance=do_cfg,
+                device=self.device,
+                num_images_per_prompt=1,
+                max_sequence_length=max_sequence_length,
+            )
+
+            if do_cfg:
+                prompt_embeds = torch.cat(
+                    [negative_prompt_embeds, prompt_embeds], dim=0
+                )
+                pooled_prompt_embeds = torch.cat(
+                    [negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0
+                )
+
+            # --- Prepare latents (CPU) ---
+            num_channels_latents = pipe.transformer.config.in_channels
+            latents = pipe.prepare_latents(
+                1,
+                num_channels_latents,
+                self.height,
+                self.width,
+                prompt_embeds.dtype,
+                self.device,
+                generator,
+                None,
+            )
+
+            # --- Prepare timesteps with dynamic shifting (CPU) ---
+            scheduler_kwargs = {}
+            if pipe.scheduler.config.get("use_dynamic_shifting", None):
+                _, _, lat_h, lat_w = latents.shape
+                image_seq_len = (lat_h // pipe.transformer.config.patch_size) * (
+                    lat_w // pipe.transformer.config.patch_size
+                )
+                scheduler_kwargs["mu"] = calculate_shift(
+                    image_seq_len,
+                    pipe.scheduler.config.get("base_image_seq_len", 256),
+                    pipe.scheduler.config.get("max_image_seq_len", 4096),
+                    pipe.scheduler.config.get("base_shift", 0.5),
+                    pipe.scheduler.config.get("max_shift", 1.16),
+                )
+            timesteps, num_inference_steps = retrieve_timesteps(
+                pipe.scheduler,
+                num_inference_steps,
+                "cpu",
+                sigmas=None,
+                **scheduler_kwargs,
+            )
+
+            # --- Denoising loop (transformer on TT) ---
+            for i, t in enumerate(timesteps):
+                print(f"Step {i + 1} of {num_inference_steps}")
+
+                latent_model_input = torch.cat([latents] * 2) if do_cfg else latents
+                timestep = t.expand(latent_model_input.shape[0])
+
+                # CPU -> TT
+                noise_pred = self.transformer(
+                    hidden_states=tt_cast(latent_model_input),
+                    timestep=tt_cast(timestep),
+                    encoder_hidden_states=tt_cast(prompt_embeds),
+                    pooled_projections=tt_cast(pooled_prompt_embeds),
+                    return_dict=False,
+                )[0]
+
+                # TT -> CPU
+                noise_pred = cpu_cast(noise_pred)
+
+                if do_cfg:
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                    noise_pred = noise_pred_uncond + guidance_scale * (
+                        noise_pred_text - noise_pred_uncond
+                    )
+
+                latents = pipe.scheduler.step(
+                    noise_pred, t, latents, return_dict=False
+                )[0]
+
+            # --- VAE decode (CPU) ---
+            latents = (
+                latents / pipe.vae.config.scaling_factor
+            ) + pipe.vae.config.shift_factor
+            latents = latents.to(dtype=torch.float32)
+            images = pipe.vae.decode(latents, return_dict=False)[0]
+
+            return images
+
+
+def save_image(image: torch.Tensor, filepath: str = "output.png"):
+    """Rescale, reshape and save the image from pipeline output."""
+    image = (
+        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
+    )
+    image_np = image.cpu().squeeze().numpy()
+    assert image_np.ndim == 3, "Image must be 3D"
+    if image_np.shape[0] == 3:
+        image_np = image_np.transpose(1, 2, 0)
+    Image.fromarray(image_np).save(filepath)

--- a/stable_diffusion_3/pytorch/pipeline.py
+++ b/stable_diffusion_3/pytorch/pipeline.py
@@ -18,6 +18,7 @@ This is the reusable pipeline implementation shared by the tt-xla examples and
 benchmarks; callers construct ``SD3Pipeline`` and drive it through ``generate``.
 """
 
+import time
 from typing import Optional
 
 import torch
@@ -75,6 +76,18 @@ class SD3Pipeline:
         pipe = self.pipe
         do_cfg = guidance_scale > 1.0
 
+        # Per-component forward+sync times for the benchmark harness (reset
+        # every generate() call). ``components`` holds scalar per-stage seconds,
+        # ``steps`` holds per-transformer-step seconds; the cpu cast after each
+        # TT forward forces a device sync, so the timer captures device work.
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "transformer_step",
+            "total": None,
+        }
+        t_total_start = time.perf_counter()
+
         tt_cast = lambda x: (
             x.to(dtype=torch.bfloat16).to(device=xm.xla_device())
             if x.device == torch.device("cpu")
@@ -90,6 +103,7 @@ class SD3Pipeline:
                 generator.seed()
 
             # --- Text encoding (CLIP x2 + T5) on CPU ---
+            t0 = time.perf_counter()
             (
                 prompt_embeds,
                 negative_prompt_embeds,
@@ -105,6 +119,7 @@ class SD3Pipeline:
                 num_images_per_prompt=1,
                 max_sequence_length=max_sequence_length,
             )
+            self._perf["components"]["text_encode"] = time.perf_counter() - t0
 
             if do_cfg:
                 prompt_embeds = torch.cat(
@@ -157,6 +172,7 @@ class SD3Pipeline:
                 timestep = t.expand(latent_model_input.shape[0])
 
                 # CPU -> TT
+                t0 = time.perf_counter()
                 noise_pred = self.transformer(
                     hidden_states=tt_cast(latent_model_input),
                     timestep=tt_cast(timestep),
@@ -165,8 +181,9 @@ class SD3Pipeline:
                     return_dict=False,
                 )[0]
 
-                # TT -> CPU
+                # TT -> CPU (cpu cast forces sync — timer ends after this)
                 noise_pred = cpu_cast(noise_pred)
+                self._perf["steps"].append(time.perf_counter() - t0)
 
                 if do_cfg:
                     noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
@@ -183,8 +200,11 @@ class SD3Pipeline:
                 latents / pipe.vae.config.scaling_factor
             ) + pipe.vae.config.shift_factor
             latents = latents.to(dtype=torch.float32)
+            t0 = time.perf_counter()
             images = pipe.vae.decode(latents, return_dict=False)[0]
+            self._perf["components"]["vae"] = time.perf_counter() - t0
 
+            self._perf["total"] = time.perf_counter() - t_total_start
             return images
 
 


### PR DESCRIPTION
## What

Add reusable end-to-end **text-to-image (diffusion) pipeline implementations** to tt-forge-models so they can be shared by the tt-xla examples and image-gen benchmarks, instead of living in `examples/pytorch` in tt-xla.

| Family | Module | Classes |
|---|---|---|
| `stable_diffusion_1_5` (existing) | `pytorch/pipeline.py` | `SD15Config`, `SD15Pipeline` |
| `stable_diffusion_3` (new) | `pytorch/pipeline.py` | `SD3Config`, `SD3Pipeline` |
| `bria_2_3` (new) | `pytorch/pipeline.py` | `Bria23Config`, `Bria23Pipeline` |

Each pipeline runs the heavy net (UNet / MMDiT transformer) on the Tenstorrent backend via `torch.compile(backend="tt")` while keeping the precision-sensitive text encoders, scheduler and VAE on CPU. The denoising loop / prompt encoding / latent prep / VAE decode reuse the upstream diffusers helper methods so numerics match upstream.

### Per-component `_perf` instrumentation

Each `generate()` records a model-agnostic timing dict the tt-xla image-gen benchmark harness reads:

```python
_perf = {
    "components": {<name>: seconds, ...},   # scalar per-stage times (e.g. text_encoder, vae)
    "steps": [seconds, ...],                # per heavy-net-step times
    "step_metric_name": "unet_step" | "transformer_step",
    "total": seconds,                       # full generate() wall time
}
```

Each TT forward is timed up to the `.to("cpu")` cast that follows it (the cast forces a device sync), so the timers capture real device work.

## Why

Addresses review feedback on [tenstorrent/tt-xla#5085](https://github.com/tenstorrent/tt-xla/pull/5085) / #5044: model pipeline implementations should not live in `examples/`. They live here and are imported by the tt-xla image-gen benchmark.

## Companion PR

- tt-xla: [#5085](https://github.com/tenstorrent/tt-xla/pull/5085) — `test_imagegen.py` imports these pipelines. After this PR merges, tt-xla picks the pipelines up via the normal `third_party/tt_forge_models` **submodule uplift** (tt-xla #5085 carries no submodule bump).
- tt-xla benchmarks currently wire **SD 1.5 + SD 3**; **BRIA 2.3** is included here but deferred in the tt-xla benchmark until the CI `HF_TOKEN` is granted access to the gated `briaai/BRIA-2.3` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)