### PR TITLE
[lumina_image] Use single-axis Megatron for transformer sharding

### DIFF
--- a/lumina_image/pytorch/src/model_utils.py
+++ b/lumina_image/pytorch/src/model_utils.py
@@ -239,45 +239,63 @@ def shard_text_encoder_specs(encoder) -> dict:
 def _shard_lumina_block(block, specs: dict, has_adaln: bool) -> None:
     """Add shard specs for a single Lumina2TransformerBlock in-place.
 
-    has_adaln distinguishes blocks that include the adaptive-norm path
-    (noise_refiner / layers) from context_refiner blocks where norm1 is a
-    plain RMSNorm without a learned modulation linear.
+    Single-axis Megatron tensor parallelism on the "model" axis only. Each
+    block is two column->row pairs (attention Q/K/V -> O, FFN gate/up -> down),
+    so it emits exactly two all-reduces and never a reshard. The block's input
+    and output stay replicated (post-all-reduce), which lets the next block's
+    column-parallel ops consume them directly.
+
+    We deliberately do NOT shard on the "batch" axis. The earlier 2-D scheme
+    (("model","batch") column, ("batch","model") row) alternated axis order, so
+    a row output feeding the next column op had to swap its sharded dim from the
+    "model" axis to the "batch" axis -- an axis-swap reshard that Shardy lowers
+    to sdy.collective_permute, which tt-mlir cannot lower yet (tt-mlir #3370).
+    Single-axis "model" keeps every contraction dim on the same axis, so only
+    all-reduce is emitted. Mirrors shard_vae_specs and examples/pytorch/llama.py.
+
+    has_adaln only documents which blocks carry the AdaLN modulation linear
+    (noise_refiner / layers); that linear is left replicated (see below), so the
+    flag no longer changes the specs.
     """
     attn = block.attn
-    specs[attn.to_q.weight] = ("model", "batch")
-    specs[attn.to_k.weight] = ("model", "batch")
-    specs[attn.to_v.weight] = ("model", "batch")
-    specs[attn.to_out[0].weight] = ("batch", "model")
+    # Column-parallel: shard output (head) dim. GQA-safe (24 q-heads, 8 kv-heads
+    # both divide by the model-axis size); to_q/k/v take a replicated input.
+    specs[attn.to_q.weight] = ("model", None)
+    specs[attn.to_k.weight] = ("model", None)
+    specs[attn.to_v.weight] = ("model", None)
+    # Row-parallel: shard contraction dim -> one all-reduce, replicated output.
+    specs[attn.to_out[0].weight] = (None, "model")
 
     ff = block.feed_forward
-    specs[ff.linear_1.weight] = ("model", "batch")
-    specs[ff.linear_3.weight] = ("model", "batch")
-    specs[ff.linear_2.weight] = ("batch", "model")
+    # SwiGLU column->row pair: gate/up column-parallel, down row-parallel.
+    specs[ff.linear_1.weight] = ("model", None)
+    specs[ff.linear_3.weight] = ("model", None)
+    specs[ff.linear_2.weight] = (None, "model")
 
-    if has_adaln:
-        specs[block.norm1.linear.weight] = ("model", "batch")
-        specs[block.norm1.linear.bias] = ("model",)
+    # block.norm1.linear (AdaLN modulation) is intentionally left replicated:
+    # its chunked scale/gate vectors multiply a replicated normalized activation,
+    # so sharding it would force a reshard. Likewise all RMSNorm weights
+    # (norm1.norm, norm2, ffn_norm1, ffn_norm2, norm_q, norm_k) stay replicated
+    # because they act on replicated activations / the unsharded head_dim.
 
 
 def shard_transformer_specs(transformer) -> dict:
     """Shard specs for Lumina2Transformer2DModel.
 
-    Mesh axes: ("batch", "model")
-    Column-parallel (Q, K, V, FFN up/gate): ("model", "batch")
-    Row-parallel   (O, FFN down):           ("batch", "model")
-    """
-    specs = {
-        transformer.x_embedder.weight: ("model", "batch"),
-        transformer.x_embedder.bias: ("model",),
-    }
+    Mesh axes: ("batch", "model"). Strategy: single-axis Megatron tensor
+    parallelism on "model" for the 30 transformer blocks; everything else
+    replicated.
+      Column-parallel (Q, K, V, FFN up/gate): ("model", None)
+      Row-parallel    (O, FFN down):          (None, "model")
 
-    tce = transformer.time_caption_embed
-    specs[tce.timestep_embedder.linear_1.weight] = ("model", "batch")
-    specs[tce.timestep_embedder.linear_1.bias] = ("model",)
-    specs[tce.timestep_embedder.linear_2.weight] = ("batch", "model")
-    specs[tce.timestep_embedder.linear_2.bias] = ("batch",)
-    specs[tce.caption_embedder[1].weight] = ("model", "batch")
-    specs[tce.caption_embedder[1].bias] = ("model",)
+    Embedders and the output projection (x_embedder, time_caption_embed,
+    norm_out) are replicated: they sit at graph boundaries, are tiny relative to
+    the blocks, and replicating them keeps block inputs/outputs replicated so no
+    boundary reshard or final all-gather is needed. CCL budget: 60 all-reduces
+    (2 per block x 30), 0 collective_permute, 0 all-gather. See
+    sharding_analysis.md.
+    """
+    specs: dict = {}
 
     for block in transformer.noise_refiner:
         _shard_lumina_block(block, specs, has_adaln=True)
@@ -285,11 +303,6 @@ def shard_transformer_specs(transformer) -> dict:
         _shard_lumina_block(block, specs, has_adaln=False)
     for block in transformer.layers:
         _shard_lumina_block(block, specs, has_adaln=True)
-
-    specs[transformer.norm_out.linear_1.weight] = ("model", "batch")
-    specs[transformer.norm_out.linear_1.bias] = ("model",)
-    specs[transformer.norm_out.linear_2.weight] = ("batch", "model")
-    specs[transformer.norm_out.linear_2.bias] = ("batch",)
 
     return specs
 


### PR DESCRIPTION
### Ticket


### Problem description

tests/torch/models/lumina_image/test_transformer.py::test_transformer_sharded fails with:

`loc("slice.4008"): error: 'sdy.collective_permute' op requires the same type for all operands and results`

### What's changed

- The strategy was designed using the `sharding-model-analysis skill` the model architecture was mapped from the config and diffusers source, the mesh was fixed at (2,4)=8 devices, and the collective for each candidate sharding pattern was looked up in the skill's CCL cheatsheet before any code was touched. 

- Attention and feed-forward Megatron pairs (fixes the 264 CollectivePermuteOp errors). These used a 2-D scheme with alternating axis order: column-parallel ("model","batch") for to_q/to_k/to_v and feed_forward.linear_1/linear_3, row-parallel ("batch","model") for to_out[0] and feed_forward.linear_2. Because the order flips between the two sides, a row-parallel output feeding the next column-parallel op had to move the same logical dim from the "model" axis to the "batch" axis. That axis-swap reshard is materialized by Shardy as sdy.collective_permute, which cannot be lowered by tt-mlir. Changed to single-axis Megatron on "model": column-parallel ("model", None) and row-parallel (None, "model"), so every contraction dim stays on one axis and only an all-reduce is emitted per pair. GQA is preserved, as the 24 query heads and 8 kv heads are both divisible by the model-axis size. Applied generically across all 30 blocks (noise_refiner, context_refiner, layers).

- AdaLN modulation linear norm1.linear (fixes slice.4008). Its output is the concatenated modulation vector chunked into scale/gate slices that multiply a replicated normalized activation. Sharding Cout on "model" made every sliced chunk inherit "model", conflicting with the replicated activation it modulates and forcing a reshard. The right move is to replicate the modulation: norm1.linear is removed from the spec (left replicated), so the chunks match the activation with no collective. This is applied generically, so it covers norm1.linear across all modulation blocks.

- Boundary embedders and output projection. x_embedder, time_caption_embed (timestep_embedder, caption_embedder) and norm_out (linear_1/linear_2) were sharded with the same alternating 2-D pattern. They sit at graph boundaries and are tiny relative to the blocks, so they are left replicated (removed from the spec); this keeps block inputs/outputs replicated and avoids any boundary reshard or final all-gather.

The "batch" axis is intentionally left unused for weights; the model-sharded compute is replicated across it (batch=1 at inference).

With these changes the sharded Lumina Image transformer test now compiles and runs end-to-end on 8 devices.

### Logs
[lumina_transformer_jun24_before_fix.log](https://github.com/user-attachments/files/29287225/lumina_transformer_jun24_before_fix.log)
[lumina_transformer_jun24_after_fix.log](https://github.com/user-attachments/files/29287232/lumina_transformer_jun24_after_fix.log)
