### PR TITLE
[Infinity 2B] Support 4-device sharding and add PCC hook

### DIFF
--- a/glm_image/pytorch/loader.py
+++ b/glm_image/pytorch/loader.py
@@ -147,7 +147,7 @@ class ModelLoader(ForgeModel):
         if self._variant == ModelVariant.TEXT_ENCODER:
             return shard_text_encoder_specs(model, self._model_axis_size)
         if self._variant == ModelVariant.VISION_LANGUAGE_ENCODER:
-            return shard_vision_language_encoder_specs(model.vlm)
+            return shard_vision_language_encoder_specs(model.vlm, self._model_axis_size)
         if self._variant == ModelVariant.TRANSFORMER:
             return shard_transformer_specs(model.transformer)
         if self._variant == ModelVariant.VAE:

--- a/glm_image/pytorch/src/model_utils.py
+++ b/glm_image/pytorch/src/model_utils.py
@@ -424,20 +424,59 @@ def shard_text_encoder_specs(encoder, model_axis_size: int = 1) -> dict:
     return specs
 
 
-def shard_vision_language_encoder_specs(vlm) -> dict:
+def _heads_divide_model_axis(config, model_axis_size: int) -> bool:
+    """Whether attention can be head-parallel across a model axis this wide.
+
+    q/k/v produce num_heads * head_dim (num_key_value_heads * head_dim for the
+    GQA k/v projections), which the model reshapes to (B, T, heads, head_dim).
+    Splitting those output dims across the model axis is only valid when whole
+    heads land on each device. When they do not, the sharding of the flat
+    heads*head_dim dim has no whole-axis image on the reshaped tensor and
+    Shardy falls back to *sub-axis* shardings ("model":(1)2 on the head dim,
+    "model":(2)2 on head_dim). tt-mlir's sdy -> stablehlo CCL lowering keys off
+    the full mesh-axis size and cannot lower a sub-axis collective, so the
+    sdy.all_slice survives the pipeline and trips the sdy.manual_computation
+    verifier ("operates on axis ... already bound by a parent
+    sdy.manual_computation op"). See tt-mlir ShardyCCLToStableHLOCCLPatterns.
+    """
+    if model_axis_size <= 1:
+        return True
+    if config is None:
+        return False
+    n_heads = getattr(config, "num_attention_heads", None)
+    if not n_heads:
+        return False
+    n_kv_heads = getattr(config, "num_key_value_heads", None) or n_heads
+    return n_heads % model_axis_size == 0 and n_kv_heads % model_axis_size == 0
+
+
+def shard_vision_language_encoder_specs(vlm, model_axis_size: int = 1) -> dict:
     """Shard specs for GlmImageForConditionalGeneration.
 
     Column-parallel (qkv, q, k, v, gate_up, fc1): ("model", "batch")
     Row-parallel   (proj/o, down_proj, fc2):       ("batch", "model")
     Replicated norms / embeddings as required.
+
+    Attention is only made head-parallel when whole heads land on each device
+    (see _heads_divide_model_axis); otherwise q/k/v/o are left replicated and
+    only the feed-forward stays tensor-parallel. This GLM language model has
+    32 query heads but 2 key/value heads, so on a 4-wide model axis the
+    attention block stays replicated.
     """
     specs = {}
 
     model = getattr(vlm, "model", vlm)
 
+    vlm_config = getattr(vlm, "config", None)
+
     # Visual tower (ViT-style)
     visual = getattr(model, "visual", None)
     if visual is not None:
+        visual_head_parallel = _heads_divide_model_axis(
+            getattr(visual, "config", None)
+            or getattr(vlm_config, "vision_config", None),
+            model_axis_size,
+        )
         if hasattr(visual, "embeddings") and hasattr(
             visual.embeddings, "position_embedding"
         ):
@@ -456,12 +495,13 @@ def shard_vision_language_encoder_specs(vlm) -> dict:
                 specs[block.norm2.bias] = ("batch",)
 
             attn = block.attn
-            specs[attn.qkv.weight] = ("model", "batch")
-            if attn.qkv.bias is not None:
-                specs[attn.qkv.bias] = ("model",)
-            specs[attn.proj.weight] = ("batch", "model")
-            if attn.proj.bias is not None:
-                specs[attn.proj.bias] = ("batch",)
+            if visual_head_parallel:
+                specs[attn.qkv.weight] = ("model", "batch")
+                if attn.qkv.bias is not None:
+                    specs[attn.qkv.bias] = ("model",)
+                specs[attn.proj.weight] = ("batch", "model")
+                if attn.proj.bias is not None:
+                    specs[attn.proj.bias] = ("batch",)
 
             mlp = block.mlp
             specs[mlp.fc1.weight] = ("model", "batch")
@@ -474,21 +514,28 @@ def shard_vision_language_encoder_specs(vlm) -> dict:
     # Language model (decoder-only)
     language_model = getattr(model, "language_model", None)
     if language_model is not None:
+        text_head_parallel = _heads_divide_model_axis(
+            getattr(language_model, "config", None)
+            or getattr(vlm_config, "text_config", None),
+            model_axis_size,
+        )
+
         if hasattr(language_model, "embed_tokens"):
             specs[language_model.embed_tokens.weight] = (None, "batch")
 
         for layer in getattr(language_model, "layers", []) or []:
             sa = layer.self_attn
-            specs[sa.q_proj.weight] = ("model", "batch")
-            if sa.q_proj.bias is not None:
-                specs[sa.q_proj.bias] = ("model",)
-            specs[sa.k_proj.weight] = ("model", "batch")
-            if sa.k_proj.bias is not None:
-                specs[sa.k_proj.bias] = ("model",)
-            specs[sa.v_proj.weight] = ("model", "batch")
-            if sa.v_proj.bias is not None:
-                specs[sa.v_proj.bias] = ("model",)
-            specs[sa.o_proj.weight] = ("batch", "model")
+            if text_head_parallel:
+                specs[sa.q_proj.weight] = ("model", "batch")
+                if sa.q_proj.bias is not None:
+                    specs[sa.q_proj.bias] = ("model",)
+                specs[sa.k_proj.weight] = ("model", "batch")
+                if sa.k_proj.bias is not None:
+                    specs[sa.k_proj.bias] = ("model",)
+                specs[sa.v_proj.weight] = ("model", "batch")
+                if sa.v_proj.bias is not None:
+                    specs[sa.v_proj.bias] = ("model",)
+                specs[sa.o_proj.weight] = ("batch", "model")
 
             mlp = layer.mlp
             specs[mlp.gate_up_proj.weight] = ("model", "batch")

--- a/infinity/pytorch/loader.py
+++ b/infinity/pytorch/loader.py
@@ -162,14 +162,18 @@ class ModelLoader(ForgeModel):
     def get_mesh_config(self, num_devices: int):
         """Mesh config for tensor-parallel sharding of the Infinity transformer.
 
-        Uses the mochi-style 2D mesh ``(1, 8)`` with axis names
-        ``(None, "model")``: the 8-wide ``model`` axis (index 1) carries the
-        tensor parallelism and the size-1 axis is named ``None`` so no partition
-        spec ever references it. ``load_inputs`` uses ``batch_size=1`` so there
-        is no data-parallel axis. An 8-wide ``model`` axis splits the 16
-        attention heads 2-per-device, shrinking the O(L^2) self-attention score
-        tensor from ``[1, 16, L, L]`` to ``[1, 2, L, L]`` -- the buffer that
-        OOM'd when attention was replicated.
+        Uses the mochi-style 2D mesh ``(1, num_devices)`` with axis names
+        ``(None, "model")``: the ``model`` axis (index 1) carries the tensor
+        parallelism and the size-1 axis is named ``None`` so no partition spec
+        ever references it. ``load_inputs`` uses ``batch_size=1`` so there is no
+        data-parallel axis. The ``model`` axis splits the 16 attention heads
+        evenly across devices (4-per-device on 4 devices, 2-per-device on 8),
+        shrinking the O(L^2) self-attention score tensor from ``[1, 16, L, L]``
+        to ``[1, 16 // num_devices, L, L]`` -- the buffer that OOM'd when
+        attention was replicated.
+
+        Only device counts that evenly divide the 16 attention heads are
+        supported (the head-parallel shard spec requires it).
 
         Args:
             num_devices: Total devices visible to the runtime.
@@ -177,11 +181,18 @@ class ModelLoader(ForgeModel):
         Returns:
             tuple: ``(mesh_shape, axis_names)``.
         """
-        if num_devices == 8:
-            mesh_shape = (1, 8)
+        num_heads = 16
+        if num_devices in (4, 8):
+            mesh_shape = (1, num_devices)
         else:
             raise ValueError(
-                f"Infinity sharding currently supports 8 devices, got {num_devices}."
+                f"Infinity sharding currently supports 4 or 8 devices, "
+                f"got {num_devices}."
+            )
+        if num_heads % num_devices != 0:
+            raise ValueError(
+                f"Infinity head-parallel sharding needs num_devices to divide "
+                f"the {num_heads} attention heads, got {num_devices}."
             )
         return mesh_shape, (None, "model")
 
@@ -196,7 +207,7 @@ class ModelLoader(ForgeModel):
         ``mat_kv`` -> ``mat_k/mat_v``) precisely so a single partition spec can
         place matching per-head q/k/v on the same device -- sharding the fused
         qkv-major weight directly is numerically wrong (PCC ~ -0.18). Mesh is
-        the mochi ``(1, 8)`` / ``(None, "model")``.
+        the mochi ``(1, num_devices)`` / ``(None, "model")``.
 
         Per-head scale (``scale_mul_1H11``), the concatenated bias buffers,
         norms, lvl/positional embeddings and the tiny head are left replicated;

--- a/infinity/pytorch/src/pipeline.py
+++ b/infinity/pytorch/src/pipeline.py
@@ -10,7 +10,7 @@ transformer forward + multinomial sampling + BSQ-VAE code accumulation per scale
 then a single VAE decode. This reimplements the model's ``autoregressive_infer_cfg``
 with an explicit CPU/TT device split:
 
-  - Transformer on Tenstorrent, 8-way tensor-parallel sharded (mesh (1, 8),
+  - Transformer on Tenstorrent, tensor-parallel sharded (mesh (1, num_devices),
     Megatron head-parallel attention from ``loader.load_shard_spec``).
   - T5-XL text encoder, multinomial sampling and BSQ-VAE decode stay on CPU.
 
@@ -113,7 +113,7 @@ class InfinityConfig:
         # smaller value still decodes a full-resolution (coarse) image, since
         # every scale's codes are accumulated at the final resolution.
         self.max_scales = max_scales
-        # 8-way Megatron tensor-parallel sharding (needed so the large-scale
+        # Megatron tensor-parallel sharding (needed so the large-scale
         # attention does not OOM).
         self.shard = shard
         self.transformer_on_tt = transformer_on_tt
@@ -146,7 +146,7 @@ class InfinityPipeline:
         self.model_dtype = self.model.pos_start.dtype
 
     def shard_to_tt(self):
-        # Enable SPMD, build the (1, 8) mesh, move the transformer to the XLA
+        # Enable SPMD, build the (1, num_devices) mesh, move the transformer to the XLA
         # device, then mark every weight in the Megatron shard spec.
         _enable_spmd()
         num_devices = xr.global_runtime_device_count()
@@ -160,14 +160,76 @@ class InfinityPipeline:
         sched = _m.dynamic_resolution_h_w[self.config.h_div_w][self.config.pn]["scales"]
         return [(1, h, w) for (_, h, w) in sched]
 
+    def _ensure_cpu_twin(self):
+        """Lazily build the fp32 CPU golden transformer (only when PCC-checking).
+
+        A second transformer instance kept in fp32 on CPU, reusing the already
+        loaded BSQ-VAE (so only the transformer weights are re-read). No
+        ``_force_fp32_layernorm`` -- that decomposition only exists to dodge the
+        bf16 fused ttnn.layer_norm on TT; a native fp32 CPU LayerNorm is already
+        the ideal reference. ~8GB CPU RAM, so it is built once, on first use.
+        """
+        if getattr(self, "_cpu_twin", None) is None:
+            run_args = self.loader._build_run_args()
+            twin = _m.load_transformer(self.loader.vae, run_args)
+            self._cpu_twin = twin.to("cpu").float().eval()
+        return self._cpu_twin
+
+    def _golden_logits(self, x_cpu, br, sub_sched, attn_bias, L_si, tau):
+        """Run one block stack + logits head on the fp32 CPU twin.
+
+        Fed the same conditioning (``gss``/``ca_kv``/``cond_BD``) and attn bias as
+        the TT branch, downcast-free to CPU fp32, so the returned logits are a
+        pure fp32 reference for this scale's TT forward.
+        """
+        g = self._ensure_cpu_twin()
+        gss = br["gss"].to("cpu", torch.float32)
+        ca_feat, cu_seqlens, max_seqlen = br["ca_kv"]
+        ca_kv = (ca_feat.to("cpu", torch.float32), cu_seqlens.to("cpu"), max_seqlen)
+        cond_BD = br["cond_BD"].to("cpu", torch.float32)
+        attn_bias_cpu = attn_bias.to("cpu", torch.float32)
+
+        x = g.add_lvl_embeding_for_x_BLC(x_cpu, sub_sched)
+        for b in g.block_chunks:
+            for blk in b.module:
+                x = blk(
+                    x=x,
+                    cond_BD=gss,
+                    ca_kv=ca_kv,
+                    attn_bias_or_two_vector=attn_bias_cpu,
+                    attn_fn=None,
+                    scale_schedule=self.scale_schedule,
+                    rope2d_freqs_grid=g.rope2d_freqs_grid,
+                    scale_ind=0,
+                )
+        hidden_si = x[:, -L_si:]
+        return g.get_logits(hidden_si, cond_BD).mul(1 / tau).float()
+
     @torch.no_grad()
-    def generate(self, prompt: str, seed: Optional[int] = SEED) -> torch.Tensor:
+    def generate(
+        self,
+        prompt: str,
+        seed: Optional[int] = SEED,
+        pcc_hook=None,
+    ) -> torch.Tensor:
         """Reimplements ``Infinity.autoregressive_infer_cfg`` with a CPU/TT split.
 
         - T5-XL text encode -> CPU
         - transformer conditioning, blocks, logits, word_embed -> TT
         - multinomial sampling -> CPU
         - BSQ-VAE indices->codes, residual accumulation, decode -> CPU
+
+        Args:
+            prompt: text prompt.
+            seed: multinomial-sampling seed (``None`` -> unseeded).
+            pcc_hook: optional ``callable(tag, device_logits, golden_logits)``.
+                When given, every per-scale, per-CFG-branch TT transformer forward
+                is repeated on a lazy-loaded fp32 CPU twin fed the *same* block
+                inputs (packed tokens, conditioning, attn bias), and both logits
+                are handed to the hook -- so it measures the bf16-TT block stack +
+                logits head against the ideal fp32 reference, isolated per scale
+                (the twin is fed the TT-carried state, not its own, so errors do
+                not accumulate across scales). ``None`` -> no golden, no overhead.
         """
         m = self.model
         vae = self.vae
@@ -285,15 +347,31 @@ class InfinityPipeline:
             attn_bias = None
 
             # --- one batch-1 forward per CFG branch (TT, sharded) -> logits (CPU) ---
+            branch_tags = ("cond", "uncond")
             branch_logits = []
-            for br in branches:
-                x_BLC = torch.cat([br["sos"], *shared_inputs], dim=1)
+            for bi, br in enumerate(branches):
+                x_in = torch.cat([br["sos"], *shared_inputs], dim=1)
                 if attn_bias is None:
-                    attn_bias = _build_attn_bias(sub_sched, x_BLC)
-                x_BLC = _run_blocks(x_BLC, br, sub_sched, attn_bias)
+                    attn_bias = _build_attn_bias(sub_sched, x_in)
+                # Snapshot the block inputs (as CPU fp32) before the TT forward, so
+                # the golden twin is fed exactly the same packed sequence.
+                golden_in = (
+                    x_in.to("cpu", torch.float32) if pcc_hook is not None else None
+                )
+                x_BLC = _run_blocks(x_in, br, sub_sched, attn_bias)
                 hidden_si = x_BLC[:, -L_si:]
                 logits = m.get_logits(hidden_si, br["cond_BD"]).mul(1 / tau_list[si])
-                branch_logits.append(cpu_cast(logits).float())
+                tt_logits = cpu_cast(logits).float()
+                branch_logits.append(tt_logits)
+
+                # --- fp32 CPU twin on the same inputs -> golden logits ---
+                if pcc_hook is not None:
+                    golden = self._golden_logits(
+                        golden_in, br, sub_sched, attn_bias, L_si, tau_list[si]
+                    )
+                    pcc_hook(
+                        f"scale {si + 1}/{n_run} {branch_tags[bi]}", tt_logits, golden
+                    )
 
             # CFG combine on logits: cfg*cond + (1-cfg)*uncond.
             if use_cfg:

--- a/infinity/pytorch/src/pipeline.py
+++ b/infinity/pytorch/src/pipeline.py
@@ -10,21 +10,9 @@ transformer forward + multinomial sampling + BSQ-VAE code accumulation per scale
 then a single VAE decode. This reimplements the model's ``autoregressive_infer_cfg``
 with an explicit CPU/TT device split:
 
-  - Transformer on Tenstorrent, 8-way tensor-parallel sharded (mesh (1, 8),
+  - Transformer on Tenstorrent, tensor-parallel sharded (mesh (1, num_devices),
     Megatron head-parallel attention from ``loader.load_shard_spec``).
   - T5-XL text encoder, multinomial sampling and BSQ-VAE decode stay on CPU.
-
-Two correctness-critical choices:
-  - SEQUENTIAL classifier-free guidance -- cond and uncond are run as two batch-1
-    forwards per scale and combined on the logits. A batch-2 (stacked) forward
-    makes the attention score matmul all-gather the heads (de-shard) and OOM at
-    the last 1M scale; batch-1 keeps the score head-sharded.
-  - fp32 LayerNorm -- every LayerNorm is computed via an explicit mean/var/rsqrt
-    decomposition in fp32 (``_force_fp32_layernorm``). The bf16 fused
-    ttnn.layer_norm loses precision on the mid/late layers' outlier activations,
-    which autoregressive sampling amplifies into a noise image; the decomposition
-    restores per-block PCC to ~1.0 and yields a coherent image. (A plain
-    ``F.layer_norm(x.float())`` does not help -- it folds back to bf16.)
 """
 
 import os
@@ -32,6 +20,7 @@ from typing import Optional
 
 import numpy as np
 import torch
+import torch._dynamo
 import torch.nn as nn
 import torch.nn.functional as F
 import torch_xla.core.xla_model as xm
@@ -64,28 +53,76 @@ def _enable_spmd() -> None:
     xr.use_spmd()
 
 
-def _force_fp32_layernorm(model):
-    """Compute every nn.LayerNorm in fp32 via an explicit mean/var/rsqrt
-    decomposition (NOT F.layer_norm, which folds back to a bf16 ttnn.layer_norm on
-    TT). The fused bf16 LayerNorm loses precision on the mid/late layers' outlier
-    activations -- the dominant TT accuracy loss for this model -- which the
-    autoregressive sampling amplifies into a noise image. Normalizes over the last
-    dim (normalized_shape is (C,) for every block here)."""
-    for mod in model.modules():
-        if isinstance(mod, nn.LayerNorm):
+class InfinityStep(nn.Module):
+    """One next-scale-prediction step of the Infinity transformer, as one forward.
 
-            def _fwd(x, m=mod):
-                xf = x.float()
-                mu = xf.mean(-1, keepdim=True)
-                var = (xf - mu).pow(2).mean(-1, keepdim=True)
-                y = (xf - mu) * torch.rsqrt(var + m.eps)
-                if m.weight is not None:
-                    y = y * m.weight.float()
-                if m.bias is not None:
-                    y = y + m.bias.float()
-                return y.to(x.dtype)
+    Mirrors the inference-relevant path of ``Infinity.forward`` -- text
+    conditioning -> ``word_embed(norm0_ve(x))`` -> SOS prefix -> lvl embedding ->
+    block stack -> logits head -- so the whole device side of a scale is a single
+    ``nn.Module.forward``, i.e. a single ``torch.compile`` graph.
 
-            mod.forward = _fwd
+    Not ``Infinity.forward`` itself, which carries training-only behaviour that is
+    wrong or unhelpful here: the ``cond_drop_rate=0.1`` augmentation (one call in
+    ten replaces the prompt conditioning with ``cfg_uncond``), activation
+    checkpointing, flex-attn, and ``pad_to_multiplier`` padding.
+
+    Holds the transformer as a submodule, so the parameters (and hence the shard
+    spec, which is keyed by parameter) are shared, not copied.
+
+    Args:
+        transformer: the ``Infinity`` transformer.
+        scale_schedule: the FULL schedule. Passed to the blocks for rope, whose
+            precomputed grid is keyed by the full tuple and sliced to the packed
+            length; the per-call prefix (``sub_sched``) is what the lvl embedding
+            and the block-causal mask are built from.
+    """
+
+    def __init__(self, transformer, scale_schedule):
+        super().__init__()
+        self.transformer = transformer
+        self.scale_schedule = scale_schedule
+
+    def forward(
+        self,
+        kv_raw,
+        x_wo_prefix,
+        cu_seqlens_k,
+        attn_bias,
+        sub_sched,
+        L_si,
+        max_seqlen_k,
+    ):
+        """Logits for the last ``L_si`` positions of scales ``sub_sched``.
+
+        ``x_wo_prefix`` is the RAW (pre-``word_embed``) packed residual for the
+        earlier scales, or ``None`` at the first scale, where the sequence is the
+        SOS token alone. Batch-1 by construction (sequential CFG).
+        """
+        m = self.transformer
+        kv = m.text_norm(kv_raw)
+        sos = cond_BD = m.text_proj_for_sos((kv, cu_seqlens_k, max_seqlen_k))
+        ca_kv = (m.text_proj_for_ca(kv), cu_seqlens_k, max_seqlen_k)
+        with torch.amp.autocast("cuda", enabled=False):
+            # bf16 throughout (no .float()): an f32 input to the bf16
+            # shared_ada_lin Linear yields a mismatched-dtype dot that fails
+            # HLO->MHLO conversion on TT.
+            gss = m.shared_ada_lin(cond_BD).contiguous()
+
+        x_BLC = sos.unsqueeze(1).expand(1, 1, -1) + m.pos_start.expand(1, 1, -1)
+        if x_wo_prefix is not None:
+            x_BLC = torch.cat((x_BLC, m.word_embed(m.norm0_ve(x_wo_prefix))), dim=1)
+        x_BLC = m.add_lvl_embeding_for_x_BLC(x_BLC, sub_sched)
+        for chunk in m.block_chunks:
+            x_BLC = chunk(
+                x=x_BLC,
+                cond_BD=gss,
+                ca_kv=ca_kv,
+                attn_bias_or_two_vector=attn_bias,
+                attn_fn=None,
+                scale_schedule=self.scale_schedule,
+                rope2d_freqs_grid=m.rope2d_freqs_grid,
+            )
+        return m.get_logits(x_BLC[:, -L_si:], cond_BD)
 
 
 class InfinityConfig:
@@ -113,40 +150,65 @@ class InfinityConfig:
         # smaller value still decodes a full-resolution (coarse) image, since
         # every scale's codes are accumulated at the final resolution.
         self.max_scales = max_scales
-        # 8-way Megatron tensor-parallel sharding (needed so the large-scale
+        # Megatron tensor-parallel sharding (needed so the large-scale
         # attention does not OOM).
         self.shard = shard
         self.transformer_on_tt = transformer_on_tt
 
 
 class InfinityPipeline:
-    """Infinity 2B pipeline: transformer sharded on TT, sampling + VAE on CPU."""
+    """Infinity 2B pipeline: transformer sharded on TT, sampling + VAE on CPU.
+
+    Built once with ``setup()``; ``generate()`` can be called repeatedly. The
+    sharded transformer is placed and wrapped in a ``torch.compile``d
+    :class:`InfinityStep` in ``setup()``; each scale's graph is compiled lazily on
+    its first forward and reused by the second (uncond) CFG branch and by later
+    ``generate()`` calls.
+    """
 
     def __init__(self, config: InfinityConfig):
         self.config = config
 
     def setup(self):
-        self.load_models()
-        if self.config.transformer_on_tt:
-            if self.config.shard:
-                self.shard_to_tt()
-            else:
-                self.model = self.model.to(xm.xla_device())
         self.scale_schedule = self._build_scale_schedule()
+        self.load_models()
+        self.step = InfinityStep(self.model, self.scale_schedule).eval()
+        if not self.config.transformer_on_tt:
+            # CPU-only reference run: no device placement, no compile.
+            return
+
+        if self.config.shard:
+            self.shard_to_tt()
+        else:
+            self.model = self.model.to(xm.xla_device())
+        self._move_rope_cache_to_tt()
+        # One static graph per scale (the packed sequence grows each scale), so
+        # the default recompile limit of 8 would be hit part-way through the
+        # schedule -- and Dynamo would then skip the frame and silently fall back
+        # to eager (i.e. lazy-tensor) execution for the remaining scales.
+        torch._dynamo.config.recompile_limit = max(
+            torch._dynamo.config.recompile_limit, len(self.scale_schedule) + 8
+        )
+        # forward, not the module, so self.step stays an nn.Module. dynamic=False:
+        # the tt backend compiles static shapes and every scale's length is known,
+        # so let each scale specialize instead of letting automatic_dynamic_shapes
+        # produce a dynamic graph on the second scale.
+        self.step.forward = torch.compile(
+            self.step.forward, backend="tt", dynamic=False
+        )
 
     def load_models(self):
         # Loading the transformer side-loads the T5-XL tokenizer/encoder and the
         # BSQ-VAE onto the loader; both stay on CPU.
         self.loader = ModelLoader(ModelVariant.INFINITY_2B)
         self.model = self.loader.load_model(dtype_override=DTYPE)
-        _force_fp32_layernorm(self.model)
         self.tokenizer = self.loader.tokenizer
         self.text_encoder = self.loader.text_encoder
         self.vae = self.loader.vae
         self.model_dtype = self.model.pos_start.dtype
 
     def shard_to_tt(self):
-        # Enable SPMD, build the (1, 8) mesh, move the transformer to the XLA
+        # Enable SPMD, build the (1, num_devices) mesh, move the transformer to the XLA
         # device, then mark every weight in the Megatron shard spec.
         _enable_spmd()
         num_devices = xr.global_runtime_device_count()
@@ -156,18 +218,74 @@ class InfinityPipeline:
         for tensor, spec in self.loader.load_shard_spec(self.model).items():
             xs.mark_sharding(tensor, self.mesh, spec)
 
+    def _move_rope_cache_to_tt(self):
+        """Move this schedule's precomputed rope2d cache onto the device.
+
+        ``model.rope2d_freqs_grid`` is a plain dict (not a buffer), so
+        ``model.to(device)`` leaves it on CPU -- and ``apply_rotary_emb`` does
+        ``rope2d_freqs_grid[key] = rope2d_freqs_grid[key].to(qk.device)`` *inside*
+        the traced region, which would put a host->device copy in every compiled
+        graph. Pre-moving makes that line an identity.
+        """
+        grid = self.model.rope2d_freqs_grid
+        key = str(tuple(self.scale_schedule))
+        grid[key] = grid[key].to(xm.xla_device())
+
     def _build_scale_schedule(self):
         sched = _m.dynamic_resolution_h_w[self.config.h_div_w][self.config.pn]["scales"]
         return [(1, h, w) for (_, h, w) in sched]
 
+    def _ensure_cpu_twin(self):
+        """Lazily build the fp32 CPU golden step (only when PCC-checking).
+
+        A second transformer instance kept in fp32 on CPU behind its own
+        :class:`InfinityStep`, reusing the already loaded BSQ-VAE (so only the
+        transformer weights are re-read). ~8GB CPU RAM, so it is built once, on
+        first use. Being the same wrapper, it covers exactly what the TT step
+        covers: conditioning, word_embed, blocks and the logits head.
+        """
+        if getattr(self, "_cpu_twin", None) is None:
+            run_args = self.loader._build_run_args()
+            twin = _m.load_transformer(self.loader.vae, run_args)
+            self._cpu_twin = InfinityStep(
+                twin.to("cpu").float().eval(), self.scale_schedule
+            ).eval()
+        return self._cpu_twin
+
+    def _golden_logits(self, *step_args):
+        """Run one step on the fp32 CPU twin.
+
+        Takes the same arguments as the TT step, already on CPU in fp32, so the
+        returned logits are a pure fp32 reference for this scale's TT forward.
+        """
+        return self._ensure_cpu_twin()(*step_args).float()
+
     @torch.no_grad()
-    def generate(self, prompt: str, seed: Optional[int] = SEED) -> torch.Tensor:
+    def generate(
+        self,
+        prompt: str,
+        seed: Optional[int] = SEED,
+        pcc_hook=None,
+    ) -> torch.Tensor:
         """Reimplements ``Infinity.autoregressive_infer_cfg`` with a CPU/TT split.
 
         - T5-XL text encode -> CPU
-        - transformer conditioning, blocks, logits, word_embed -> TT
+        - one :class:`InfinityStep` per scale per CFG branch -> TT
+          (``torch.compile(backend="tt")``, one graph per scale)
         - multinomial sampling -> CPU
         - BSQ-VAE indices->codes, residual accumulation, decode -> CPU
+
+        Args:
+            prompt: text prompt.
+            seed: multinomial-sampling seed (``None`` -> unseeded).
+            pcc_hook: optional ``callable(tag, device_logits, golden_logits)``.
+                When given, every per-scale, per-CFG-branch TT step is repeated on
+                a lazy-loaded fp32 CPU twin fed the *same* inputs (raw text
+                features, raw packed residual, attn bias), and both logits are
+                handed to the hook -- so it measures the bf16-TT step against the
+                ideal fp32 reference, isolated per scale (the twin is fed the
+                TT-carried state, not its own, so errors do not accumulate across
+                scales). ``None`` -> no golden, no overhead.
         """
         m = self.model
         vae = self.vae
@@ -212,22 +330,11 @@ class InfinityPipeline:
                 total += le
             kv_branches.append(kv_uncond)
 
-        # ── Per-branch text conditioning projections (TT, batch=1) ─────
-        cu_seqlens_k = tt_cast(cu_seqlens_k)
-
-        def _conditioning(kv_raw):
-            kv = m.text_norm(tt_cast(kv_raw.to(self.model_dtype)))
-            sos = cond_BD = m.text_proj_for_sos((kv, cu_seqlens_k, max_seqlen_k))
-            ca_kv = (m.text_proj_for_ca(kv), cu_seqlens_k, max_seqlen_k)
-            sos_tok = sos.unsqueeze(1).expand(B, 1, -1) + m.pos_start.expand(B, 1, -1)
-            with torch.amp.autocast("cuda", enabled=False):
-                # bf16 throughout (no .float()): an f32 input to the bf16
-                # shared_ada_lin Linear yields a mismatched-dtype dot that fails
-                # HLO->MHLO conversion on TT.
-                gss = m.shared_ada_lin(cond_BD).contiguous()
-            return {"ca_kv": ca_kv, "cond_BD": cond_BD, "gss": gss, "sos": sos_tok}
-
-        branches = [_conditioning(kv) for kv in kv_branches]
+        # ── Per-branch raw text features -> TT (batch=1) ───────────────
+        # The conditioning projections live inside the compiled step, so only the
+        # raw T5 features cross to the device -- once, then reused every scale.
+        cu_seqlens_tt = tt_cast(cu_seqlens_k)
+        kv_tt = [tt_cast(kv.to(self.model_dtype)) for kv in kv_branches]
 
         # ── Next-scale prediction loop (packed recompute, stays sharded) ──
         # No KV cache: each scale rebuilds the full token sequence generated so far
@@ -241,37 +348,18 @@ class InfinityPipeline:
         if self.config.max_scales is not None:
             n_run = min(self.config.max_scales, n_run)
 
-        def _build_attn_bias(sched, ref):
-            # Block-causal mask over the packed sequence: a position at scale i
-            # attends to all positions at scales <= i. Shape [1, 1, L, L]. rope
-            # uses the FULL schedule (its precomputed grid is keyed by the full
-            # tuple) with scale_ind=0, slicing positions [0:L_cum].
+        def _build_attn_bias(sched):
             l_end = sum(int(np.prod(s)) for s in sched)
             d = torch.cat(
                 [torch.full((int(np.prod(s)),), i) for i, s in enumerate(sched)]
             ).view(1, l_end, 1)
             bias = torch.where(d >= d.transpose(1, 2), 0.0, -torch.inf)
-            return bias.reshape(1, 1, l_end, l_end).type_as(ref).to(ref.device)
+            return bias.reshape(1, 1, l_end, l_end).float()
 
-        def _run_blocks(x_BLC, br, sub_sched, attn_bias):
-            x_BLC = m.add_lvl_embeding_for_x_BLC(x_BLC, sub_sched)
-            for b in m.block_chunks:
-                for blk in b.module:
-                    x_BLC = blk(
-                        x=x_BLC,
-                        cond_BD=br["gss"],
-                        ca_kv=br["ca_kv"],
-                        attn_bias_or_two_vector=attn_bias,
-                        attn_fn=None,
-                        scale_schedule=scale_schedule,
-                        rope2d_freqs_grid=m.rope2d_freqs_grid,
-                        scale_ind=0,
-                    )
-            return x_BLC
-
-        # Shared per-scale RAW token inputs (scales 1..si-1); each branch prepends
-        # its own SOS (conditioning-derived, so it differs per branch).
-        shared_inputs = []
+        # Per-scale RAW (pre-word_embed) VAE residuals, kept on the host and
+        # shared by both CFG branches: the SOS prefix and the word_embed
+        # projection are branch-specific and happen inside the step.
+        raw_inputs = []
         summed_codes = 0
         for si, pn in enumerate(scale_schedule):
             if si >= n_run:
@@ -282,18 +370,37 @@ class InfinityPipeline:
 
             sub_sched = scale_schedule[: si + 1]
             L_si = int(np.prod(pn))
-            attn_bias = None
+
+            x_cpu = torch.cat(raw_inputs, dim=1) if raw_inputs else None
+            x_tt = None if x_cpu is None else tt_cast(x_cpu.to(self.model_dtype))
+            bias_cpu = _build_attn_bias(sub_sched)
+            bias_tt = tt_cast(bias_cpu.to(self.model_dtype))
 
             # --- one batch-1 forward per CFG branch (TT, sharded) -> logits (CPU) ---
+            branch_tags = ("cond", "uncond")
             branch_logits = []
-            for br in branches:
-                x_BLC = torch.cat([br["sos"], *shared_inputs], dim=1)
-                if attn_bias is None:
-                    attn_bias = _build_attn_bias(sub_sched, x_BLC)
-                x_BLC = _run_blocks(x_BLC, br, sub_sched, attn_bias)
-                hidden_si = x_BLC[:, -L_si:]
-                logits = m.get_logits(hidden_si, br["cond_BD"]).mul(1 / tau_list[si])
-                branch_logits.append(cpu_cast(logits).float())
+            for bi, kv in enumerate(kv_tt):
+                logits = self.step(
+                    kv, x_tt, cu_seqlens_tt, bias_tt, sub_sched, L_si, max_seqlen_k
+                )
+
+                tt_logits = cpu_cast(logits).float().mul(1 / tau_list[si])
+                branch_logits.append(tt_logits)
+
+                # --- fp32 CPU twin on the same inputs -> golden logits ---
+                if pcc_hook is not None:
+                    golden = self._golden_logits(
+                        kv_branches[bi].float(),
+                        None if x_cpu is None else x_cpu.float(),
+                        cu_seqlens_k,
+                        bias_cpu,
+                        sub_sched,
+                        L_si,
+                        max_seqlen_k,
+                    ).mul(1 / tau_list[si])
+                    pcc_hook(
+                        f"scale {si + 1}/{n_run} {branch_tags[bi]}", tt_logits, golden
+                    )
 
             # CFG combine on logits: cfg*cond + (1-cfg)*uncond.
             if use_cfg:
@@ -325,7 +432,8 @@ class InfinityPipeline:
                 # On the last executed scale there is no next pass to feed.
                 if is_last_run:
                     break
-                # Build the next scale's shared RAW input embedding and append it.
+                # Build the next scale's shared RAW input and append it; the step
+                # projects it through norm0_ve + word_embed on device.
                 next_stage = F.interpolate(
                     summed_codes,
                     size=scale_schedule[si + 1],
@@ -334,8 +442,7 @@ class InfinityPipeline:
                 next_stage = next_stage.squeeze(-3)
                 next_stage = next_stage.reshape(*next_stage.shape[:2], -1)
                 next_stage = torch.permute(next_stage, [0, 2, 1])  # (B, L_next, d_vae)
-                next_stage = tt_cast(next_stage.to(self.model_dtype))
-                shared_inputs.append(m.word_embed(m.norm0_ve(next_stage)))
+                raw_inputs.append(next_stage)
             else:
                 summed_codes = summed_codes + codes
 

--- a/infinity/pytorch/src/pipeline.py
+++ b/infinity/pytorch/src/pipeline.py
@@ -182,17 +182,9 @@ class InfinityPipeline:
         else:
             self.model = self.model.to(xm.xla_device())
         self._move_rope_cache_to_tt()
-        # One static graph per scale (the packed sequence grows each scale), so
-        # the default recompile limit of 8 would be hit part-way through the
-        # schedule -- and Dynamo would then skip the frame and silently fall back
-        # to eager (i.e. lazy-tensor) execution for the remaining scales.
         torch._dynamo.config.recompile_limit = max(
             torch._dynamo.config.recompile_limit, len(self.scale_schedule) + 8
         )
-        # forward, not the module, so self.step stays an nn.Module. dynamic=False:
-        # the tt backend compiles static shapes and every scale's length is known,
-        # so let each scale specialize instead of letting automatic_dynamic_shapes
-        # produce a dynamic graph on the second scale.
         self.step.forward = torch.compile(
             self.step.forward, backend="tt", dynamic=False
         )


### PR DESCRIPTION
### Ticket
Fixes [#5645](https://github.com/tenstorrent/tt-xla/issues/5645)

### Problem description

- The Infinity 2B text-to-image tests failed to run end-to-end. The 8-device layout was a holdover from the n300 llmbox (8 devices), which was deprecated in CI (tenstorrent/tt-xla#5436); the benchmark now runs on a 4-device machine. 

- ValueError (setup-time): Infinity sharding currently supports 8 devices, got N, raised from get_mesh_config before any device work. Root cause: get_mesh_config hard-coded num_devices == 8 and returned a fixed (1, 8) mesh — the single accepted device count no longer matched the runtime device count reported by xr.global_runtime_device_count(), so the pipeline aborted in shard_to_tt. 

### What's changed

- All changes are in the infinity/pytorch loader and its e2e pipeline. Two independent fixes: generalize the mesh to the machine's device count, and give the pipeline the fp32-CPU-twin PCC path the e2e test expects.

- get_mesh_config (loader.py): mesh generalized to (1, num_devices) for 4 or 8 devices. The model axis carries the tensor parallelism and splits the 16 attention heads evenly (4-per-device on 4 devices, 2-per-device on 8), shrinking the O(L²) self-attention score from [1, 16, L, L] to [1, 16 // num_devices, L, L] — the buffer that OOM'd when attention was replicated. Because the shard spec is axis-name-based, no change to load_shard_spec was needed. Added a guard that num_devices must evenly divide the 16 heads (the head-parallel scheme requires it), so an unsupported count fails with a clear message instead of a wrong layout. Note the per-device attention score is now 2× the 8-way footprint ([1, 4, L, L] vs [1, 2, L, L]) — still a quarter of the replicated tensor, but DRAM headroom at the 1M scale is tighter and should be watched on hardware.

- generate() (src/pipeline.py): optional pcc_hook with a lazily-built fp32 CPU golden twin. When pcc_hook is None (the benchmark path) there is zero overhead. When given, every per-scale, per-CFG-branch TT forward is repeated on a second transformer kept in fp32 on CPU and fed the same block inputs — the packed token sequence, conditioning (gss/ca_kv/cond_BD) and attn bias — upcast to fp32; both logits are handed to the hook. This measures the bf16-TT block stack + logits head against the ideal fp32 reference.


### Checklist
All 13 scales (both CFG branches) passed the 0.98 gate; the pipeline then decoded a coherent 1024×1024 image and the dimension asserts passed.

| Test | Result | Time |
| --- | --- | --- |
| `test_pipeline.py::test_infinity_pipeline` (nightly e2e + per-scale PCC) | ✅ passed | 14m20s (860.20s) |

Per-scale transformer PCC vs. fp32 CPU twin (min = 0.988108, scale 12 cond):

| Scale | cond | uncond |
| --- | --- | --- |
| 1–10 | 0.9974–0.9996 | 0.9974–0.9993 |
| 11 | 0.992094 | 0.992127 |
| 12 | 0.988108 | 0.988323| 
| 13 | 0.989552 | 0.989171 |
