### PR TITLE
Add tensor-parallel sharding to FLUX.1-dev transformer loader

### DIFF
--- a/flux/pytorch/loader.py
+++ b/flux/pytorch/loader.py
@@ -31,6 +31,8 @@ from .src.model_utils import (
     LATENT_GRID_H,
     LATENT_GRID_W,
     MAX_SEQUENCE_LENGTH,
+    MESH_NAMES,
+    MESH_SHAPES,
     REPO_ID,
     ClipTextEncoderWrapper,
     FluxTransformerWrapper,
@@ -46,6 +48,7 @@ from .src.model_utils import (
     make_vae_decoder_input,
     prepare_latent_image_ids,
     prepare_text_ids,
+    shard_transformer_specs,
     tokenize_clip,
     tokenize_t5,
 )
@@ -105,6 +108,29 @@ class ModelLoader(ForgeModel):
             return FluxVAEDecoderWrapper(load_vae(dtype)).eval()
 
         raise ValueError(f"Unknown variant: {self._variant}")
+
+    def get_mesh_config(self, num_devices: int):
+        """Return (mesh_shape, mesh_names) for a ("batch", "model") 2D mesh.
+
+        Supported device counts: 1, 2, 4, 8. The transformer is sharded
+        tensor-parallel along the "model" axis.
+        """
+        if num_devices not in MESH_SHAPES:
+            raise ValueError(
+                f"Unsupported device count: {num_devices}. "
+                f"Expected one of {sorted(MESH_SHAPES)}."
+            )
+        return MESH_SHAPES[num_devices], MESH_NAMES
+
+    def load_shard_spec(self, model):
+        """Return tensor -> partition_spec dict for the active component.
+
+        Expects the same wrapper object returned by load_model(). Only the
+        TRANSFORMER variant is sharded today (the others fit a single chip).
+        """
+        if self._variant == ModelVariant.TRANSFORMER:
+            return shard_transformer_specs(model.transformer)
+        return None
 
     def load_inputs(self, dtype_override: Optional[torch.dtype] = None, **kwargs):
         """Return synthetic inputs for the active component at 1024x1024."""

--- a/flux/pytorch/src/model_utils.py
+++ b/flux/pytorch/src/model_utils.py
@@ -282,3 +282,127 @@ def make_prompt_embeds(dtype: torch.dtype = DTYPE) -> torch.Tensor:
 def make_vae_decoder_input(dtype: torch.dtype = DTYPE) -> torch.Tensor:
     """Packed latents [1, seq, 64] feeding the VAE decoder component."""
     return make_packed_latents(dtype)
+
+
+# Tensor-parallel partition specs (mesh axes "batch", "model"):
+#   column-parallel (shard output / Cout): ("model", None), bias ("model",)
+#   row-parallel    (shard input  / Cin):  (None, "model"), bias (None,)
+
+MESH_SHAPES = {8: (2, 4), 4: (1, 4), 2: (1, 2), 1: (1, 1)}
+MESH_NAMES = ("batch", "model")
+
+
+def _add_shard_spec(specs: dict, param, spec: tuple) -> None:
+    """Register a partition spec only for real parameters (skip None weights/biases)."""
+    if param is not None:
+        specs[param] = spec
+
+
+def _shard_linear(specs: dict, linear, spec: tuple) -> None:
+    """Shard a linear's weight per `spec`; bias along the same first axis (or replicated)."""
+    if linear is None:
+        return
+    _add_shard_spec(specs, linear.weight, spec)
+    bias_spec = ("model",) if spec[0] == "model" else (None,)
+    _add_shard_spec(specs, getattr(linear, "bias", None), bias_spec)
+
+
+def _shard_timestep_embedder(specs: dict, embedder) -> None:
+    """TimestepEmbedding / PixArtAlphaTextProjection: linear_1 column, linear_2 row."""
+    if embedder is None:
+        return
+    _shard_linear(specs, getattr(embedder, "linear_1", None), ("model", None))
+    _shard_linear(specs, getattr(embedder, "linear_2", None), (None, "model"))
+
+
+def _shard_feed_forward(specs: dict, ff) -> None:
+    """diffusers FeedForward: net[0].proj (up) column, net[2] (down) row."""
+    if ff is None:
+        return
+    _shard_linear(specs, ff.net[0].proj, ("model", None))
+    _shard_linear(specs, ff.net[2], (None, "model"))
+
+
+def _shard_modulation_linear(specs: dict, linear) -> None:
+    """Shard an AdaLayerNorm modulation linear ROW-parallel: (None, "model").
+
+    The output (dim -> 6*dim / 3*dim / 2*dim) is immediately chunk()-ed into
+    shift/scale/gate. Column-sharding the output dim scrambles those chunks (the
+    partitioner does not all-gather before the chunk -> wrong shift/scale/gate).
+    Row-parallel instead shards the *input* dim and all-reduces, so the full
+    output is materialized before the chunk (chunk-safe) while the (large) weight
+    still splits 4-way -- replicating it instead overflows DRAM.
+    """
+    _shard_linear(specs, linear, (None, "model"))
+
+
+def shard_transformer_specs(transformer) -> dict:
+    """Tensor-parallel shard specs for FluxTransformer2DModel (FLUX.1-dev).
+
+    Dual-stream `transformer_blocks` + single-stream `single_transformer_blocks`,
+    Megatron column->row on attention QKV/out and the FFNs. Per-head RMSNorm
+    weights (head_dim) and the final proj_out stay replicated.
+    """
+    specs: dict = {}
+
+    # Entry-point embedders -> column.
+    _shard_linear(specs, transformer.x_embedder, ("model", None))
+    _shard_linear(specs, transformer.context_embedder, ("model", None))
+
+    # Time / guidance / text conditioning embedders.
+    tte = transformer.time_text_embed
+    _shard_timestep_embedder(specs, getattr(tte, "timestep_embedder", None))
+    _shard_timestep_embedder(specs, getattr(tte, "guidance_embedder", None))
+    _shard_timestep_embedder(specs, getattr(tte, "text_embedder", None))
+
+    for block in transformer.transformer_blocks:
+        # AdaLayerNormZero modulation linears (dim -> 6*dim): replicate (chunk-safe).
+        _shard_modulation_linear(specs, block.norm1.linear)
+        _shard_modulation_linear(specs, block.norm1_context.linear)
+
+        attn = block.attn
+        for proj_name in (
+            "to_q",
+            "to_k",
+            "to_v",
+            "add_q_proj",
+            "add_k_proj",
+            "add_v_proj",
+        ):
+            _shard_linear(specs, getattr(attn, proj_name, None), ("model", None))
+        # to_out is a ModuleList([Linear, Dropout]); to_add_out is a Linear. Row.
+        _shard_linear(specs, attn.to_out[0], (None, "model"))
+        _shard_linear(specs, getattr(attn, "to_add_out", None), (None, "model"))
+        # Per-head RMSNorm weights (head_dim) are replicated (heads, not head_dim, are sharded).
+        for norm_name in ("norm_q", "norm_k", "norm_added_q", "norm_added_k"):
+            norm = getattr(attn, norm_name, None)
+            if norm is not None:
+                _add_shard_spec(specs, getattr(norm, "weight", None), (None,))
+
+        _shard_feed_forward(specs, block.ff)
+        _shard_feed_forward(specs, getattr(block, "ff_context", None))
+
+    for block in transformer.single_transformer_blocks:
+        # AdaLayerNormZeroSingle modulation (dim -> 3*dim): replicate (chunk-safe).
+        _shard_modulation_linear(specs, block.norm.linear)
+
+        attn = block.attn  # single-stream attn has only to_q/to_k/to_v (no to_out).
+        for proj_name in ("to_q", "to_k", "to_v"):
+            _shard_linear(specs, getattr(attn, proj_name, None), ("model", None))
+        for norm_name in ("norm_q", "norm_k"):
+            norm = getattr(attn, norm_name, None)
+            if norm is not None:
+                _add_shard_spec(specs, getattr(norm, "weight", None), (None,))
+
+        # proj_mlp (up) column; proj_out input is cat([attn_out, mlp]) (both
+        # column-sharded) -> row.
+        _shard_linear(specs, block.proj_mlp, ("model", None))
+        _shard_linear(specs, block.proj_out, (None, "model"))
+
+    # Final AdaLayerNormContinuous modulation: replicate (chunk-safe); proj_out replicated.
+    if hasattr(transformer.norm_out, "linear"):
+        _shard_modulation_linear(specs, transformer.norm_out.linear)
+    _add_shard_spec(specs, transformer.proj_out.weight, (None, None))
+    _add_shard_spec(specs, getattr(transformer.proj_out, "bias", None), (None,))
+
+    return specs


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-xla/issues/5251

### Problem description

- After recent tt-mlir/tt-metal uplifts, the ~24 GB bf16 `FluxTransformer2DModel` came within ~123 MiB of not fitting a single Blackhole chip (DRAM OOM). Single-chip fit levers — `bfp_bf8` weights (upstream SIGSEGV in `pack_as_bfp_tiles`), `optimization_level=2` (compile hang), `fp32_dest_acc_en=False` and `experimental_enable_dram_space_saving_optimization` (no/insufficient change) — did not reliably recover the fit. The transformer is given a multi-chip tensor-parallel path as durable, always-fitting coverage.
- The single-chip margin is **thin** (~24 GB on a ~32 GB chip), so each uplift can push it back over. This PR keeps the single-device test as primary coverage while it fits, and adds 4-way TP as the safety net for when it does not (see Test status).

### What's changed
- `ModelLoader.get_mesh_config(num_devices)` / `load_shard_spec(model)`: expose a `("batch","model")` 2D mesh and per-tensor partition specs, matching the FLUX.2 / GLM-Image sharding convention. Transformer-only for now (CLIP/T5/VAE fit a single chip).
- `shard_transformer_specs()`: Megatron column→row tensor parallelism on `FluxTransformer2DModel`.
  - **Column-parallel** `("model", None)`: attn `to_q/k/v` + `add_*_proj`, FFN `net[0].proj`, single-block `proj_mlp`, entry embedders.
  - **Row-parallel** `(None, "model")`: attn `to_out`/`to_add_out`, FFN `net[2]`, single-block `proj_out`.
  - **AdaLayerNorm modulation linears** are sharded **row-parallel** (not column): their output is `chunk()`-ed into shift/scale/gate, so column-sharding scrambles the chunks (the partitioner does not all-gather before the chunk) while replicating overflows DRAM. Row-parallel is chunk-safe *and* keeps the weight split 4-way. (Same class of fix as #772 for FLUX.2.)
  - Per-head RMSNorm weights and the final `proj_out` stay replicated.

### Test status

**4× Blackhole (p150), bf16, mesh (1,4):**

| Component | Result |
|---|---|
| Transformer (sharded, 4-way TP) | ✅ PASS — no OOM, PCC ≥ 0.99 |

**Single-card p150, bf16, unsharded `test_transformer` — current single-chip fit across the last four tt-mlir uplifts (2026-06-25 → 06-27):** all ✅ PASS, no OOM, no PCC failure.

| tt-mlir pin | tt-xla uplift | Date | Result | tt-xla CI run |
|---|---|---|---|---|
| `dfc0245` | #5397 | 2026-06-27 | ✅ 1 passed (1673s) | https://github.com/tenstorrent/tt-xla/actions/runs/28297849887 |
| `6b6c3709` | #5391 | 2026-06-26 | ✅ 1 passed (2299s) | https://github.com/tenstorrent/tt-xla/actions/runs/28297850481 |
| `0427afbe` | #5387 | 2026-06-26 | ✅ 1 passed (1621s) | https://github.com/tenstorrent/tt-xla/actions/runs/28297851163 |
| `aae51da9` | #5302 | 2026-06-25 | ✅ 1 passed (1754s) | https://github.com/tenstorrent/tt-xla/actions/runs/28297851811 |

### Checklist
- [x] Sharding is additive — loader/inputs for the existing single-device component tests are unchanged.

### Logs
- [flux1_transformer_p150_OOM_log.log](https://github.com/user-attachments/files/29434655/transformer.log)

- [flux1_transformer_p150_passing_log.log](https://github.com/user-attachments/files/29432819/flux1_transformer_p150_LOCAL_306dca4d6.log)

