### PR TITLE
[diffusiongemma] Pass decoder_input_ids to skip the model's randint

### DIFF
--- a/diffusiongemma/pytorch/loader.py
+++ b/diffusiongemma/pytorch/loader.py
@@ -11,6 +11,7 @@ MoE backbone that denoises a block of tokens instead of decoding left-to-right.
 
 from typing import Optional
 
+import torch
 from transformers import AutoProcessor
 
 from ...base import ForgeModel
@@ -106,6 +107,15 @@ class ModelLoader(ForgeModel):
         for key in list(inputs):
             value = inputs[key].repeat_interleave(batch_size, dim=0)
             inputs[key] = cast_input_to_type(value, dtype_override)
+        # Workaround: pass decoder_input_ids to skip the model's randint (its
+        # lowering hits unsupported uint32 remainder).
+        # tt-metal ticket - https://github.com/tenstorrent/tt-metal/issues/27621
+        # tt-metal pr - https://github.com/tenstorrent/tt-metal/pull/48697
+        # tt-xla tracker - https://github.com/tenstorrent/tt-xla/issues/5423
+        text_cfg = getattr(self.config, "text_config", self.config)
+        inputs["decoder_input_ids"] = torch.randint(
+            0, text_cfg.vocab_size, (batch_size, self.config.canvas_length)
+        )
         return inputs
 
     def _text_layers(self, model):


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/5423

### Problem description

- DiffusionGemma's forward initializes the decoder canvas with [`torch.randint` when `decoder_input_ids is None`](https://github.com/huggingface/transformers/blob/e0e7504bca2bfd1b85bb0eedb148f7b250226f06/src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py#L1570-L1575). On device, `randint` lowers to `rng_bit_generator` + an unsigned `remainder` (`bits % range`), and tt-metal doesn't support `remainder` on `UINT32` → the model crashes with `Unsupported data type for remainder DataType::UINT32`.

### What's changed

- `load_inputs` now passes `decoder_input_ids` (host-side `torch.randint`, same shape/range/dtype as the model's own init), so the model skips its internal device-side `randint` and no `remainder` op is emitted. The model now compiles and runs end-to-end on 8 chips. This is just a quick workaround for the tt-metal gap (UINT32 `remainder`); removable once supported.
- With this fix and [tt-xla#5424](https://github.com/tenstorrent/tt-xla/pull/5424), models now fails at runtime with `PCC=0.96`

### Checklist
- [x] Verify the changes through local testing in WH

### Logs

- [jun30_diffgemma_before_work_around.log.zip](https://github.com/user-attachments/files/29496015/jun30_diffgemma_after_fix.log.zip)
- [jun30_diffgemma_after_work_around.log.zip](https://github.com/user-attachments/files/29516803/jun30_diffgemma_after_workaround.log.zip)

