### PR TITLE
[HunyuanVideo] Run AdaLayerNorm modulation matmuls in bf16 via einsum

### DIFF
--- a/hunyuan_video/pytorch/src/model_utils.py
+++ b/hunyuan_video/pytorch/src/model_utils.py
@@ -78,16 +78,75 @@ def load_text_encoder_2(dtype: torch.dtype = DTYPE):
     ).eval()
 
 
+class _Bf16ModulationLinear(torch.nn.Linear):
+    """nn.Linear that runs its matmul in bf16 via einsum, then restores the input
+    dtype.
+
+    Used for the HunyuanVideo AdaLayerNorm modulation linears so their weight stays
+    bf16 — see _force_bf16_modulation. Two subtleties, both verified against the tt
+    backend:
+
+    * Subclassing (not overriding the instance `forward`) is required because the
+      model is traced via torch.compile/dynamo, which inlines
+      ``type(module).forward`` and ignores an instance-attribute override.
+    * The matmul must go through ``einsum``, not ``F.linear``. tt_torch's
+      decomposition of aten.linear/aten.addmm upcasts every operand to f32 (mm in
+      f32, result back to bf16), which would keep the weight f32. aten.einsum is
+      explicitly popped from that decomposition table (decompositions.py), so an
+      einsum stays bf16 end-to-end and the weight remains bf16.
+    """
+
+    def forward(self, x):
+        xb = x.to(torch.bfloat16)
+        # weight is (out_features, in_features); contract the last dim of x.
+        out = torch.einsum("...k,nk->...n", xb, self.weight)
+        if self.bias is not None:
+            out = out + self.bias
+        return out.to(x.dtype)
+
+
+def _force_bf16_modulation(transformer):
+    """Compute the AdaLayerNorm modulation linears (norm1, norm1_context, single
+    block norm, final norm_out) in bf16 instead of f32.
+
+    In the traced graph `temb` is f32, so each modulation matmul runs in f32 and
+    its bf16 weight is upcast to f32. tt-mlir then fuses all 81 modulation matmuls
+    (they share the same `temb` input) into one (768 x 1,112,064) f32 weight =
+    3.4 GB, which OOMs device DRAM. Running these matmuls in bf16 halves the fused
+    weight to ~1.7 GB and clears the OOM. Validated PCC(f32 vs bf16) = 0.999994 on
+    the full transformer output, well above the 0.99 gate; the CPU golden is bf16
+    anyway (eager `temb` is bf16), so this aligns device and golden.
+
+    Swaps the linear's __class__ in place so the matmul is traced in bf16 while
+    keeping the same weight/bias tensors (so shard_transformer_specs, which keys
+    on `*.linear.weight`, is unaffected).
+    """
+    n = 0
+    for mod in transformer.modules():
+        # Matches AdaLayerNormZero / AdaLayerNormZeroSingle / AdaLayerNormContinuous
+        # (substring "AdaLayerNorm") and HunyuanVideoAdaNorm (token refiner, substring
+        # "AdaNorm") — all carry a `.linear` modulation projection off the (f32) temb.
+        name = type(mod).__name__
+        if ("AdaLayerNorm" in name or "AdaNorm" in name) and hasattr(mod, "linear"):
+            lin = mod.linear
+            if isinstance(lin, torch.nn.Linear):
+                lin.__class__ = _Bf16ModulationLinear
+                n += 1
+    return n
+
+
 def load_transformer(dtype: torch.dtype = DTYPE):
     """Load HunyuanVideoTransformer3DModel from the transformer subfolder."""
     from diffusers import HunyuanVideoTransformer3DModel
 
-    return HunyuanVideoTransformer3DModel.from_pretrained(
+    transformer = HunyuanVideoTransformer3DModel.from_pretrained(
         REPO_ID,
         subfolder="transformer",
         torch_dtype=dtype,
         device_map="cpu",
     ).eval()
+    _force_bf16_modulation(transformer)
+    return transformer
 
 
 def load_vae(dtype: torch.dtype = DTYPE):


### PR DESCRIPTION
### Ticket
Fixes [#5474](https://github.com/tenstorrent/tt-xla/issues/5474)

### Problem description

tests/torch/models/hunyuan_video/test_transformer.py::test_transformer_sharded fails with a device DRAM out-of-memory at a ttnn.concat:

```
TT_FATAL: Out of Memory: Not enough space to allocate 3416260608 B DRAM buffer
across 12 banks, where each bank needs to store 284688384 B, but bank size is
1070773184 B (allocated: 809780928 B, free: 260992256 B) (bank_manager.cpp:462)
```

### What's changed

- The 3.4 GB buffer is the AdaLayerNorm modulation weight. All 81 modulation linears across the transformer (norm1.linear, norm1_context.linear, single-block norm.linear, final norm_out.linear, and the token refiner's HunyuanVideoAdaNorm.linear) share the same temb input, so tt-mlir's common-operand matmul fusion concatenates them into one 768 × 1,112,064 weight. That weight is f32 — even though the model is bf16 — because tt_torch's decomposition of aten.linear/aten.addmm (in torch_pass_pipeline's run_decompositions) upcasts every matmul operand to f32 (mm in f32, result back to bf16). f32 × the fused width = 3.4 GB, which overflows per-bank DRAM. This was isolated by tracing the model through dynamo (bf16 preserved) and then running the captured graph through torch_pass_pipeline stage by stage: run_decompositions is the stage that flips bf16→f32.

- The weight is already sharded on the contracting dim ("model"), so a single-axis re-shard gives the identical per-device size; sharding the output dim instead makes the downstream scale/gate chunk-slices straddle shards and hits the sdy.collective_permute lowering gap (tt-mlir #3370). Running the modulation in bf16 is numerically safe — validated PCC(f32 vs bf16) = 0.999994 on the full transformer output, well above the 0.99 gate, and the CPU golden is bf16 anyway (eager temb is bf16) — but no model-side dtype cast survives, because the f32 upcast happens in decomposition and reverts any input/output cast or F.linear-based override.

- The fix: modulation matmuls in bf16 via einsum. aten.einsum is explicitly popped from tt_torch's decomposition table, so it escapes the f32 upcast. _force_bf16_modulation swaps each modulation linear's __class__ to _Bf16ModulationLinear, whose forward casts the input to bf16 and computes the projection with torch.einsum (bias added, then restore input dtype). The einsum keeps the weight bf16 end-to-end, so the fused constant drops to ~1.7 GB (~136 MiB/bank, under the ~249 MiB free) and the OOM clears. Called from load_transformer so it applies to the loaded transformer before wrapping/sharding.

- The model is traced via torch.compile/dynamo, which inlines type(module).forward and ignores an instance-attribute forward; swapping __class__ is what dynamo actually traces. The swap keeps the same weight/bias tensors, so shard_transformer_specs (which keys on *.linear.weight) is unaffected and the existing contracting-dim sharding still applies.

With these changes the sharded Hunyuan video transformer test now compiles and runs end-to-end on 8 devices.

### Logs
[hunyuan_transformer_before_fix.zip](https://github.com/user-attachments/files/29536669/hunyuan_transformer_before_fix.zip)
[hunyuan_transformer_einsum_after_fix.zip](https://github.com/user-attachments/files/29536679/hunyuan_transformer_einsum_after_fix.zip)


