### PR TITLE
[diffusiongemma] Add ENCODER variant with per-variant shard spec

### DIFF
--- a/diffusiongemma/pytorch/loader.py
+++ b/diffusiongemma/pytorch/loader.py
@@ -32,6 +32,7 @@ class ModelVariant(StrEnum):
     """Available DiffusionGemma model variants."""
 
     DIFFUSIONGEMMA_26B_A4B_IT = "26B-A4B-it"
+    ENCODER = "encoder"
 
 
 class ModelLoader(ForgeModel):
@@ -39,6 +40,9 @@ class ModelLoader(ForgeModel):
 
     _VARIANTS = {
         ModelVariant.DIFFUSIONGEMMA_26B_A4B_IT: LLMModelConfig(
+            pretrained_model_name="google/diffusiongemma-26B-A4B-it",
+        ),
+        ModelVariant.ENCODER: LLMModelConfig(
             pretrained_model_name="google/diffusiongemma-26B-A4B-it",
         ),
     }
@@ -85,8 +89,14 @@ class ModelLoader(ForgeModel):
         )
         model.eval()
         model = _install_dynamo_safe_param_props(model)
-        self.model = model
         self.config = model.config
+        # ENCODER variant: return the encoder as a standalone model so it can
+        # be freed independently -> staged residency avoids OOM.
+        # See https://github.com/tenstorrent/tt-xla/issues/5538
+        if self._variant == ModelVariant.ENCODER:
+            self.model = model.model.encoder
+            return self.model
+        self.model = model
         return model
 
     def load_inputs(
@@ -131,12 +141,19 @@ class ModelLoader(ForgeModel):
         assert text_cfg.num_experts % mesh_shape[1] == 0
         return mesh_shape, ("batch", "model")
 
+    def _layers_for_variant(self, model):
+        """Layers to shard: the ENCODER variant's `model` is the encoder submodule, so shard
+        its own language_model layers; else shard both encoder+decoder text layers."""
+        if self._variant == ModelVariant.ENCODER:
+            return list(model.language_model.layers)
+        return self._text_layers(model)
+
     def load_shard_spec(self, model):
         """Shard the dense MLP (col->row) and expert-parallel MoE. Attention is
         replicated: the global layers' 2 KV heads can't shard the model axis,
         and head-sharding Q crashes the repeat_kv reshard."""
         shard_specs = {}
-        for layer in self._text_layers(model):
+        for layer in self._layers_for_variant(model):
             shard_specs[layer.mlp.gate_proj.weight] = ("model", None)
             shard_specs[layer.mlp.up_proj.weight] = ("model", None)
             shard_specs[layer.mlp.down_proj.weight] = (None, "model")


### PR DESCRIPTION
### Ticket 

- https://github.com/tenstorrent/tt-xla/issues/5526
- https://github.com/tenstorrent/tt-xla/issues/5538

### Problem description

DiffusionGemma-26B's e2e script must run both the **encoder** (prefill) and **decoder** (denoising loop) on TT. As two co-resident compiled graphs they bake two device weight copies (~2×52 GB > 8× n150 ~103 GB) → **OOM**. Staged residency (prefill → free encoder → load decoder) fixes it, but a submodule encoder can't be freed cleanly — the full model still references it (tied weights).

For full details, see https://github.com/tenstorrent/tt-xla/issues/5538


### What's changed

Added an **`ENCODER` model variant** that loads only the encoder as a standalone, independent model, so a consumer can load → prefill → **free it cleanly** before loading the decoder — keeping **one component device-resident at a time and preventing OOM**.
- `load_model`: for the `ENCODER` variant, returns just the encoder submodule as its own model (the rest of the full model is dropped at load time → deletable).
- `load_shard_spec` is now **variant-aware**: `ENCODER` shards its own `language_model` layers; the full-model variant shards both encoder + decoder text layers. Sharding scheme unchanged (MLP col→row, expert-parallel MoE, attention replicated).

### Logs

- [jul6_diffgemma_nightly_test_before_fix.log.zip](https://github.com/user-attachments/files/29708499/jul6_diffgemma_nightly_before_fix.log.zip)
- [jul6_diffgemma_nightly_test_after_fix.log.zip](https://github.com/user-attachments/files/29708504/jul6_diffgemma_nightly_test_after_fix.log.zip)

