### PR TITLE
Qwen2.5-Math-72B-Instruct variant Bringup

### DIFF
--- a/qwen_2_5/causal_lm/pytorch/loader.py
+++ b/qwen_2_5/causal_lm/pytorch/loader.py
@@ -42,6 +42,7 @@ class ModelVariant(StrEnum):
     QWEN_2_5_72B_INSTRUCT = "72B_Instruct"
     QWEN_2_5_72B = "72B"
     QWEN_2_5_MATH_7B = "Math_7B"
+    QWEN_2_5_MATH_72B_INSTRUCT = "Math_72B_Instruct"
 
 
 class ModelLoader(ForgeModel):
@@ -111,6 +112,10 @@ class ModelLoader(ForgeModel):
         ),
         ModelVariant.QWEN_2_5_MATH_7B: LLMModelConfig(
             pretrained_model_name="Qwen/Qwen2.5-Math-7B",
+            max_length=128,
+        ),
+        ModelVariant.QWEN_2_5_MATH_72B_INSTRUCT: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen2.5-Math-72B-Instruct",
             max_length=128,
         ),
     }
@@ -277,6 +282,9 @@ class ModelLoader(ForgeModel):
     def load_shard_spec(self, model):
         """Default shard spec on a ("batch", "model") mesh."""
         shard_specs = {}
+        # Shard the embedding only for the Math-72B variant
+        if self._variant == ModelVariant.QWEN_2_5_MATH_72B_INSTRUCT:
+            shard_specs[model.model.embed_tokens.weight] = ("model", "batch")
         for layer in model.model.layers:
             shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
             shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")

--- a/qwen_2_5/causal_lm/pytorch/mixed_precision_configs/Qwen2.5-Math-72B-Instruct.json
+++ b/qwen_2_5/causal_lm/pytorch/mixed_precision_configs/Qwen2.5-Math-72B-Instruct.json
@@ -1,0 +1,3 @@
+{
+    "default": "bfp_bf8"
+}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Add the `Qwen/Qwen2.5-Math-72B-Instruct` variant to the Qwen2.5 causal-LM loader.
At bf16 the 72B weights (~145 GB) don't fit across the target 4-device mesh (~36 GB/device vs ~34 GB available), so the model OOMs.

### What's changed
- Added the `Math_72B_Instruct` variant (`Qwen/Qwen2.5-Math-72B-Instruct`) to  `ModelVariant` and `_VARIANTS`.
- Added a `mixed_precision_configs/Qwen2.5-Math-72B-Instruct.json` (`{"default": "bfp_bf8"}`) so the weights are converted to **bfp8**, halving weight memory to ~18 GB/device and letting the model fit and run.
- Sharded the token embedding (`embed_tokens.weight`) in `load_shard_spec` so the large vocab table is no longer replicated on every device.

### Checklist
- [ ] New/Existing tests provide coverage for changes
