### PR TITLE
Bringup Orion-14B-Chat model

### DIFF
--- a/orion/pytorch/__init__.py
+++ b/orion/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Orion PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/orion/pytorch/loader.py
+++ b/orion/pytorch/loader.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Orion-14B causal LM model loader implementation.
+"""
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+from typing import Optional
+
+from ...base import ForgeModel
+from ...config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Orion model variants for causal language modeling."""
+
+    ORION_14B_CHAT = "14B_Chat"
+
+
+class ModelLoader(ForgeModel):
+    """Orion model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.ORION_14B_CHAT: LLMModelConfig(
+            pretrained_model_name="OrionStarAI/Orion-14B-Chat",
+            max_length=256,
+        )
+    }
+
+    DEFAULT_VARIANT = ModelVariant.ORION_14B_CHAT
+
+    sample_text = "Who are you?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.model = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="Orion-14B",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        tokenizer_kwargs = {"trust_remote_code": True}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+        )
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        """Load and return the Orion-14B model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use bfloat16.
+
+        Returns:
+            torch.nn.Module: The Orion-14B model for causal language modeling.
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        model_kwargs = {"trust_remote_code": True}
+        model_kwargs["torch_dtype"] = (
+            dtype_override if dtype_override is not None else torch.bfloat16
+        )
+        model_kwargs |= kwargs
+
+        config = AutoConfig.from_pretrained(
+            pretrained_model_name, trust_remote_code=True
+        )
+        config.rope_scaling = None
+        config.use_cache = False
+        model_kwargs["config"] = config
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+        model.config.use_cache = False
+        model.eval()
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the Orion-14B model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+            batch_size: Batch size for the inputs.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        max_length = self._variant_config.max_length
+        inputs = self.tokenizer(
+            self.sample_text,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+        return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        """Return mesh shape and axis names for tensor parallel."""
+        if self.config.num_attention_heads % num_devices == 0:
+            mesh_shape = (1, num_devices)
+        elif (
+            self.config.num_attention_heads % (num_devices // 2) == 0
+            and num_devices % 2 == 0
+        ):
+            mesh_shape = (2, num_devices // 2)
+        else:
+            raise ValueError(
+                f"Cannot evenly distribute {self.config.num_attention_heads} heads "
+                f"across {num_devices} devices"
+            )
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        """Standard Llama-style column/row tensor-parallel (MHA, no bias)."""
+        shard_specs = {}
+        for layer in model.model.layers:
+            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+
+            shard_specs[layer.self_attn.q_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.k_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.v_proj.weight] = ("model", "batch")
+            shard_specs[layer.self_attn.o_proj.weight] = ("batch", "model")
+        shard_specs[model.lm_head.weight] = ("model", "batch")
+        return shard_specs
+
+    def load_config(self):
+        """Load and return the configuration for the model variant."""
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name, trust_remote_code=True
+        )
+        return self.config

--- a/orion/pytorch/requirements.txt
+++ b/orion/pytorch/requirements.txt
@@ -1,0 +1,1 @@
+transformers==4.57.1

--- a/orion/pytorch/requirements.txt
+++ b/orion/pytorch/requirements.txt
@@ -1,1 +1,4 @@
+# Orion's trust_remote_code modeling file uses transformers APIs removed in
+# 5.5.1 (repo default), e.g. is_flash_attn_2_available and _tied_weights_keys.
+# 4.57.1 is the last release it imports/runs cleanly against.
 transformers==4.57.1


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Bringup Orion-14B-Chat model.

### What's changed
Added Orion-14B-Chat tensor-parallel loader.

### Note on the transformers pin
Orion uses `trust_remote_code`; its modeling file relies on transformers APIs removed in the repo default 5.5.1 (`is_flash_attn_2_available`, `_tied_weights_keys`). 4.57.1 is the last release it runs against. Proper fix is upstream; pin is installed only for this model and rolled back after.

### Logs
[orion.log](https://github.com/user-attachments/files/29173378/orion.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
