### PR TITLE
[Z-Image] Fix transformer sharding reshape: use model=2 mesh

### DIFF
--- a/z_image/pytorch/src/model_utils.py
+++ b/z_image/pytorch/src/model_utils.py
@@ -35,9 +35,17 @@ TRANSFORMER_NUM_REFINER_LAYERS = 2
 TRANSFORMER_IN_CHANNELS = 16
 TRANSFORMER_CAP_FEAT_DIM = 2560
 
-# (batch, model) mesh shapes by device count
-MESH_SHAPES = {32: (8, 4), 8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
-MESH_NAMES = ("batch", "model")
+# Mesh axes ("model", "batch") by device count. Megatron TP shards Q/K/V on
+# "model", splitting the hidden dim into n_heads=30 heads; the head-split reshape
+# unflatten(-1, (30, head_dim)) only partitions when "model" evenly divides 30
+# (divisors 1,2,3,5,6,10,15,30). On power-of-2 device counts "model" must be 2 —
+# model=4/8 give non-integer heads (3840/8 = 3.75) and fail SHLO reshape
+# partitioning (tt-xla#5148). The "model" axis is placed first so the logical
+# mesh maps onto the physical board. model=2 clears the reshape; the transformer
+# then reaches the RoPE complex legalization blocker (tt-xla#4756). Validated on
+# 2/4/8 devices (meshes (2,1)/(2,2)/(2,4)).
+MESH_SHAPES = {32: (2, 16), 8: (2, 4), 4: (2, 2), 2: (2, 1), 1: (1, 1)}
+MESH_NAMES = ("model", "batch")
 
 
 def latent_hw_from_pixels(height: int = HEIGHT, width: int = WIDTH) -> tuple[int, int]:


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-xla/issues/5148 (After this fix the sharded transformer reaches [tt-xla#4756](https://github.com/tenstorrent/tt-xla/issues/4756) — RoPE complex
 legalization — which is fixed by [tt-mlir#8637](https://github.com/tenstorrent/tt-mlir/pull/8637), pending uplift.)

### Problem description
- The sharded `ZImageTransformer2DModel` component test (`tests/torch/models/z_image/test_transformer.py::test_transformer_sharded`) fails on latest main during the SHLO sharding stage (before TTIRlegalization) with a `reshape` element-count mismatch ("Failed to run stablehlo
pipeline"; see attached before-fix log).

- Root cause is attention head-divisibility. Q/K/V are column-parallel (`("model", None)`), so the hidden dim (3840) is sharded by the `model` axis, and the head split `unflatten(-1, (30, head_dim))` only partitions when the `model` axis evenl divides `n_heads = 30` (divisors 1,2,3,5,6,10,15,30). On power-of-2 device counts `model = 4/8` give non-integer heads (3840/8 = 3.75,3840/4 = 7.5) so the reshape element count cannot reconcile — the mismatchfactor equals the `model` axis size. Tracked as tt-xla#5148.

### What's changed
- Single change, Z-Image shard specs only:
- Use a `model = 2` mesh (the only power-of-2 size that divides n_heads=30), with the `model` axis placed first so the logical mesh maps onto the physical board:
```
      MESH_SHAPES = {32:(2,16), 8:(2,4), 4:(2,2), 2:(2,1), 1:(1,1)}
      MESH_NAMES  = ("model", "batch")
```
- Impact: the head-split reshape now partitions, so the transformer clears the SHLO sharding stage and reaches the RoPE complex<f32> legalization blocker (tt-xla#4756). Validated on 2 / 4 / 8 devices (meshes (2,1) / (2,2) / (2,4)) — all reach #4756, none hit the reshape error or "Mesh is not valid".

### Checklist
- [x] Existing test provides coverage: tt-xla#4764 (`test_transformer.py::test_transformer_sharded`(nightly / llmbox / tensor_parallel, xfail against tt-xla#4756)).
- [ ] PCC not yet validated (blocked by tt-xla#4756 until tt-mlir#8637 uplift).


### Logs
- Before fix: reshape failure on latest main. [log](https://github.com/user-attachments/files/28809421/transformer_sharded.log)
- After fix: sharded runs on 2 / 4 / 8 devices, each reaching tt-xla#4756. [2dev_log](https://github.com/user-attachments/files/28809415/sharded_2dev_meshonly.log), [4dev_log](https://github.com/user-attachments/files/28809418/sharded_4dev_meshonly.log), [8dev_log](https://github.com/user-attachments/files/28809420/sharded_meshonly.log)
