### PR TITLE
[Infinity] Bring up and shard transformer test

### DIFF
--- a/infinity/pytorch/loader.py
+++ b/infinity/pytorch/loader.py
@@ -122,7 +122,7 @@ class ModelLoader(ForgeModel):
         return self.model
 
     def load_inputs(self, dtype_override=None, batch_size=1, prompt=None):
-        """Return a single forward-pass input dict for the Infinity transformer.
+        """Return positional forward-pass inputs for the Infinity transformer.
 
         Delegates input construction to
         :func:`.src.model_utils.build_forward_inputs`. Targets the
@@ -135,12 +135,16 @@ class ModelLoader(ForgeModel):
             prompt: Optional override prompt; defaults to a fixed string.
 
         Returns:
-            dict: ``{"label_B_or_BLT": (kv_compact, lens, cu_seqlens_k,
-                max_seqlen_k), "x_BLC_wo_prefix": tensor, "scale_schedule": [...]}``.
+            list: Positional ``forward`` arguments in signature order
+                ``[label_B_or_BLT, x_BLC_wo_prefix, scale_schedule]``, where
+                ``label_B_or_BLT`` is ``(kv_compact, lens, cu_seqlens_k,
+                max_seqlen_k)``. A positional sequence (not a dict) is required
+                because the test infra invokes the model as ``model(*inputs)``;
+                unpacking a dict would pass its string keys instead of tensors.
         """
         if self.text_encoder is None:
             raise RuntimeError("load_model() must be called before load_inputs().")
-        return build_forward_inputs(
+        forward_inputs = build_forward_inputs(
             tokenizer=self.tokenizer,
             text_encoder=self.text_encoder,
             vae=self.vae,
@@ -149,3 +153,88 @@ class ModelLoader(ForgeModel):
             prompt=prompt,
             dtype_override=dtype_override,
         )
+        return [
+            forward_inputs["label_B_or_BLT"],
+            forward_inputs["x_BLC_wo_prefix"],
+            forward_inputs["scale_schedule"],
+        ]
+
+    def get_mesh_config(self, num_devices: int):
+        """Mesh config for tensor-parallel sharding of the Infinity transformer.
+
+        Uses the mochi-style 2D mesh ``(1, 8)`` with axis names
+        ``(None, "model")``: the 8-wide ``model`` axis (index 1) carries the
+        tensor parallelism and the size-1 axis is named ``None`` so no partition
+        spec ever references it. ``load_inputs`` uses ``batch_size=1`` so there
+        is no data-parallel axis. An 8-wide ``model`` axis splits the 16
+        attention heads 2-per-device, shrinking the O(L^2) self-attention score
+        tensor from ``[1, 16, L, L]`` to ``[1, 2, L, L]`` -- the buffer that
+        OOM'd when attention was replicated.
+
+        Args:
+            num_devices: Total devices visible to the runtime.
+
+        Returns:
+            tuple: ``(mesh_shape, axis_names)``.
+        """
+        if num_devices == 8:
+            mesh_shape = (1, 8)
+        else:
+            raise ValueError(
+                f"Infinity sharding currently supports 8 devices, got {num_devices}."
+            )
+        return mesh_shape, (None, "model")
+
+    def load_shard_spec(self, model):
+        """Megatron tensor-parallel shard spec for the Infinity transformer.
+
+        Head-parallel attention: each of the (unfused) q/k/v projections is
+        column-parallel (split output heads on ``model``), and the output
+        ``proj`` is row-parallel (split the contraction dim) -- one all-reduce
+        per attention/FFN pair (Megatron-LM, arXiv:1909.08053). The projections
+        are unfused in ``model.py`` (``mat_qkv`` -> ``mat_q/mat_k/mat_v``,
+        ``mat_kv`` -> ``mat_k/mat_v``) precisely so a single partition spec can
+        place matching per-head q/k/v on the same device -- sharding the fused
+        qkv-major weight directly is numerically wrong (PCC ~ -0.18). Mesh is
+        the mochi ``(1, 8)`` / ``(None, "model")``.
+
+        Per-head scale (``scale_mul_1H11``), the concatenated bias buffers,
+        norms, lvl/positional embeddings and the tiny head are left replicated;
+        the partitioner slices them to match the sharded heads.
+
+        Args:
+            model: The Infinity transformer instance.
+
+        Returns:
+            Dict[torch.Tensor, tuple]: parameter -> partition spec.
+        """
+        specs = {}
+        for block in model.unregistered_blocks:
+            # --- self-attention: column-parallel q/k/v, row-parallel proj ---
+            sa = block.sa
+            specs[sa.mat_q.weight] = ("model", None)
+            specs[sa.mat_k.weight] = ("model", None)
+            specs[sa.mat_v.weight] = ("model", None)
+            specs[sa.proj.weight] = (None, "model")  # row: all-reduce
+            if sa.proj.bias is not None:
+                specs[sa.proj.bias] = (None,)
+
+            # --- cross-attention: column-parallel q/k/v, row-parallel proj ---
+            ca = block.ca
+            specs[ca.mat_q.weight] = ("model", None)
+            if ca.mat_q.bias is not None:
+                specs[ca.mat_q.bias] = ("model",)
+            specs[ca.mat_k.weight] = ("model", None)
+            specs[ca.mat_v.weight] = ("model", None)
+            specs[ca.proj.weight] = (None, "model")  # row: all-reduce
+            if ca.proj.bias is not None:
+                specs[ca.proj.bias] = (None,)
+
+            # --- FFN (column fc1 -> row fc2) ---
+            specs[block.ffn.fc1.weight] = ("model", None)
+            if block.ffn.fc1.bias is not None:
+                specs[block.ffn.fc1.bias] = ("model",)
+            specs[block.ffn.fc2.weight] = (None, "model")
+            if block.ffn.fc2.bias is not None:
+                specs[block.ffn.fc2.bias] = (None,)
+        return specs

--- a/infinity/pytorch/src/model.py
+++ b/infinity/pytorch/src/model.py
@@ -2238,7 +2238,15 @@ class SelfAttention(nn.Module):
             self.max_scale_mul = torch.log(torch.tensor(100)).item()
         else:
             self.scale = 1 / math.sqrt(self.head_dim) / self.tau
-        self.mat_qkv = nn.Linear(embed_dim, embed_dim * 3, bias=False)
+        # Q/K/V kept as three separate projections (not a single fused
+        # ``mat_qkv``) so they can be sharded head-parallel for tensor
+        # parallelism. A fused qkv-major weight, sharded column-parallel, splits
+        # q/k/v of different heads onto different devices and produces incorrect
+        # attention (PCC ~ -0.18). The checkpoint's fused ``mat_qkv.weight`` is
+        # split into these at load time (``_unfuse_fused_projections``).
+        self.mat_q = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.mat_k = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.mat_v = nn.Linear(embed_dim, embed_dim, bias=False)
         self.q_bias = nn.Parameter(torch.zeros(embed_dim))
         self.v_bias = nn.Parameter(torch.zeros(embed_dim))
         self.register_buffer("zero_k_bias", torch.zeros(embed_dim))
@@ -2267,16 +2275,24 @@ class SelfAttention(nn.Module):
         scale_ind=0,
     ):
         B, L, C = x.shape
-        qkv = F.linear(
-            x,
-            self.mat_qkv.weight,
-            torch.cat((self.q_bias, self.zero_k_bias, self.v_bias)),
-        ).view(B, L, 3, self.num_heads, self.head_dim)
+        # Separate q/k/v projections (unfused). Each is [B, L, num_heads,
+        # head_dim], equivalent to the original fused
+        # ``view(B, L, 3, num_heads, head_dim)`` then unbind(dim=2).
+        q = F.linear(x, self.mat_q.weight, self.q_bias).view(
+            B, L, self.num_heads, self.head_dim
+        )
+        k = F.linear(x, self.mat_k.weight, self.zero_k_bias).view(
+            B, L, self.num_heads, self.head_dim
+        )
+        v = F.linear(x, self.mat_v.weight, self.v_bias).view(
+            B, L, self.num_heads, self.head_dim
+        )
         if self.using_flash:
-            q, k, v = qkv.unbind(dim=2)
             L_dim = 1
         else:
-            q, k, v = qkv.permute(2, 0, 3, 1, 4).unbind(dim=0)
+            q = q.permute(0, 2, 1, 3)
+            k = k.permute(0, 2, 1, 3)
+            v = v.permute(0, 2, 1, 3)
             L_dim = 2
         if self.cos_attn:
             scale_mul = self.scale_mul_1H11.clamp_max(self.max_scale_mul).exp()
@@ -2359,7 +2375,10 @@ class CrossAttention(nn.Module):
             self.mat_q = nn.Parameter(q)
         else:
             self.mat_q = nn.Linear(embed_dim, embed_dim, bias=True)
-        self.mat_kv = nn.Linear(kv_dim, embed_dim * 2, bias=False)
+        # K/V kept as separate projections (unfused) for head-parallel sharding;
+        # the checkpoint's fused ``mat_kv.weight`` is split at load time.
+        self.mat_k = nn.Linear(kv_dim, embed_dim, bias=False)
+        self.mat_v = nn.Linear(kv_dim, embed_dim, bias=False)
         self.v_bias = nn.Parameter(torch.zeros(embed_dim))
         self.register_buffer("zero_k_bias", torch.zeros(embed_dim))
         self.proj = nn.Linear(embed_dim, embed_dim)
@@ -2368,9 +2387,15 @@ class CrossAttention(nn.Module):
     def forward(self, q, ca_kv):
         kv_compact, cu_seqlens_k, max_seqlen_k = ca_kv
         N = kv_compact.shape[0]
-        kv_compact = F.linear(
-            kv_compact, self.mat_kv.weight, torch.cat((self.zero_k_bias, self.v_bias))
-        ).view(N, 2, self.num_heads, self.head_dim)
+        # Separate k/v projections (unfused), stacked to [N, 2, num_heads,
+        # head_dim] -- equivalent to the original fused ``mat_kv`` + view.
+        k = F.linear(kv_compact, self.mat_k.weight, self.zero_k_bias).view(
+            N, self.num_heads, self.head_dim
+        )
+        v = F.linear(kv_compact, self.mat_v.weight, self.v_bias).view(
+            N, self.num_heads, self.head_dim
+        )
+        kv_compact = torch.stack((k, v), dim=1)
         if not self.for_attn_pool:
             B, Lq = q.shape[:2]
             q_compact = self.mat_q(q).view(-1, self.num_heads, self.head_dim)
@@ -3012,10 +3037,19 @@ class Infinity(nn.Module):
         patch_t, patch_h, patch_w = scale_schedule[scale_ind]
         t_mul_h_mul_w = patch_t * patch_h * patch_w
         assert t_mul_h_mul_w + need_to_pad == seq_len
-        feature[:, :t_mul_h_mul_w] += self.lvl_embed(
-            scale_ind
-            * torch.ones((bs, t_mul_h_mul_w), dtype=torch.int).to(feature.device)
-        )
+        # ``lvl_embed`` is looked up with the constant index ``scale_ind`` at
+        # every position, which lowers to a dynamic gather plus an in-place
+        # sliced scatter -- a pattern that segfaults the tt-mlir compiler.
+        # Since the index is a constant, read the embedding row directly and add
+        # it via broadcasting (out-of-place, no gather, no scatter).
+        lvl_emb = self.lvl_embed.weight[scale_ind].to(feature.dtype)  # (C,)
+        if need_to_pad:
+            feature = torch.cat(
+                [feature[:, :t_mul_h_mul_w] + lvl_emb, feature[:, t_mul_h_mul_w:]],
+                dim=1,
+            )
+        else:
+            feature = feature + lvl_emb
         return feature
 
     def add_lvl_embeding_for_x_BLC(self, x_BLC, scale_schedule, need_to_pad=0):
@@ -3039,7 +3073,10 @@ class Infinity(nn.Module):
                 label_B_or_BLT=label_B_or_BLT, scale_schedule=scale_schedule, **kwargs
             )
 
-        _model_dtype = next(self.parameters()).dtype
+        # Read dtype from a concrete parameter rather than ``next(self.parameters())``:
+        # TorchDynamo cannot trace the ``parameters()`` generator here and raises an
+        # InternalTorchDynamoError ("cannot access free variable 'named_children'").
+        _model_dtype = self.pos_start.dtype
         x_BLC_wo_prefix = x_BLC_wo_prefix.to(_model_dtype)
         B = x_BLC_wo_prefix.shape[0]
         with torch.amp.autocast("cuda", enabled=False):
@@ -3505,6 +3542,33 @@ def load_visual_tokenizer(args):
     ).to(device)
 
 
+def _unfuse_fused_projections(state_dict):
+    """Split fused attention weights for the unfused SelfAttention/CrossAttention.
+
+    The official checkpoint stores fused projections; the modules now use
+    separate ones (for head-parallel sharding). Split along the output dim,
+    preserving the original q/k/v (qkv-major) and k/v (kv-major) ordering:
+      ``*.mat_qkv.weight`` [3C, C] -> ``*.mat_q/mat_k/mat_v.weight`` [C, C]
+      ``*.mat_kv.weight``  [2C, C] -> ``*.mat_k/mat_v.weight``       [C, C]
+    """
+    new_sd = {}
+    for key, w in state_dict.items():
+        if key.endswith("mat_qkv.weight"):
+            prefix = key[: -len("mat_qkv.weight")]
+            q, k, v = torch.chunk(w, 3, dim=0)
+            new_sd[prefix + "mat_q.weight"] = q
+            new_sd[prefix + "mat_k.weight"] = k
+            new_sd[prefix + "mat_v.weight"] = v
+        elif key.endswith("mat_kv.weight"):
+            prefix = key[: -len("mat_kv.weight")]
+            k, v = torch.chunk(w, 2, dim=0)
+            new_sd[prefix + "mat_k.weight"] = k
+            new_sd[prefix + "mat_v.weight"] = v
+        else:
+            new_sd[key] = w
+    return new_sd
+
+
 def load_infinity(
     rope2d_each_sa_layer,
     rope2d_normalized_by_hw,
@@ -3562,6 +3626,7 @@ def load_infinity(
             torch.cuda.empty_cache()
         if checkpoint_type == "torch":
             state_dict = torch.load(model_path, map_location=device)
+            state_dict = _unfuse_fused_projections(state_dict)
             infinity_test.load_state_dict(state_dict)
     return infinity_test
 


### PR DESCRIPTION
### Ticket

- [#5019](https://github.com/tenstorrent/tt-xla/issues/5019)

### Problem description

tests/torch/models/infinity/test_transformer.py::test_transformer_sharded fails had the following compilation issues.

- load_inputs returned a dict, but the test infra passes inputs positionally and calls model(*args) — unpacking a dict yields its string keys, so the model received "x_BLC_wo_prefix" (a str) and crashed with 'str' object has no attribute 'to'.

- forward read its dtype via next(self.parameters()). TorchDynamo cannot trace the parameters() generator and raised `NameError: cannot access free variable 'named_children'`

### What's changed

- forward crashed at x_BLC_wo_prefix.to(...) because the input arrived as the string "x_BLC_wo_prefix" — the test infra passes inputs positionally and calls model(*args), and load_inputs returned a dict, so *-unpacking yielded its keys (strings) instead of its values. This was fixed by having loader.load_inputs return a positional list [label_B_or_BLT, x_BLC_wo_prefix, scale_schedule] in forward's signature order, so the tensors arrive as the actual positional arguments.

- Dynamo tracing of parameters(): Fix 1 - forward read its dtype via next(self.parameters()), which TorchDynamo cannot trace — the parameters() generator triggers a known bug (tt-xla #5019) that raises NameError: cannot access free variable 'named_children' during TT compilation. This was fixed by reading the dtype from a concrete parameter, self.pos_start.dtype, instead of the generator — a plain attribute access that Dynamo traces cleanly and that yields the identical value.

-  Out of Memory on multi-device: Fix 3 — With attention replicated across chips, the O(L²) self-attention score tensor [1, 16, 10624, 10624] ≈ 3.6 GB was allocated in full on every device and triggered TT_FATAL: Out of Memory. This was fixed by sharding attention head-parallel so each device holds only its heads' scores ([1, 2, L, L] ≈ 451 MB), which in turn required the projections to be shardable.

- Fused QKV/KV are not shardable head-parallel: Fix 4 - The self-attention mat_qkv (fused Linear(C, 3C), qkv-major) and cross-attention mat_kv (fused Linear(kv, 2C), kv-major) cannot be split head-parallel by a partition spec — a contiguous column split places q/k/v of different heads on different devices, so sharding the fused weights directly ran but computed incorrect attention (PCC = −0.18). This was fixed by unfusing the projections so each can be column-sharded by heads: SelfAttention.mat_qkv → mat_q/mat_k/mat_v (forward computes q/k/v independently, same output layout as the old fused view(...,3,H,d)), and CrossAttention.mat_kv → mat_k/mat_v (forward stacks them to [N, 2, H, d], identical to the old fused path). A new _unfuse_fused_projections() splits the checkpoint's fused weights at load time via chunk(3)/chunk(2), preserving qkv-/kv-major row order — pure slicing, numerically identical on a single device (matmul rounding only, far below bf16 noise).

- `get_mesh_config` returns a (1, 8) mesh with axis names (None, "model"), where the 8-wide model axis carries the tensor parallelism (the size-1 axis is named None so no spec references it); and load_shard_spec applies per-block Megatron tensor parallelism — column-parallel ("model", None) for q/k/v (self- and cross-attn) and FFN fc1, row-parallel (None, "model") for the attention/FFN output projections (one all-reduce per pair), with column-side biases sharded and row-side/concatenated/scaled biases, norms, embeddings and the head left replicated.

Final result is that model runs on 8 devices with no OOM and with a pcc of 0.98.
The cpu results remains the same before and after these changes, attched logs for the cpu results as well.

### Logs
[infinity_cpu_orig.log](https://github.com/user-attachments/files/29190338/infinity_cpu_orig.log)
[infinity_cpu_patched.log](https://github.com/user-attachments/files/29190340/infinity_cpu_patched.log)
[infinity_final.zip](https://github.com/user-attachments/files/29190374/infinity_final.zip)

Final Results from cpu original run Vs cpu run with patch:
<img width="2048" height="1024" alt="everest_infinity_side_by_side" src="https://github.com/user-attachments/assets/f51485ef-dda5-44d8-ab93-396e8aba500b" />




