### PR TITLE
yolov3: fix dataset load failure on datasets>=4

### DIFF
--- a/yolov3/pytorch/loader.py
+++ b/yolov3/pytorch/loader.py
@@ -137,7 +137,9 @@ class ModelLoader(ForgeModel):
 
         # If image is None, use default dataset image (backward compatibility)
         if image is None:
-            dataset = load_dataset("chrismontes/dog_images", split="train")
+            dataset = load_dataset(
+                "chrismontes/dog_images", split="train", drop_labels=True
+            )
             image = dataset[0]["image"]
 
         return self._preprocessor.preprocess(


### PR DESCRIPTION
### Ticket


### Problem description
uplift and forge models uplift prs are failing CI in tt-xla because of the behavior of `datasets` and this code

### What's changed
Just drop the labels, we don't need them

### Checklist
- [ ] New/Existing tests provide coverage for changes
