### PR TITLE
Fix MoE sharding for GLM 4.7 and Deepseek v3.1

### DIFF
--- a/deepseek/deepseek_v3_1/pytorch/loader.py
+++ b/deepseek/deepseek_v3_1/pytorch/loader.py
@@ -215,24 +215,24 @@ class ModelLoader(ForgeModel):
                 inner = mlp.mlp if hasattr(mlp, "mlp") else mlp
                 shard_specs[inner.router.gate.weight] = (None, "model")
                 shard_specs[inner.experts.gate_proj] = (
-                    ("model", "batch"),
+                    ("batch", "model"),
                     None,
                     None,
                 )
                 shard_specs[inner.experts.up_proj] = (
-                    ("model", "batch"),
+                    ("batch", "model"),
                     None,
                     None,
                 )
                 shard_specs[inner.experts.down_proj] = (
-                    ("model", "batch"),
+                    ("batch", "model"),
                     None,
                     None,
                 )
                 for bias_name in ("gate_proj_bias", "up_proj_bias", "down_proj_bias"):
                     b = getattr(inner.experts, bias_name, None)
                     if b is not None:
-                        shard_specs[b] = (("model", "batch"), None)
+                        shard_specs[b] = (("batch", "model"), None)
 
                 shared = getattr(mlp, "shared_experts", None)
                 if shared is not None:

--- a/glm/causal_lm/pytorch/loader.py
+++ b/glm/causal_lm/pytorch/loader.py
@@ -314,9 +314,9 @@ class ModelLoader(ForgeModel):
             if isinstance(mlp, A2aSparseMLPWithSharedExperts):
                 inner = mlp.mlp  # A2aSparseMLP
                 shard_specs[inner.router.gate.weight] = (None, "model")
-                shard_specs[inner.experts.gate_proj] = (("model", "batch"), None, None)
-                shard_specs[inner.experts.up_proj] = (("model", "batch"), None, None)
-                shard_specs[inner.experts.down_proj] = (("model", "batch"), None, None)
+                shard_specs[inner.experts.gate_proj] = (("batch", "model"), None, None)
+                shard_specs[inner.experts.up_proj] = (("batch", "model"), None, None)
+                shard_specs[inner.experts.down_proj] = (("batch", "model"), None, None)
                 shared = getattr(mlp, "shared_experts", None)
                 if shared is not None:
                     shard_specs[shared.gate_proj.weight] = (None, "model")


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5096

### Problem description
Deepseek v3.1 and GLM4.7 were seeing low pcc which was a result of experts being sharded `("model", "batch")` instead of `("batch", "model")`. This is already fixed in the benchmarks tests but should also be fixed here to avoid confusion.

### What's changed
Changed the expert shard specs to be `("batch", "model")`.

### Checklist
- [ ] New/Existing tests provide coverage for changes
