### PR TITLE
Bringup InternLM2-chat-20b model

### DIFF
--- a/internlm2/pytorch/__init__.py
+++ b/internlm2/pytorch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+InternLM2 PyTorch model implementation for Tenstorrent projects.
+"""
+from .loader import ModelLoader, ModelVariant

--- a/internlm2/pytorch/loader.py
+++ b/internlm2/pytorch/loader.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+InternLM2 chat causal LM model loader implementation.
+"""
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+from typing import Optional
+
+from ...base import ForgeModel
+from ...config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available InternLM2 model variants for causal language modeling."""
+
+    INTERNLM2_CHAT_20B = "internlm2-chat-20b"
+
+
+class ModelLoader(ForgeModel):
+    """InternLM2 model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.INTERNLM2_CHAT_20B: LLMModelConfig(
+            pretrained_model_name="internlm/internlm2-chat-20b",
+            max_length=256,
+        )
+    }
+
+    DEFAULT_VARIANT = ModelVariant.INTERNLM2_CHAT_20B
+
+    sample_text = "Who are you?"
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.model = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="InternLM2",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self, dtype_override=None):
+        """Load tokenizer for the current variant.
+        Args:
+            dtype_override: Optional torch.dtype to override the tokenizer's default dtype.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        from transformers import AutoTokenizer
+
+        tokenizer_kwargs = {"trust_remote_code": True, "use_fast": False}
+        if dtype_override is not None:
+            tokenizer_kwargs["torch_dtype"] = dtype_override
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+        )
+
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        """Load and return the InternLM2 model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The InternLM2 model for causal language modeling.
+        """
+        from transformers import AutoModelForCausalLM
+
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        model_kwargs = {"trust_remote_code": True}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+        model.eval()
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the InternLM2 model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+            batch_size: Batch size for the inputs.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        if self.tokenizer is None:
+            self._load_tokenizer(dtype_override=dtype_override)
+
+        max_length = self._variant_config.max_length
+        conversation = [{"role": "user", "content": self.sample_text}]
+        prompt = self.tokenizer.apply_chat_template(
+            conversation, tokenize=False, add_generation_prompt=True
+        )
+        inputs = self.tokenizer(
+            prompt,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+        return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        """Return mesh shape and axis names for tensor parallel."""
+        if self.config.num_attention_heads % num_devices == 0:
+            mesh_shape = (1, num_devices)
+        elif (
+            self.config.num_attention_heads % (num_devices // 2) == 0
+            and num_devices % 2 == 0
+        ):
+            mesh_shape = (2, num_devices // 2)
+        else:
+            raise ValueError(
+                f"Cannot evenly distribute {self.config.num_attention_heads} heads "
+                f"across {num_devices} devices"
+            )
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+        for layer in model.model.layers:
+            shard_specs[layer.feed_forward.w1.weight] = ("model", "batch")
+            shard_specs[layer.feed_forward.w3.weight] = ("model", "batch")
+            shard_specs[layer.feed_forward.w2.weight] = ("batch", "model")
+
+            shard_specs[layer.attention.wqkv.weight] = ("model", "batch")
+            shard_specs[layer.attention.wo.weight] = ("batch", "model")
+        shard_specs[model.output.weight] = ("model", "batch")
+        return shard_specs
+
+    def load_config(self):
+        """Load and return the configuration for the model variant."""
+        from transformers import AutoConfig
+
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name, trust_remote_code=True
+        )
+        return self.config

--- a/internlm2/pytorch/loader.py
+++ b/internlm2/pytorch/loader.py
@@ -6,8 +6,10 @@ InternLM2 chat causal LM model loader implementation.
 """
 
 import torch
-from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
 from typing import Optional
+
+# transformers is imported inside the methods so it binds to the pinned 4.46.3
+# after RequirementsManager swaps it in, not the repo default at collection time.
 
 from ...base import ForgeModel
 from ...config import (

--- a/internlm2/pytorch/requirements.txt
+++ b/internlm2/pytorch/requirements.txt
@@ -1,0 +1,1 @@
+transformers==4.46.3

--- a/internlm2/pytorch/requirements.txt
+++ b/internlm2/pytorch/requirements.txt
@@ -1,1 +1,4 @@
+# InternLM2's trust_remote_code modeling/tokenizer code uses transformers APIs
+# removed in 5.5.1 (repo default), e.g. from_legacy_cache and the tokenizer's
+# convert_to_native_format path. 4.46.3 is the version it runs cleanly against.
 transformers==4.46.3


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Bringup InternLM2-chat-20b model

### What's changed
Add InternLM2-chat-20b tensor-parallel loader

### Note on the transformers pin
InternLM2's trust_remote_code modeling/tokenizer code uses transformers APIs removed in 5.5.1 (repo default), e.g. from_legacy_cache and the tokenizer's convert_to_native_format path. 4.46.3 is the version it runs cleanly against.

### Logs
[internlm2.log](https://github.com/user-attachments/files/29174969/internlm2.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
