### PR TITLE
yolox: expose detection boxes + numeric scores from output_postprocess

### DIFF
--- a/yolox/pytorch/loader.py
+++ b/yolox/pytorch/loader.py
@@ -137,6 +137,12 @@ class ModelLoader(ForgeModel):
         model.load_state_dict(ckpt["model"])
         model.eval()
 
+        # Return raw (undecoded) head outputs. The box decode (grids + exp on
+        # w/h) is done once on the host by get_detections -> demo_postprocess.
+        # Leaving this True double-decodes the boxes (exp applied twice) and
+        # overflows to inf/NaN coordinates, so keep it False.
+        model.head.decode_in_inference = False
+
         # Only convert dtype if explicitly requested
         if dtype_override is not None:
             model = model.to(dtype_override)

--- a/yolox/pytorch/loader.py
+++ b/yolox/pytorch/loader.py
@@ -187,18 +187,24 @@ class ModelLoader(ForgeModel):
 
         return batch_tensor
 
-    def output_postprocess(self, output, top_k=None):
+    def output_postprocess(self, output, top_k=None, score_thr=0.01):
         """Post-process raw model output into structured detection results.
 
-        Returns a dict with keys "labels", "probabilities", and "indices" (sorted by
-        descending confidence), compatible with ForgeRunner's _postprocess_model_output.
+        Returns a dict with keys "labels", "probabilities", "indices",
+        "boxes", and "scores" (sorted by descending confidence), compatible
+        with ForgeRunner's _postprocess_model_output. Boxes ([x1,y1,x2,y2] in
+        original-image coordinates) and numeric scores are included so callers
+        (e.g. a COCO mAP eval) can consume detections directly.
 
         Args:
             output: Model output tensor [batch, n_anchors, 85] or list/tuple thereof.
             top_k: Maximum number of detections to return. None returns all.
+            score_thr: NMS confidence threshold. Defaults to 0.01 so low-confidence
+                detections are retained (needed for COCO mAP); the classification
+                response path filters further by ``min_confidence`` downstream.
 
         Returns:
-            dict: {"labels": [...], "probabilities": [...], "indices": [...]}
+            dict: {"labels", "probabilities", "indices", "boxes", "scores"}
         """
         from .src.utils import get_detections
 
@@ -207,7 +213,9 @@ class ModelLoader(ForgeModel):
         else:
             out_np = output.cpu().detach().float().numpy()
 
-        detections = get_detections(out_np, self.ratio, self.input_shape)
+        detections = get_detections(
+            out_np, self.ratio, self.input_shape, score_thr=score_thr
+        )
         if top_k is not None:
             detections = detections[:top_k]
 
@@ -215,6 +223,8 @@ class ModelLoader(ForgeModel):
             "labels": [d["class_name"] for d in detections],
             "probabilities": [f"{d['score'] * 100:.4f}%" for d in detections],
             "indices": [d["cls_ind"] for d in detections],
+            "boxes": [list(d["bbox"]) for d in detections],
+            "scores": [float(d["score"]) for d in detections],
         }
 
     def load_inputs(self, dtype_override=None, batch_size=1):

--- a/yolox/pytorch/src/utils.py
+++ b/yolox/pytorch/src/utils.py
@@ -6,13 +6,17 @@ import numpy as np
 import torch
 
 
-def get_detections(out_np, ratio, input_shape):
+def get_detections(out_np, ratio, input_shape, score_thr=0.1, nms_thr=0.45):
     """Run NMS on raw model output and return a list of detection dicts.
 
     Args:
         out_np: numpy array of shape [batch, n_anchors, 85].
         ratio: scale ratio from preproc, used to map boxes back to original image size.
         input_shape: (h, w) tuple used during preprocessing.
+        score_thr: confidence threshold for NMS. Defaults to 0.1 (demo/display).
+            Lower it (e.g. 0.01) for COCO mAP so low-confidence detections are
+            retained for recall/AP.
+        nms_thr: IoU threshold for NMS. Defaults to 0.45.
 
     Returns:
         List of dicts with keys: class_name, score, cls_ind, bbox ([x1,y1,x2,y2]).
@@ -30,7 +34,7 @@ def get_detections(out_np, ratio, input_shape):
     boxes_xyxy[:, 2] = boxes[:, 0] + boxes[:, 2] / 2.0
     boxes_xyxy[:, 3] = boxes[:, 1] + boxes[:, 3] / 2.0
     boxes_xyxy /= ratio
-    dets = multiclass_nms(boxes_xyxy, scores, nms_thr=0.45, score_thr=0.1)
+    dets = multiclass_nms(boxes_xyxy, scores, nms_thr=nms_thr, score_thr=score_thr)
 
     result = []
     if dets is not None:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/5442 

### Problem description
Yolox Nano labels are not enough for release appropriate accuracy calculation. 

### What's changed
For COCO mAP evaluation of the served model, output_postprocess now returns "boxes" ([x1,y1,x2,y2] in original-image coords) and numeric "scores" in addition to labels/probabilities/indices, and uses a low score_thr (0.01) so low-confidence detections are retained. get_detections gains score_thr/nms_thr params (defaults preserve prior demo behavior).

### Checklist
- [x] `pytest -s tests/runner/test_models.py::test_all_models_torch[yolox/pytorch-Nano-single_device-inference]`: https://github.com/tenstorrent/tt-xla/actions/runs/28672861752