### PR TITLE
[HiDream-I1] Patch moe_infer to drop hardcoded device and numpy conversion (#5290)

### DIFF
--- a/hidream_i1/pytorch/src/model_utils.py
+++ b/hidream_i1/pytorch/src/model_utils.py
@@ -109,9 +109,50 @@ def load_text_encoder_4(pretrained_model_name: str, dtype: torch.dtype):
     ).eval()
 
 
+def _patch_hidream_moe_infer() -> None:
+    """Drop the `.cpu().numpy()` round-trip in MOEFeedForwardSwiGLU.moe_infer —
+    it forces a host sync + numpy array that torch.compile can't trace
+    ("'ndarray' object has no attribute 'dim'"). Keeping bincount().cumsum(0) as
+    on-device torch ops makes it traceable; everything else is unchanged.
+
+    See https://github.com/tenstorrent/tt-xla/issues/5290
+    """
+    from diffusers.models.transformers.transformer_hidream_image import (
+        MOEFeedForwardSwiGLU,
+    )
+
+    @torch.no_grad()
+    def moe_infer(self, x, flat_expert_indices, flat_expert_weights):
+        expert_cache = torch.zeros_like(x)
+        idxs = flat_expert_indices.argsort()
+        tokens_per_expert = flat_expert_indices.bincount().cumsum(0)
+        token_idxs = idxs // self.num_activated_experts
+        for i, end_idx in enumerate(tokens_per_expert):
+            start_idx = 0 if i == 0 else tokens_per_expert[i - 1]
+            if start_idx == end_idx:
+                continue
+            expert = self.experts[i]
+            exp_token_idx = token_idxs[start_idx:end_idx]
+            expert_tokens = x[exp_token_idx]
+            expert_out = expert(expert_tokens)
+            expert_out.mul_(flat_expert_weights[idxs[start_idx:end_idx]])
+            expert_cache = expert_cache.to(expert_out.dtype)
+            expert_cache.scatter_reduce_(
+                0,
+                exp_token_idx.view(-1, 1).repeat(1, x.shape[-1]),
+                expert_out,
+                reduce="sum",
+            )
+        return expert_cache
+
+    MOEFeedForwardSwiGLU.moe_infer = moe_infer
+
+
 def load_transformer(pretrained_model_name: str, dtype: torch.dtype):
     """Load HiDreamImageTransformer2DModel from the transformer subfolder."""
     from diffusers import HiDreamImageTransformer2DModel
+
+    _patch_hidream_moe_infer()
 
     return HiDreamImageTransformer2DModel.from_pretrained(
         pretrained_model_name,


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5290

### Problem description

- HiDream-I1 transformer fails to compile under torch.compile. `MOEFeedForwardSwiGLU.moe_infer` runs `flat_expert_indices.bincount().cpu().numpy().cumsum(0)` — the `.numpy()` produces a numpy array that Dynamo can't trace: `torch._dynamo.exc.TorchRuntimeError: ... got AttributeError("'ndarray' object has no attribute 'dim'")` and there is hardcoded device conversion too.

### What's changed

- Monkey-patched `MOEFeedForwardSwiGLU.moe_infer` in the HiDream-I1 loader (`third_party/tt_forge_models/hidream_i1/pytorch/src/model_utils.py`) to drop the hardcoded `.cpu()` and `.numpy()` conversion — `bincount().cumsum(0)` now stays as on-device torch ops. Logic otherwise unchanged; patch applied in `load_transformer()`.
- post this change model fails with OOM

### Checklist

- [x] verify the changes through local testing

### Logs

- [jun19_hidream_transformer_after_fix.log](https://github.com/user-attachments/files/29139573/jun19_hidream_transformer_after_fix.log)
- [jun19_hidream_transformer_before_fix.log](https://github.com/user-attachments/files/29139575/jun19_hidream_transformer_before_fix.log)
