### PR TITLE
Fix janus_pro import error in load_processor

### DIFF
--- a/janus_pro/text_to_image/pytorch/src/model_utils.py
+++ b/janus_pro/text_to_image/pytorch/src/model_utils.py
@@ -146,6 +146,9 @@ def model_from_pretrained_kwargs() -> dict:
 
 
 def load_processor(repo_id: str):
+    # Patch must run before importing janus.models (transformers 5.5+ compat).
+    apply_janus_config_dataclass_compat()
+
     from janus.models import VLChatProcessor
 
     if repo_id not in _processor_cache:


### PR DESCRIPTION
## Problem

The janus_pro `text_to_image` loader fails at import time with:

```
ValueError: mutable default <class 'dict'> for field params is not allowed: use default_factory
```

This breaks `test_image_token_prefill_pro_1b` / `_pro_7b` (n150, p150) in tt-xla nightly.

## Root cause

The upstream `deepseek-ai/Janus` configs declare `params: AttrDict = {}` (a mutable default). transformers 5.5+ wraps every `PretrainedConfig` subclass with `dataclass(...)` in `__init_subclass__`, which rejects the mutable default.

The loader already has an idempotent compat monkeypatch, `apply_janus_config_dataclass_compat()`, but it was only applied inside `load_mmgpt()`. `make_cfg_inputs_embeds()` calls `load_processor()` **first**, and `load_processor()` imported `janus.models` with no patch applied yet — so the import blew up before any patch ran.

## Fix

Apply the existing patch before the import in `load_processor()`, mirroring `load_mmgpt()`. The patch is idempotent, so the redundant call is harmless.

## Verification

`pytest -v tests/torch/models/janus_pro/test_image_token_step.py` in tt-xla:
- `test_image_token_prefill_pro_1b` → **PASSED** (previously failed with the ValueError)
- `test_image_token_prefill_pro_7b` → skipped locally (requires p150/blackhole); same import path as 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)