### PR TITLE
Bringup: diffusiongemma/26B-A4B-it [8-way tensor parallel]

### DIFF
--- a/diffusiongemma/pytorch/__init__.py
+++ b/diffusiongemma/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DiffusionGemma PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/diffusiongemma/pytorch/loader.py
+++ b/diffusiongemma/pytorch/loader.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+DiffusionGemma loader (text-only path).
+
+google/diffusiongemma-26B-A4B-it: a multimodal block-diffusion LLM on a Gemma 4
+MoE backbone that denoises a block of tokens instead of decoding left-to-right.
+~25.8B params.
+"""
+
+from typing import Optional
+
+from transformers import AutoProcessor
+
+from ...base import ForgeModel
+from ...config import (
+    Framework,
+    LLMModelConfig,
+    ModelGroup,
+    ModelInfo,
+    ModelSource,
+    ModelTask,
+    StrEnum,
+)
+from ...tools.utils import cast_input_to_type
+from .utils import _install_dynamo_safe_param_props
+
+
+class ModelVariant(StrEnum):
+    """Available DiffusionGemma model variants."""
+
+    DIFFUSIONGEMMA_26B_A4B_IT = "26B-A4B-it"
+
+
+class ModelLoader(ForgeModel):
+    """DiffusionGemma loader (text-only block-diffusion path)."""
+
+    _VARIANTS = {
+        ModelVariant.DIFFUSIONGEMMA_26B_A4B_IT: LLMModelConfig(
+            pretrained_model_name="google/diffusiongemma-26B-A4B-it",
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.DIFFUSIONGEMMA_26B_A4B_IT
+
+    sample_text = "Why is the sky blue?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        super().__init__(variant)
+        self.processor = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="DiffusionGemma",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_processor(self):
+        self.processor = AutoProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.processor
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        """Load the DiffusionGemmaForBlockDiffusion model (text-only path)."""
+        from transformers import DiffusionGemmaForBlockDiffusion
+
+        if self.processor is None:
+            self._load_processor()
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["dtype"] = dtype_override
+        model_kwargs |= kwargs
+        model = DiffusionGemmaForBlockDiffusion.from_pretrained(
+            self._variant_config.pretrained_model_name, **model_kwargs
+        )
+        model.eval()
+        model = _install_dynamo_safe_param_props(model)
+        self.model = model
+        self.config = model.config
+        return model
+
+    def load_inputs(
+        self, dtype_override=None, batch_size=1, prompt: Optional[str] = None
+    ):
+        """Build text inputs via the chat template (dict -> keyword-bound)."""
+        if self.processor is None:
+            self._load_processor()
+        inputs = dict(
+            self.processor.apply_chat_template(
+                [{"role": "user", "content": prompt or self.sample_text}],
+                tokenize=True,
+                add_generation_prompt=True,
+                return_dict=True,
+                return_tensors="pt",
+            )
+        )
+        for key in list(inputs):
+            value = inputs[key].repeat_interleave(batch_size, dim=0)
+            inputs[key] = cast_input_to_type(value, dtype_override)
+        return inputs
+
+    def _text_layers(self, model):
+        """Encoder then decoder text transformer layers."""
+        base = model.model
+        return list(base.encoder.language_model.layers) + list(base.decoder.layers)
+
+    def get_mesh_config(self, num_devices: int):
+        """((1, num_devices), ("batch", "model")); model axis carries query heads
+        and the expert axis, so both must divide it (KV is replicated)."""
+        mesh_shape = (1, num_devices)
+        text_cfg = getattr(self.config, "text_config", self.config)
+        assert text_cfg.num_attention_heads % mesh_shape[1] == 0
+        assert text_cfg.num_experts % mesh_shape[1] == 0
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        """Megatron TP (q col / o row, dense MLP col->row) + expert-parallel MoE
+        (3D expert tensors sharded on the expert axis). K/V replicated: the
+        full-attention layers carry only 2 global KV heads (unsharddable)."""
+        shard_specs = {}
+        for layer in self._text_layers(model):
+            attn = layer.self_attn
+            shard_specs[attn.q_proj.weight] = ("model", None)
+            shard_specs[attn.o_proj.weight] = (None, "model")
+
+            shard_specs[layer.mlp.gate_proj.weight] = ("model", None)
+            shard_specs[layer.mlp.up_proj.weight] = ("model", None)
+            shard_specs[layer.mlp.down_proj.weight] = (None, "model")
+
+            experts = getattr(layer, "experts", None)
+            if experts is not None:
+                shard_specs[experts.gate_up_proj] = ("model", None, None)
+                shard_specs[experts.down_proj] = ("model", None, None)
+        return shard_specs

--- a/diffusiongemma/pytorch/requirements.txt
+++ b/diffusiongemma/pytorch/requirements.txt
@@ -1,0 +1,1 @@
+transformers==5.12.0

--- a/diffusiongemma/pytorch/utils.py
+++ b/diffusiongemma/pytorch/utils.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Helpers for the DiffusionGemma loader."""
+
+
+def _install_dynamo_safe_param_props(model):
+    """Make dtype/device iterate named_parameters() instead of parameters(), on
+    the model and every submodule that exposes those properties.
+
+    torch 2.10 Dynamo's wrap_values() emits an invalid `named_children` reference
+    when tracing .parameters(); named_parameters() takes a clean path. The forward
+    reads submodule props (e.g. self.decoder.device), so every PreTrainedModel in
+    the tree must be patched, not just the root.
+    """
+    for module in list(model.modules()):
+        cls = type(module)
+        if getattr(cls, "_tt_xla_dynamo_safe", False):
+            continue
+        # Only patch modules that actually expose the buggy property.
+        if not (
+            isinstance(getattr(cls, "dtype", None), property)
+            or isinstance(getattr(cls, "device", None), property)
+        ):
+            continue
+
+        class _DynamoSafe(cls):
+            _tt_xla_dynamo_safe = True
+
+            @property
+            def dtype(self):
+                for _, p in self.named_parameters():
+                    if p.is_floating_point():
+                        return p.dtype
+                return super().dtype
+
+            @property
+            def device(self):
+                for _, p in self.named_parameters():
+                    return p.device
+                return super().device
+
+        module.__class__ = _DynamoSafe
+    return model


### PR DESCRIPTION
## Ticket

- https://github.com/tenstorrent/tt-xla/issues/5195

## Problem Description

- Adds the `diffusiongemma` text-only loader (`google/diffusiongemma-26B-A4B-it`, `DiffusionGemmaForBlockDiffusion`) and an 8-way tensor-parallel inference config on `n300-llmbox`.


## Highlights
- Loader      : `tt_forge_models/diffusiongemma/pytorch/loader.py` (submodule)
- Params      : ~25.8 B (128-expert MoE, top-8; text path)
- Modality    : multimodal arch, **text path** only
- Parallelism : tensor_parallel, TP=8, mesh (1, 8) ["batch", "model"]
- Archs       : n300-llmbox
- Status      : Model fails with `RuntimeError: Value out of range (expected to be in range of [-19, 18], but got -1023)` -  [#5199](https://github.com/tenstorrent/tt-xla/issues/5199)
- Transformers: requires `5.12.0` — brand-new arch

## Shard strategy

Megatron 1D TP on the `model` axis:
- **Attention/MLP**: column-parallel `q_proj` + MLP `gate/up`; row-parallel `o_proj` + `down_proj`.
- **MoE (expert-parallel)**: the 3D expert tensors (`gate_up_proj`, `down_proj`) are sharded on dim-0 (the 128-expert axis).
- **KV replicated**: `full_attention` layers carry only `num_global_key_value_heads=2`, unsharddable across the mesh — standard GQA-TP fallback, keeps query heads grouped per chip. Router, norms, embeddings, lm_head and the unused vision tower are replicated.

## Loader specifics (why this arch needed care)
- Dynamo-safe `dtype`/`device` props (`named_parameters`, applied recursively to
  all submodules) to dodge a torch 2.10 `.parameters()` tracing bug.


## Test
`tests/runner/test_models.py::test_all_models_torch[diffusiongemma/pytorch-26B-A4B-it-tensor_parallel-inference]`

```
TT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 TT_XLA_SPMD=1 CONVERT_SHLO_TO_SHARDY=1 \
  TT_XLA_ARCH=n300-llmbox HF_HOME=/proj_sw/user_dev/kkannan/new_hub \
  pytest -svv "tests/runner/test_models.py::test_all_models_torch[diffusiongemma/pytorch-26B-A4B-it-tensor_parallel-inference]"
```

## Logs

- [jun15_diffusongemma4_8_torch_xla_bug.log](https://github.com/user-attachments/files/28949505/jun15_diffusongemma4_8_torch_xla_bug.log)
- [jun15_diffusongemma4_8_chips.log](https://github.com/user-attachments/files/28948637/jun15_diffusongemma4_8_chips_3.log)
