### PR TITLE
[forge-models] Add Transformers 5.x compat and HF loading helpers

### DIFF
--- a/baichuan_m2/pytorch/loader.py
+++ b/baichuan_m2/pytorch/loader.py
@@ -83,12 +83,8 @@ class ModelLoader(ForgeModel):
         Returns:
             The loaded tokenizer instance
         """
-        tokenizer_kwargs = {}
-        if dtype_override is not None:
-            tokenizer_kwargs["torch_dtype"] = dtype_override
-
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+            self._variant_config.pretrained_model_name
         )
 
         return self.tokenizer

--- a/coherlabs/pytorch/loader.py
+++ b/coherlabs/pytorch/loader.py
@@ -97,9 +97,7 @@ class ModelLoader(ForgeModel):
         Returns:
             The loaded tokenizer instance
         """
-        tokenizer_kwargs = {}
-        if dtype_override is not None:
-            tokenizer_kwargs["torch_dtype"] = dtype_override
+        tokenizer_kwargs = {"trust_remote_code": True}
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             self._variant_config.pretrained_model_name, **tokenizer_kwargs
@@ -122,7 +120,7 @@ class ModelLoader(ForgeModel):
         if self.tokenizer is None:
             self._load_tokenizer(dtype_override=dtype_override)
 
-        model_kwargs = {}
+        model_kwargs = {"trust_remote_code": True}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
         model_kwargs |= kwargs

--- a/deepseek/qwen/pytorch/loader.py
+++ b/deepseek/qwen/pytorch/loader.py
@@ -87,12 +87,8 @@ class ModelLoader(ForgeModel):
         Returns:
             The loaded tokenizer instance
         """
-        tokenizer_kwargs = {}
-        if dtype_override is not None:
-            tokenizer_kwargs["torch_dtype"] = dtype_override
-
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+            self._variant_config.pretrained_model_name
         )
 
         return self.tokenizer

--- a/exaone_3_5/pytorch/loader.py
+++ b/exaone_3_5/pytorch/loader.py
@@ -85,8 +85,6 @@ class ModelLoader(ForgeModel):
         """
         # EXAONE 3.5 ships a custom tokenizer; trust_remote_code is required.
         tokenizer_kwargs = {"trust_remote_code": True}
-        if dtype_override is not None:
-            tokenizer_kwargs["torch_dtype"] = dtype_override
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             self._variant_config.pretrained_model_name, **tokenizer_kwargs

--- a/hyperclovax/pytorch/loader.py
+++ b/hyperclovax/pytorch/loader.py
@@ -92,12 +92,8 @@ class ModelLoader(ForgeModel):
         # Lazy import so it binds to the pinned transformers (see module note).
         from transformers import AutoTokenizer
 
-        tokenizer_kwargs = {}
-        if dtype_override is not None:
-            tokenizer_kwargs["torch_dtype"] = dtype_override
-
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+            self._variant_config.pretrained_model_name
         )
 
         return self.tokenizer

--- a/hyperclovax_32b/pytorch/loader.py
+++ b/hyperclovax_32b/pytorch/loader.py
@@ -9,7 +9,7 @@ import torch
 from typing import Optional
 
 # NOTE: `transformers` is intentionally NOT imported at module top level.
-# HyperCLOVA X SEED Think gained native support in transformers == 4.52.4 (see
+# HyperCLOVA X SEED Think gained native support in transformers >= 5.9.0 (see
 # requirements.txt; model_type "hyperclovax"). The test runner upgrades
 # transformers at test time and purges it from sys.modules. A top-level import
 # would bind the Auto* classes to whatever transformers was loaded during pytest
@@ -93,8 +93,6 @@ class ModelLoader(ForgeModel):
         from transformers import AutoTokenizer
 
         tokenizer_kwargs = {"trust_remote_code": True}
-        if dtype_override is not None:
-            tokenizer_kwargs["torch_dtype"] = dtype_override
 
         self.tokenizer = AutoTokenizer.from_pretrained(
             self._variant_config.pretrained_model_name, **tokenizer_kwargs

--- a/hyperclovax_32b/pytorch/requirements.txt
+++ b/hyperclovax_32b/pytorch/requirements.txt
@@ -1,1 +1,1 @@
-transformers==4.52.4
+transformers>=5.9.0

--- a/tools/hf_loading.py
+++ b/tools/hf_loading.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Shared HuggingFace model/tokenizer loading helpers for forge model loaders."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from .transformers_compat import apply_transformers_compat_patches, load_causal_lm, load_tokenizer
+
+
+def load_causal_lm_from_variant(
+    model_id: str,
+    *,
+    dtype_override: Optional[torch.dtype] = None,
+    trust_remote_code: bool = False,
+    **kwargs,
+):
+    """Standard causal LM load path used by many forge model loaders."""
+    apply_transformers_compat_patches()
+    model_kwargs = dict(kwargs)
+    if dtype_override is not None:
+        model_kwargs.setdefault("torch_dtype", dtype_override)
+    model = load_causal_lm(model_id, trust_remote_code=trust_remote_code, **model_kwargs)
+    model.eval()
+    return model
+
+
+def load_tokenizer_from_variant(
+    model_id: str,
+    *,
+    trust_remote_code: bool = False,
+    pad_to_eos: bool = True,
+    **kwargs,
+):
+    """Standard tokenizer load path; never forwards torch_dtype to the tokenizer."""
+    apply_transformers_compat_patches()
+    tokenizer = load_tokenizer(model_id, trust_remote_code=trust_remote_code, **kwargs)
+    if pad_to_eos and tokenizer.pad_token is None and tokenizer.eos_token is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return tokenizer

--- a/tools/transformers_compat.py
+++ b/tools/transformers_compat.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility shims for HuggingFace Transformers 5.x in forge model tests.
+
+Transformers 5.5.1 (the repo default in venv/requirements-dev.txt) changed
+``PreTrainedModel.initialize_weights`` to call ``smart_apply(fn, is_remote_code)``.
+Remote modeling code and some native configs still expose the older 2-argument
+``smart_apply`` signature, which raises ``TypeError`` during weight init.
+
+Passing a loaded ``PreTrainedConfig`` instance as the first positional argument
+to ``from_pretrained`` is also invalid: Transformers coerces it with ``str()``
+which produces strings like ``Qwen2Config { ... }`` and HuggingFace Hub rejects
+them as repo ids.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, Optional
+
+
+def _config_repo_id(config: Any) -> Optional[str]:
+    for attr in ("name_or_path", "_name_or_path"):
+        value = getattr(config, attr, None)
+        if value:
+            return str(value)
+    return None
+
+
+def _coerce_pretrained_path(pretrained_model_name_or_path: Any, kwargs: dict) -> Any:
+    try:
+        from transformers.configuration_utils import PreTrainedConfig
+    except ImportError:
+        return pretrained_model_name_or_path
+
+    if not isinstance(pretrained_model_name_or_path, PreTrainedConfig):
+        return pretrained_model_name_or_path
+
+    config = pretrained_model_name_or_path
+    repo_id = _config_repo_id(config)
+    if not repo_id:
+        raise ValueError(
+            "A PreTrainedConfig object was passed as the first argument to "
+            "from_pretrained, but the config has no name_or_path set. Pass the "
+            "HuggingFace repo id string instead, e.g. "
+            "AutoModelForCausalLM.from_pretrained('org/model', config=config)."
+        )
+
+    kwargs.setdefault("config", config)
+    return repo_id
+
+
+def _patch_from_pretrained(classmethod_fn: Callable) -> Callable:
+    @functools.wraps(classmethod_fn)
+    def wrapped(cls, pretrained_model_name_or_path, *args, **kwargs):
+        pretrained_model_name_or_path = _coerce_pretrained_path(
+            pretrained_model_name_or_path, kwargs
+        )
+        return classmethod_fn(cls, pretrained_model_name_or_path, *args, **kwargs)
+
+    return wrapped
+
+
+def _install_compatible_smart_apply() -> None:
+    import torch
+    from transformers.modeling_utils import PreTrainedModel
+
+    def _call_init_fn(module, fn, is_remote_code):
+        try:
+            return fn(module, is_remote_code)
+        except TypeError:
+            try:
+                return fn(module)
+            except TypeError:
+                raise
+
+    def compatible_smart_apply(module, fn, is_remote_code):
+        for child in module.children():
+            if isinstance(child, PreTrainedModel):
+                compatible_smart_apply(child, child._initialize_weights, is_remote_code)
+            else:
+                compatible_smart_apply(child, fn, is_remote_code)
+        _call_init_fn(module, fn, is_remote_code)
+        return module
+
+    torch.nn.Module.smart_apply = compatible_smart_apply
+    torch.nn.Module._tt_forge_smart_apply_patched = True
+
+
+def apply_transformers_compat_patches() -> None:
+    """Install Transformers compatibility patches for the loaded transformers build."""
+    try:
+        from transformers.configuration_utils import PreTrainedConfig
+        from transformers.modeling_utils import PreTrainedModel
+        from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+    except ImportError:
+        return
+
+    _install_compatible_smart_apply()
+
+    if not getattr(PreTrainedModel, "_tt_forge_compat_patched", False):
+        PreTrainedModel.from_pretrained = classmethod(
+            _patch_from_pretrained(PreTrainedModel.from_pretrained.__func__)
+        )
+        PreTrainedModel._tt_forge_compat_patched = True
+
+    if not getattr(PreTrainedTokenizerBase, "_tt_forge_compat_patched", False):
+        PreTrainedTokenizerBase.from_pretrained = classmethod(
+            _patch_from_pretrained(PreTrainedTokenizerBase.from_pretrained.__func__)
+        )
+        PreTrainedTokenizerBase._tt_forge_compat_patched = True
+
+    if not getattr(PreTrainedConfig, "_tt_forge_compat_patched", False):
+        PreTrainedConfig.from_pretrained = classmethod(
+            _patch_from_pretrained(PreTrainedConfig.from_pretrained.__func__)
+        )
+        PreTrainedConfig._tt_forge_compat_patched = True
+
+
+def load_tokenizer(model_id: str, *, trust_remote_code: bool = False, **kwargs):
+    """Load a tokenizer without passing invalid kwargs such as torch_dtype."""
+    apply_transformers_compat_patches()
+    from transformers import AutoTokenizer
+
+    tokenizer_kwargs = dict(kwargs)
+    tokenizer_kwargs.pop("torch_dtype", None)
+    tokenizer_kwargs.pop("dtype", None)
+    if trust_remote_code:
+        tokenizer_kwargs.setdefault("trust_remote_code", True)
+    return AutoTokenizer.from_pretrained(model_id, **tokenizer_kwargs)
+
+
+def load_causal_lm(model_id: str, *, trust_remote_code: bool = False, **kwargs):
+    """Load a causal LM using a repo id string and optional trust_remote_code."""
+    apply_transformers_compat_patches()
+    from transformers import AutoModelForCausalLM
+
+    model_kwargs = dict(kwargs)
+    if trust_remote_code:
+        model_kwargs.setdefault("trust_remote_code", True)
+    return AutoModelForCausalLM.from_pretrained(model_id, **model_kwargs)

--- a/vicuna/pytorch/loader.py
+++ b/vicuna/pytorch/loader.py
@@ -84,12 +84,8 @@ class ModelLoader(ForgeModel):
         Returns:
             The loaded tokenizer instance
         """
-        tokenizer_kwargs = {}
-        if dtype_override is not None:
-            tokenizer_kwargs["torch_dtype"] = dtype_override
-
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+            self._variant_config.pretrained_model_name
         )
         # Vicuna inherits LLaMA's tokenizer with no pad token.
         if self.tokenizer.pad_token is None:

--- a/wizardmath_70b/pytorch/loader.py
+++ b/wizardmath_70b/pytorch/loader.py
@@ -82,12 +82,8 @@ class ModelLoader(ForgeModel):
         Returns:
             The loaded tokenizer instance
         """
-        tokenizer_kwargs = {}
-        if dtype_override is not None:
-            tokenizer_kwargs["torch_dtype"] = dtype_override
-
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self._variant_config.pretrained_model_name, **tokenizer_kwargs
+            self._variant_config.pretrained_model_name
         )
 
         if self.tokenizer.pad_token is None:


### PR DESCRIPTION
## Summary

Adds shared compatibility helpers for forge model loaders running against **Transformers 5.5.1** (tt-xla repo default).

- **`tools/transformers_compat.py`**: `smart_apply` fallback for legacy 2-arg weight init functions; `from_pretrained` coercion when a `PreTrainedConfig` is passed as the first argument instead of a repo id.
- **`tools/hf_loading.py`**: shared tokenizer/model load helpers (apply patches, strip invalid tokenizer kwargs).

Also updates affected causal LM loaders:
- Stop passing `torch_dtype` to `AutoTokenizer.from_pretrained`
- Add `trust_remote_code=True` for CohereLabs
- Pin `hyperclovax_32b` to `transformers>=5.9.0`

Consumed by tt-xla PR: https://github.com/tenstorrent/tt-xla/pull/5529

## Test plan

- [ ] Smoke-load exaone_3_5, falcon 40B, hyperclovax 14B, coherlabs command_r
- [ ] Smoke-load vicuna 33B or baichuan_m2 (config-as-repo-id bucket)

Made with [Cursor](https://cursor.com)