### PR TITLE
[diffusiongemma] Replicate attention in TP shard spec

### DIFF
--- a/diffusiongemma/pytorch/loader.py
+++ b/diffusiongemma/pytorch/loader.py
@@ -114,24 +114,19 @@ class ModelLoader(ForgeModel):
         return list(base.encoder.language_model.layers) + list(base.decoder.layers)
 
     def get_mesh_config(self, num_devices: int):
-        """((1, num_devices), ("batch", "model")); model axis carries query heads
-        and the expert axis, so both must divide it (KV is replicated)."""
+        """((1, num_devices), ("batch", "model")); attention is replicated, so
+        only the expert axis rides the model axis and must divide it."""
         mesh_shape = (1, num_devices)
         text_cfg = getattr(self.config, "text_config", self.config)
-        assert text_cfg.num_attention_heads % mesh_shape[1] == 0
         assert text_cfg.num_experts % mesh_shape[1] == 0
         return mesh_shape, ("batch", "model")
 
     def load_shard_spec(self, model):
-        """Megatron TP (q col / o row, dense MLP col->row) + expert-parallel MoE
-        (3D expert tensors sharded on the expert axis). K/V replicated: the
-        full-attention layers carry only 2 global KV heads (unsharddable)."""
+        """Shard the dense MLP (col->row) and expert-parallel MoE. Attention is
+        replicated: the global layers' 2 KV heads can't shard the model axis,
+        and head-sharding Q crashes the repeat_kv reshard."""
         shard_specs = {}
         for layer in self._text_layers(model):
-            attn = layer.self_attn
-            shard_specs[attn.q_proj.weight] = ("model", None)
-            shard_specs[attn.o_proj.weight] = (None, "model")
-
             shard_specs[layer.mlp.gate_proj.weight] = ("model", None)
             shard_specs[layer.mlp.up_proj.weight] = ("model", None)
             shard_specs[layer.mlp.down_proj.weight] = (None, "model")


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-mlir/issues/8861

### Problem description
`diffusiongemma-26B-A4B-it` fails to compile under 8-way tensor parallelism. Its global-attention layers are GQA with only 2 KV heads (`n_rep=8`), which can't shard across 8 devices. Head-sharding the query heads then forces Shardy to reshard the `repeat_kv` broadcast at `Q·Kᵀ`, lowering to an `sdy.all_slice` on an axis already bound by the parent `manual_computation` . see [#8861](https://github.com/tenstorrent/tt-mlir/issues/8861)

### What's changed
Dropped the `q_proj`/`o_proj` sharding from the loader shard spec so **attention is now fully replicated** (MLP and MoE expert sharding unchanged). With no head-sharding in attention there is no replicated→sharded reshard, so the illegal `all_slice` is avoided and the model compiles past the attention failure. 

### Checklist
- [x] Verify the changes through local testing in WH

### Logs

[jun25_diffgemma4_before_fix.log.zip](https://github.com/user-attachments/files/29342723/jun25_diffgemma4_org1.log.zip)
[jun25_diffgemma4_after_fix.log.zip](https://github.com/user-attachments/files/29342804/jun25_diffgemma4_after_fix.log.zip)

