### PR TITLE
Add Qwen3.5 27B causal_lm loader with tensor-parallel sharding

### DIFF
--- a/qwen_3_5/causal_lm/pytorch/loader.py
+++ b/qwen_3_5/causal_lm/pytorch/loader.py
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Qwen 3.5 model loader implementation for causal language modeling.
+
+Qwen 3.5 uses a hybrid architecture interleaving Gated DeltaNet (linear
+attention with causal conv1d + chunked delta rule) and standard full
+attention layers. Dense variants follow the layout
+(3x linear_attention + 1x full_attention) repeated.
 """
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
@@ -21,7 +26,7 @@ from ....config import (
 
 
 class ModelVariant(StrEnum):
-    """Available Qwen 3.5 model variants for causal language modeling."""
+    """Available Qwen 3.5 dense model variants for causal language modeling."""
 
     QWEN_3_5_0_8B = "0_8B"
     QWEN_3_5_2B = "2B"
@@ -30,7 +35,7 @@ class ModelVariant(StrEnum):
     QWEN_3_5_27B = "27B"
 
 
-# Variants promoted to the RED model group (larger dense / MoE).
+# Variants promoted to the RED model group.
 _RED_VARIANTS = {
     ModelVariant.QWEN_3_5_27B,
 }
@@ -228,3 +233,19 @@ class ModelLoader(ForgeModel):
             shard_specs[model.lm_head.weight] = ("model", "batch")
 
         return shard_specs
+
+    def load_activation_shard_spec(self, model):
+        """Sharding constraints for intermediate ACTIVATIONS (not weights).
+
+        The gated-delta block's fused ``in_proj_qkv`` is sharded contiguously on
+        the "model" axis; the subsequent ``torch.split`` into [Q, K, V] cuts that
+        sharded axis at points that don't align with the per-device boundaries,
+        which miscompiles under Shardy and scrambles q/k/v before the recurrence
+        (full-model PCC collapses). Replicating the conv output before the split
+        makes the split run on correct data.
+        """
+        constraints = {}
+        for layer in model.model.layers:
+            if layer.layer_type == "linear_attention":
+                constraints[layer.linear_attn.conv1d] = None
+        return constraints

--- a/qwen_3_5/causal_lm/pytorch/loader.py
+++ b/qwen_3_5/causal_lm/pytorch/loader.py
@@ -3,11 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Qwen 3.5 model loader implementation for causal language modeling.
-
-Qwen 3.5 uses a hybrid architecture interleaving Gated DeltaNet (linear
-attention with causal conv1d + chunked delta rule) and standard full
-attention layers. Dense variants follow the layout
-(3x linear_attention + 1x full_attention) repeated.
 """
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
@@ -26,12 +21,19 @@ from ....config import (
 
 
 class ModelVariant(StrEnum):
-    """Available Qwen 3.5 dense model variants for causal language modeling."""
+    """Available Qwen 3.5 model variants for causal language modeling."""
 
     QWEN_3_5_0_8B = "0_8B"
     QWEN_3_5_2B = "2B"
     QWEN_3_5_4B = "4B"
     QWEN_3_5_9B = "9B"
+    QWEN_3_5_27B = "27B"
+
+
+# Variants promoted to the RED model group (larger dense / MoE).
+_RED_VARIANTS = {
+    ModelVariant.QWEN_3_5_27B,
+}
 
 
 class ModelLoader(ForgeModel):
@@ -54,6 +56,10 @@ class ModelLoader(ForgeModel):
             pretrained_model_name="Qwen/Qwen3.5-9B",
             max_length=128,
         ),
+        ModelVariant.QWEN_3_5_27B: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3.5-27B",
+            max_length=128,
+        ),
     }
 
     DEFAULT_VARIANT = ModelVariant.QWEN_3_5_0_8B
@@ -70,10 +76,15 @@ class ModelLoader(ForgeModel):
 
     @classmethod
     def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        group = ModelGroup.RED if variant in _RED_VARIANTS else ModelGroup.GENERALITY
+
         return ModelInfo(
             model="Qwen 3.5",
             variant=variant,
-            group=ModelGroup.GENERALITY,
+            group=group,
             task=ModelTask.NLP_CAUSAL_LM,
             source=ModelSource.HUGGING_FACE,
             framework=Framework.TORCH,
@@ -96,8 +107,15 @@ class ModelLoader(ForgeModel):
             model_kwargs["torch_dtype"] = dtype_override
 
         if self.num_layers is not None:
+            # Qwen 3.5 keeps the decoder depth in the nested text_config; setting
+            # it on the outer config is ignored (the model still builds all 64
+            # layers). Set text_config and keep layer_types consistent so the
+            # hybrid linear/full pattern still includes a full_attention layer.
             config = AutoConfig.from_pretrained(pretrained_model_name)
-            config.num_hidden_layers = self.num_layers
+            text_cfg = getattr(config, "text_config", config)
+            text_cfg.num_hidden_layers = self.num_layers
+            if getattr(text_cfg, "layer_types", None) is not None:
+                text_cfg.layer_types = text_cfg.layer_types[: self.num_layers]
             model_kwargs["config"] = config
 
         model_kwargs |= kwargs
@@ -118,13 +136,15 @@ class ModelLoader(ForgeModel):
         self.model = model
         return model
 
-    def load_inputs(self, dtype_override=None, batch_size=1):
+    def load_inputs(
+        self, dtype_override=None, prompt: Optional[str] = None, batch_size=1
+    ):
         if self.tokenizer is None:
             self._load_tokenizer()
 
         max_length = self._variant_config.max_length
 
-        messages = [{"role": "user", "content": self.sample_text}]
+        messages = [{"role": "user", "content": prompt or self.sample_text}]
         text = self.tokenizer.apply_chat_template(
             messages, tokenize=False, add_generation_prompt=True
         )
@@ -169,3 +189,42 @@ class ModelLoader(ForgeModel):
             max_cache_len=max_cache_len,
             dtype=dtype_override,
         )
+
+    def get_mesh_config(self, num_devices: int):
+        mesh_shape = (1, num_devices)
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+
+        for layer in model.model.layers:
+            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+
+            if hasattr(layer, "self_attn"):
+                sa = layer.self_attn
+                shard_specs[sa.q_proj.weight] = ("batch", "model")
+                shard_specs[sa.k_proj.weight] = ("batch", "model")
+                shard_specs[sa.v_proj.weight] = ("batch", "model")
+                shard_specs[sa.o_proj.weight] = ("model", "batch")
+
+            elif hasattr(layer, "linear_attn"):
+                la = layer.linear_attn
+                shard_specs[la.in_proj_qkv.weight] = ("model", "batch")
+                if hasattr(la, "conv1d"):
+                    shard_specs[la.conv1d.weight] = (None, None, None)
+                shard_specs[la.in_proj_z.weight] = ("model", "batch")
+                shard_specs[la.in_proj_a.weight] = ("model", "batch")
+                shard_specs[la.in_proj_b.weight] = ("model", "batch")
+                shard_specs[la.out_proj.weight] = ("batch", "model")
+                if hasattr(la, "dt_bias"):
+                    shard_specs[la.dt_bias] = ("model",)
+                if hasattr(la, "A_log"):
+                    shard_specs[la.A_log] = ("model",)
+
+        shard_specs[model.model.embed_tokens.weight] = ("model", "batch")
+        if hasattr(model, "lm_head"):
+            shard_specs[model.lm_head.weight] = ("model", "batch")
+
+        return shard_specs


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/3508)

### Problem description
Qwen3.5 is a hybrid model (Gated DeltaNet + full attention) and needs a loader with a tensor-parallel sharding strategy. The gated-delta block's fused in_proj_qkv is sharded on the "model" axis, but the later torch.split into Q/K/V cuts that axis at boundaries that don't align with the per-device shards → Q/K/V get scrambled and PCC collapses. The conv output must be replicated before the split.

### What's changed
Adds qwen_3_5/causal_lm/pytorch/loader.py:
- Variants incl. QWEN_3_5_27B, get_mesh_config (("batch","model") mesh)
- load_shard_spec - weight TP specs (MLP, full-attn q/k/v/o, gated-delta)
- load_activation_shard_spec - declares {conv1d: None} (replicate output) so the fused-QKV split runs on correct data; applied by the tt-xla device runner

### Logs
[run_27b_full.log](https://github.com/user-attachments/files/29704108/run_27b_full.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
