### PR TITLE
[GLM Image] Fix prior_token_drop dtype and avoid boolean-mask graph break in transformer test

### DIFF
--- a/glm_image/pytorch/loader.py
+++ b/glm_image/pytorch/loader.py
@@ -154,7 +154,7 @@ class ModelLoader(ForgeModel):
                                    images_per_sample (1,) int64, cache_position (394,) int64,
                                    logits_to_keep scalar int64]
         TRANSFORMER             → [hidden_states (1,16,128,144), encoder_hidden_states (1,376,1472),
-                                   prior_token_id (1,4608) int64, prior_token_drop (1,4608) int64,
+                                   prior_token_id (1,4608) int64, prior_token_drop (1,4608) bool,
                                    timestep ([999.]), target_size ([[1024.,1152.]] bf16),
                                    crop_coords ([[0.,0.]] bf16)]
         VAE                     → [z (1,16,128,144) dtype]

--- a/glm_image/pytorch/src/model_utils.py
+++ b/glm_image/pytorch/src/model_utils.py
@@ -15,6 +15,133 @@ Components:
 
 import torch
 
+
+# ---------------------------------------------------------------------------
+# Model patch
+#
+# The stock GlmImageTransformer2DModel.forward zeroes the dropped prior-token
+# embeddings with a boolean-mask in-place assignment:
+#
+#     prior_embedding[prior_token_drop] *= 0.0
+#
+# Boolean-mask indexing lowers to nonzero/gather/scatter, which is
+# data-dependent (dynamic shape). Under torch.compile this forces a Dynamo
+# graph break, and torch_xla's FX partitioner then fails to fuse the resulting
+# partitions (`assert last_output_node is not None`).
+#
+# We monkey-patch forward to use the mathematically-equivalent static form
+#
+#     prior_embedding = prior_embedding * (~prior_token_drop)[..., None]
+#
+# which zeroes the same rows with no nonzero, no dynamic shape and no graph
+# break. Both the CPU golden and the TT path use the patched op, so PCC is
+# unaffected. Mirrors the GptOss monkey-patch convention in
+# python_package/tt_torch/torch_overrides.py.
+# ---------------------------------------------------------------------------
+
+
+def _patch_glm_image_transformer_forward() -> None:
+    try:
+        from typing import Any
+
+        from diffusers.models.transformers.transformer_glm_image import (
+            GlmImageTransformer2DModel,
+        )
+        from diffusers.models.modeling_outputs import Transformer2DModelOutput
+    except ImportError:
+        return
+
+    if getattr(GlmImageTransformer2DModel.forward, "_tt_static_prior_drop", False):
+        return
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        prior_token_id: torch.Tensor,
+        prior_token_drop: torch.Tensor,
+        timestep: torch.LongTensor,
+        target_size: torch.Tensor,
+        crop_coords: torch.Tensor,
+        attention_kwargs: "dict[str, Any] | None" = None,
+        return_dict: bool = True,
+        attention_mask: torch.Tensor | None = None,
+        kv_caches=None,
+        image_rotary_emb=None,
+    ):
+        batch_size, num_channels, height, width = hidden_states.shape
+
+        # 1. RoPE
+        if image_rotary_emb is None:
+            image_rotary_emb = self.rope(hidden_states)
+
+        # 2. Patch & Timestep embeddings
+        p = self.config.patch_size
+        post_patch_height = height // p
+        post_patch_width = width // p
+
+        hidden_states = self.image_projector(hidden_states)
+        encoder_hidden_states = self.glyph_projector(encoder_hidden_states)
+        prior_embedding = self.prior_token_embedding(prior_token_id)
+        # Static-shape equivalent of `prior_embedding[prior_token_drop] *= 0.0`.
+        keep = (~prior_token_drop).unsqueeze(-1).to(prior_embedding.dtype)
+        prior_embedding = prior_embedding * keep
+        prior_hidden_states = self.prior_projector(prior_embedding)
+
+        hidden_states = hidden_states + prior_hidden_states
+
+        temb = self.time_condition_embed(
+            timestep, target_size, crop_coords, hidden_states.dtype
+        )
+
+        # 3. Transformer blocks
+        for idx, block in enumerate(self.transformer_blocks):
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                (
+                    hidden_states,
+                    encoder_hidden_states,
+                ) = self._gradient_checkpointing_func(
+                    block,
+                    hidden_states,
+                    encoder_hidden_states,
+                    temb,
+                    image_rotary_emb,
+                    attention_mask,
+                    attention_kwargs,
+                    kv_caches[idx] if kv_caches is not None else None,
+                )
+            else:
+                hidden_states, encoder_hidden_states = block(
+                    hidden_states,
+                    encoder_hidden_states,
+                    temb,
+                    image_rotary_emb,
+                    attention_mask,
+                    attention_kwargs,
+                    kv_cache=kv_caches[idx] if kv_caches is not None else None,
+                )
+
+        # 4. Output norm & projection
+        hidden_states = self.norm_out(hidden_states, temb)
+        hidden_states = self.proj_out(hidden_states)
+
+        # 5. Unpatchify
+        hidden_states = hidden_states.reshape(
+            batch_size, post_patch_height, post_patch_width, -1, p, p
+        )
+        output = hidden_states.permute(0, 3, 1, 4, 2, 5).flatten(4, 5).flatten(2, 3)
+
+        if not return_dict:
+            return (output,)
+        return Transformer2DModelOutput(sample=output)
+
+    forward._tt_static_prior_drop = True
+    GlmImageTransformer2DModel.forward = forward
+
+
+_patch_glm_image_transformer_forward()
+
+
 # ---------------------------------------------------------------------------
 # Model identity
 # ---------------------------------------------------------------------------
@@ -195,9 +322,14 @@ def load_transformer_inputs(dtype: torch.dtype = DTYPE):
     prior_token_id = torch.randint(
         0, PRIOR_VOCAB_SIZE, (1, PRIOR_SEQ_LEN), dtype=torch.long, generator=gen
     )
-    prior_token_drop = torch.randint(
-        0, PRIOR_VOCAB_SIZE, (1, PRIOR_SEQ_LEN), dtype=torch.long
-    )
+    # Matches the real GLM-Image pipeline, which always passes a *uniform*
+    # boolean mask (all-False for the conditional pass, all-True for the
+    # unconditional pass) rather than a random per-token mask. We use the
+    # all-False conditional case (`prior_token_drop_cond`): no prior tokens
+    # are dropped. A random mask would also make `prior_embedding[mask] *= 0`
+    # a data-dependent nonzero/gather/scatter, which breaks static-shape
+    # compilation.
+    prior_token_drop = torch.zeros((1, PRIOR_SEQ_LEN), dtype=torch.bool)
     timestep = torch.tensor([TRANSFORMER_TIMESTEP_VALUE])
     target_size = torch.tensor([list(TRANSFORMER_TARGET_SIZE)], dtype=torch.bfloat16)
     crop_coords = torch.tensor([list(TRANSFORMER_CROP_COORDS)], dtype=torch.bfloat16)


### PR DESCRIPTION
### Ticket

- [#4804](https://github.com/tenstorrent/tt-xla/issues/4804)

### Problem description

tests/torch/models/glm_image/test_transformer.py::test_transformer_sharded fails with 
```
IndexError: index 4023 is out of bounds for dimension 0 with size 1
```
### What's changed

- A failure was hit in the GLM-Image transformer test , on the statement `prior_embedding[prior_token_drop] *= 0.0`.

- Initially,` IndexError: index 8692 is out of bounds for dimension 0 with size 1` was raised, because prior_token_drop was being constructed as a long tensor holding large vocabulary values, so it was interpreted as integer indices into dim-0 (size 1) rather than as a boolean mask.

- After the dtype was corrected, a second failure was surfaced during TT-device compilation: an AssertionError (`assert last_output_node is not None`) was raised by torch_xla's FX partitioner. This was caused by the boolean-mask in-place assignment being lowered to a data-dependent nonzero/gather/scatter, which produced a dynamic shape, forced a Dynamo graph break, and left a partition that could not be fused.

- The prior_token_drop input was changed from a long tensor of random vocabulary values to an all-False boolean mask, so that the real pipeline's conditional pass (prior_token_drop_cond) is matched and a valid boolean mask is provided.

- GlmImageTransformer2DModel.forward was patched so the boolean-mask in-place assignment prior_embedding[prior_token_drop] *= 0.0 is replaced by the mathematically-equivalent static-shape form prior_embedding = prior_embedding * (~prior_token_drop)[..., None].

- The data-dependent nonzero/gather/scatter was thereby eliminated, so the Dynamo graph break and the partitioner assertion were both avoided.

- Numerical correctness was preserved, since the same patched operation is executed on both the CPU golden path and the TT path, leaving PCC unaffected.

- Model now fails in mlir with `error: 'sdy.collective_permute' op requires the same type for all operands and results`

### Logs
[glm_transformer_before_fix.log](https://github.com/user-attachments/files/28824143/glm_transformer_before_fix.log)
[glm_transformer_after_fix.log](https://github.com/user-attachments/files/28824140/glm_transformer_after_fix.log)

