### PR TITLE
Fix prior_token_drop bool dtype and patch scatter->multiply

### DIFF
--- a/glm_image/pytorch/loader.py
+++ b/glm_image/pytorch/loader.py
@@ -154,7 +154,7 @@ class ModelLoader(ForgeModel):
                                    images_per_sample (1,) int64, cache_position (394,) int64,
                                    logits_to_keep scalar int64]
         TRANSFORMER             → [hidden_states (1,16,128,144), encoder_hidden_states (1,376,1472),
-                                   prior_token_id (1,4608) int64, prior_token_drop (1,4608) int64,
+                                   prior_token_id (1,4608) int64, prior_token_drop (1,4608) bool,
                                    timestep ([999.]), target_size ([[1024.,1152.]] bf16),
                                    crop_coords ([[0.,0.]] bf16)]
         VAE                     → [z (1,16,128,144) dtype]

--- a/glm_image/pytorch/src/model_utils.py
+++ b/glm_image/pytorch/src/model_utils.py
@@ -101,9 +101,57 @@ def load_vision_language_encoder(dtype: torch.dtype = DTYPE):
     ).eval()
 
 
+def _patch_prior_token_drop_scatter():
+    """Rewrite the prior-token-drop masking in GlmImageTransformer2DModel.forward.
+
+    Upstream diffusers zeroes dropped prior embeddings with a boolean masked
+    in-place multiply:
+
+        prior_embedding[prior_token_drop] *= 0.0
+
+    On the TT backend this lowers to a data-dependent ``scatter`` over the
+    4608-long prior sequence, which the scatter workaround explodes into tens of
+    thousands of per-position kernels (compilation never finishes in practice).
+
+    The operation is just "zero the rows where prior_token_drop is True", which
+    is equivalent to an elementwise multiply by the inverted mask -- a single
+    cheap op with no scatter. We patch only that one statement in the method
+    source and rebind it, so the rest of forward (and its annotations) stay
+    exactly as upstream. Idempotent.
+    """
+    import inspect
+    import textwrap
+
+    from diffusers.models.transformers import transformer_glm_image as _mod
+
+    cls = _mod.GlmImageTransformer2DModel
+    if getattr(cls.forward, "_tt_prior_drop_patched", False):
+        return
+
+    old_line = "prior_embedding[prior_token_drop] *= 0.0"
+    new_line = (
+        "prior_embedding = prior_embedding * "
+        "(~prior_token_drop).unsqueeze(-1).to(prior_embedding.dtype)"
+    )
+
+    src = textwrap.dedent(inspect.getsource(cls.forward))
+    if old_line not in src:
+        # Upstream changed this line; skip rather than silently mis-patch.
+        return
+    src = src.replace(old_line, new_line)
+
+    namespace = dict(_mod.__dict__)
+    exec(src, namespace)
+    patched = namespace["forward"]
+    patched._tt_prior_drop_patched = True
+    cls.forward = patched
+
+
 def load_transformer(dtype: torch.dtype = DTYPE):
     """Load GlmImageTransformer2DModel from the transformer subfolder."""
     from diffusers import GlmImageTransformer2DModel
+
+    _patch_prior_token_drop_scatter()
 
     return GlmImageTransformer2DModel.from_pretrained(
         REPO_ID,
@@ -196,8 +244,8 @@ def load_transformer_inputs(dtype: torch.dtype = DTYPE):
         0, PRIOR_VOCAB_SIZE, (1, PRIOR_SEQ_LEN), dtype=torch.long, generator=gen
     )
     prior_token_drop = torch.randint(
-        0, PRIOR_VOCAB_SIZE, (1, PRIOR_SEQ_LEN), dtype=torch.long
-    )
+        0, PRIOR_VOCAB_SIZE, (1, PRIOR_SEQ_LEN), generator=gen
+    ).bool()
     timestep = torch.tensor([TRANSFORMER_TIMESTEP_VALUE])
     target_size = torch.tensor([list(TRANSFORMER_TARGET_SIZE)], dtype=torch.bfloat16)
     crop_coords = torch.tensor([list(TRANSFORMER_CROP_COORDS)], dtype=torch.bfloat16)


### PR DESCRIPTION
### Ticket

- [#4804](https://github.com/tenstorrent/tt-xla/issues/4804)

### Problem description

tests/torch/models/glm_image/test_transformer.py::test_transformer_sharded fails with 
```
IndexError: index 4023 is out of bounds for dimension 0 with size 1
```
### What's changed

- Initial failure — `IndexError: index … is out of bounds for dimension 0 with size 1`. The GLM-Image transformer test crashed on prior_embedding[prior_token_drop] *= 0.0. Root cause: the test built prior_token_drop as a long tensor holding random prior-vocabulary values. The model uses it as a boolean mask for masked assignment, so those large integers were instead interpreted as fancy indices into dim-0 (size 1), and the first out-of-range value raised the IndexError.

- Fix 1 — provide a valid boolean mask. prior_token_drop is now generated as a bool tensor instead of a long index tensor. This matches both the model's masking semantics and the dtype the real pipeline produces . With this, the CPU path runs correctly.

- Fix 2 — eliminate a scatter explosion on the TT device. After the dtype fix the CPU path passed, but TT-device compilation appeared to hang (killed after >1 hr). The boolean in-place masked assignment prior_embedding[prior_token_drop] *= 0.0 lowers to a data-dependent scatter. The scatter workaround decomposed a single scatter.42 op into ~37,000 per-position chunks (~74,000 IR location entries), each compiled into its own RISC-V kernel — so compilation never finished in any practical time. GlmImageTransformer2DModel.forward is patched at load time to replace that statement with the mathematically-equivalent static-shape form:


- prior_embedding = prior_embedding * (~prior_token_drop).unsqueeze(-1).to(prior_embedding.dtype).This is a single elementwise multiply — no nonzero/gather/scatter, no data-dependent/dynamic shape — so the scatter explosion is eliminated. The patch is idempotent and no-ops if upstream diffusers ever changes that line.

- CPU numerics are unchanged by the patch (verified). Verified by re-running the CPU reference with and without the patch. Why the rewrite is always valid — the pipeline mask is uniformly 0 or 1. In the real pipeline ([pipeline_glm_image.py:957-958](https://github.com/huggingface/diffusers/blob/7bf00006aa005eae37bcc639fd0f010c183365b4/src/diffusers/pipelines/glm_image/pipeline_glm_image.py#L987) prior_token_drop is always a pure boolean tensor, created per classifier-free-guidance pass as either all-False (prior_token_drop_cond) or all-True (prior_token_drop_uncond):


```
prior_token_drop_cond   = torch.full_like(prior_token_ids, False, dtype=torch.bool)  # multiplier = all 1.0
prior_token_drop_uncond = torch.full_like(prior_token_ids, True,  dtype=torch.bool)  # multiplier = all 0.0
```

- So the multiplier (~prior_token_drop) is always exactly all-ones (keep prior_embedding unchanged) or all-zeros (zero it out) — precisely the masked-assignment behavior, with guaranteed bool dtype making ~ a logical (not bitwise) NOT.

-  With the index and scatter issues resolved, sharded TT compilation now advances to a separate MLIR error: error: `ttnn.concat: required CB page size (2965504 B) exceeds per-core L1 capacity (1395296 B); op cannot fit on this device.`

### Logs
[glm_transformer_before_fix.log](https://github.com/user-attachments/files/28824143/glm_transformer_before_fix.log)
[glm_transformer_after_fix_jun19.log](https://github.com/user-attachments/files/29121840/glm_transformer_after_fix_jun19.log)


