### PR TITLE
fix load_dataset failures under huggingface_hub 1.x

### DIFF
--- a/autoencoder/pytorch/loader.py
+++ b/autoencoder/pytorch/loader.py
@@ -104,7 +104,7 @@ class ModelLoader(ForgeModel):
                     transforms.Normalize((0.1307,), (0.3081,)),
                 ]
             )
-            dataset = load_dataset("mnist")
+            dataset = load_dataset("ylecun/mnist")
             sample = dataset["train"][0]["image"]
             sample_tensor = transform(sample).view(1, -1)
             batch_tensor = sample_tensor.repeat(batch_size, 1)
@@ -116,7 +116,7 @@ class ModelLoader(ForgeModel):
                     transforms.Normalize((0.1307,), (0.3081,)),
                 ]
             )
-            dataset = load_dataset("mnist")
+            dataset = load_dataset("ylecun/mnist")
             sample = dataset["train"][0]["image"]
             sample_tensor = transform(sample).unsqueeze(0)
             batch_tensor = sample_tensor.repeat(batch_size, 1, 1, 1)

--- a/mlp_mixer/image_classification/jax/loader.py
+++ b/mlp_mixer/image_classification/jax/loader.py
@@ -126,7 +126,7 @@ class ModelLoader(ForgeModel):
         from PIL import Image
 
         # Load a sample image from a publicly available dataset
-        dataset = load_dataset("cifar10", split="test")
+        dataset = load_dataset("uoft-cs/cifar10", split="test")
         # Get the first image from the dataset
         image = dataset[0]["img"]
 

--- a/monodle/pytorch/loader.py
+++ b/monodle/pytorch/loader.py
@@ -107,7 +107,7 @@ class ModelLoader(ForgeModel):
             torch.Tensor: Preprocessed input tensor suitable for Monodle.
         """
 
-        dataset = load_dataset("imagenet-1k", split="validation", streaming=True)
+        dataset = load_dataset("ILSVRC/imagenet-1k", split="validation", streaming=True)
         image = next(iter(dataset.skip(10)))["image"]
 
         # Preprocessing


### PR DESCRIPTION
### Ticket
This surfaced as `load_dataset` failures in the `autoencoder` (mnist) loader in tt-xla.

### Problem Description
`huggingface_hub` 1.x added strict repo-id validation (parse_hf_uri) that requires namespace/name and rejects bare ids like mnist . We don't have a hard-coded `huggingface_hub` version and it gets installed in the venv by one of our requirements, so it jumped to this version recently causing the issue.

### What's changed
Namespaced every bare dataset id in the loaders to its canonical `namespace/name` form (verified against the Hub API):
- `autoencoder/pytorch/loader.py`: `mnist` → `ylecun/mnist` (×2)
- `mlp_mixer/image_classification/jax/loader.py`: `cifar10` → `uoft-cs/cifar10`
- `monodle/pytorch/loader.py`: `imagenet-1k` → `ILSVRC/imagenet-1k`

### Checklist
- [ ] New/Existing tests provide coverage for changes
