### PR TITLE
Model bringup hyperclovax seed think 14b

### DIFF
--- a/hyperclovax/__init__.py
+++ b/hyperclovax/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HyperCLOVA X model implementation for Tenstorrent projects.
+"""
+# Import from the PyTorch implementation by default
+from .pytorch import ModelLoader

--- a/hyperclovax/pytorch/__init__.py
+++ b/hyperclovax/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HyperCLOVA X PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader

--- a/hyperclovax/pytorch/loader.py
+++ b/hyperclovax/pytorch/loader.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+HyperCLOVA X SEED Think causal LM model loader implementation.
+"""
+
+import torch
+from typing import Optional
+
+# NOTE: `transformers` is intentionally NOT imported at module top level.
+# HyperCLOVA X SEED Think gained native support in transformers >= 5.9.0 (see
+# requirements.txt; model_type "hyperclovax"). The test runner upgrades
+# transformers at test time and purges it from sys.modules. A top-level import
+# would bind the Auto* classes to whatever transformers was loaded during pytest
+# collection, leaving stale class objects whose in-memory code mismatches the
+# pinned files on disk. So the Auto* classes are imported lazily in the methods.
+
+from ...base import ForgeModel
+from ...config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available HyperCLOVA X model variants for causal language modeling."""
+
+    HyperCLOVAX_SEED_Think_14B = "HyperCLOVAX_SEED_Think_14B"
+
+
+class ModelLoader(ForgeModel):
+    """HyperCLOVA X model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.HyperCLOVAX_SEED_Think_14B: LLMModelConfig(
+            pretrained_model_name="naver-hyperclovax/HyperCLOVAX-SEED-Think-14B",
+            max_length=256,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.HyperCLOVAX_SEED_Think_14B
+
+    sample_text = "Who are you?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.model = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="HyperCLOVAX-SEED-Think",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        # Lazy import so it binds to the pinned transformers (see module note).
+        from transformers import AutoTokenizer
+
+        tokenizer_kwargs = {}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+        )
+
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        """Load and return the HyperCLOVA X model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The HyperCLOVA X model for causal language modeling.
+        """
+        # Lazy import so it binds to the pinned transformers (see module note).
+        from transformers import AutoModelForCausalLM
+
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+        model.eval()
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the HyperCLOVA X model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+            batch_size: Batch size for the inputs.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        max_length = self._variant_config.max_length
+        conversation = [{"role": "user", "content": self.sample_text}]
+        prompt = self.tokenizer.apply_chat_template(
+            conversation, tokenize=False, add_generation_prompt=True
+        )
+        inputs = self.tokenizer(
+            prompt,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+        return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        """Return mesh shape and axis names for tensor parallel."""
+        if self.config.num_attention_heads % num_devices == 0:
+            mesh_shape = (1, num_devices)
+        elif (
+            self.config.num_attention_heads % (num_devices // 2) == 0
+            and num_devices % 2 == 0
+        ):
+            mesh_shape = (2, num_devices // 2)
+        else:
+            raise ValueError(
+                f"Cannot evenly distribute {self.config.num_attention_heads} heads "
+                f"across {num_devices} devices"
+            )
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+        for layer in model.model.layers:
+            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+
+            shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
+        shard_specs[model.lm_head.weight] = ("model", "batch")
+        return shard_specs
+
+    def load_config(self):
+        """Load and return the configuration for the model variant."""
+        # Lazy import so it binds to the pinned transformers (see module note).
+        from transformers import AutoConfig
+
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.config

--- a/hyperclovax/pytorch/requirements.txt
+++ b/hyperclovax/pytorch/requirements.txt
@@ -1,0 +1,1 @@
+transformers>=5.9.0


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Bringup naver-hyperclovax/HyperCLOVAX-SEED-Think-14B (text causal LM, 14.74B).

### What's changed
Adds a PyTorch `ModelLoader` for HyperCLOVA X SEED Think 14B
(`hyperclovax/pytorch/`) for NLP causal LM inference, including tensor-parallel
mesh/shard specs.
The model gained native transformers support in `transformers >= 5.9.0`
(model_type `hyperclovax`, class `HyperCLOVAXForCausalLM`)


Logs:
[hyperclovax.log](https://github.com/user-attachments/files/29123988/hyperclovax.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
