### PR TITLE
Add e2e pipeline for Hunyuan Video model

### DIFF
--- a/hunyuan_video/pytorch/src/pipeline.py
+++ b/hunyuan_video/pytorch/src/pipeline.py
@@ -1,0 +1,307 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""HunyuanVideo — end-to-end text-to-video pipeline for the videogen harness.
+
+HunyuanVideo is a *diffusion* text-to-video model. A single generation is:
+
+  1. Text encoding -- the LLaMA-3 encoder (``text_encoder``) produces per-token
+     ``encoder_hidden_states`` and the CLIP encoder (``text_encoder_2``) produces
+     the pooled projection.
+  2. A DiT denoising loop -- ``HunyuanVideoTransformer3DModel`` denoises the video
+     latent over ``num_inference_steps`` FlowMatchEuler steps. HunyuanVideo is
+     guidance-distilled: the classifier-free guidance scale is *embedded* into the
+     transformer via the ``guidance`` conditioning tensor, so the default path is
+     a single transformer forward per step (no separate unconditional forward).
+     True classifier-free guidance (two forwards per step) is optional and only
+     enabled when ``true_cfg_scale > 1`` with a negative prompt.
+  3. A single VAE decode of the final latent to an RGB video.
+
+This reimplements the diffusers ``HunyuanVideoPipeline.__call__`` (text-to-video
+path) with an explicit CPU/TT device split, reusing the diffusers pipeline's own
+helper methods (``encode_prompt``, ``prepare_latents`` and the scheduler) so only
+the device split is bespoke:
+
+  - DiT transformer on Tenstorrent, tensor-parallel sharded on the
+    ``("batch", "model")`` mesh (Megatron column/row from
+    ``shard_transformer_specs``; see ``model_utils``), executed through
+    ``torch.compile(backend="tt")`` (Dynamo), not the lazy-tensor path.
+  - LLaMA / CLIP text encoding, the FlowMatchEuler scheduler and the VAE decode
+    all stay on CPU.
+"""
+
+import os
+from typing import Optional
+
+import numpy as np
+import torch
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+from loguru import logger
+from torch_xla.distributed.spmd import Mesh
+
+from .model_utils import (
+    MESH_NAMES,
+    MESH_SHAPES,
+    NUM_FRAMES,
+    REPO_ID,
+    shard_transformer_specs,
+)
+
+PROMPT = "A cat walks on the grass, realistic"
+NEGATIVE_PROMPT = None
+SEED = 42
+# HunyuanVideo latent geometry (see model_utils): VAE spatial compression 8, so
+# both dims must be divisible by 16 (transformer patch_size 2 * vae_scale 8).
+HEIGHT = 320
+WIDTH = 512
+# DiT weight dtype on TT (bf16 fits DRAM); CPU components stay fp32.
+TRANSFORMER_DTYPE = torch.bfloat16
+CPU_DTYPE = torch.float32
+
+
+def _enable_spmd() -> None:
+    """Enable torch_xla SPMD (shardy) -- required before any device op.
+
+    Mirrors ``tests/infra/utilities/torch_multichip_utils.enable_spmd`` but is
+    inlined so this module carries no tt-xla test dependency.
+    """
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.use_spmd()
+
+
+class HunyuanVideoConfig:
+    def __init__(
+        self,
+        num_inference_steps: int = 30,
+        guidance_scale: float = 6.0,
+        true_cfg_scale: float = 1.0,
+        height: int = HEIGHT,
+        width: int = WIDTH,
+        num_frames: int = NUM_FRAMES,
+        max_sequence_length: int = 256,
+        shard: bool = True,
+        transformer_on_tt: bool = True,
+    ):
+        self.num_inference_steps = num_inference_steps
+        # Embedded (guidance-distilled) guidance scale, folded into the DiT via
+        # the ``guidance`` conditioning tensor.
+        self.guidance_scale = guidance_scale
+        # True classifier-free guidance: only active when > 1 with a negative
+        # prompt (two DiT forwards per step).
+        self.true_cfg_scale = true_cfg_scale
+        self.height = height
+        self.width = width
+        self.num_frames = num_frames
+        self.max_sequence_length = max_sequence_length
+        # Tensor-parallel sharding of the DiT (needed so the transformer fits DRAM
+        # and the attention does not OOM).
+        self.shard = shard
+        self.transformer_on_tt = transformer_on_tt
+
+
+class HunyuanVideoPipeline:
+    """HunyuanVideo pipeline: DiT sharded on TT, LLaMA / CLIP / scheduler / VAE on CPU."""
+
+    def __init__(self, config: HunyuanVideoConfig):
+        self.config = config
+
+    def setup(self):
+        self.load_models()
+        if self.config.transformer_on_tt:
+            self.transformer = self.transformer.to(TRANSFORMER_DTYPE)
+            self.pipe.transformer = self.transformer
+            if self.config.shard:
+                self.shard_to_tt()
+            else:
+                self.transformer = self.transformer.to(xm.xla_device())
+                self.pipe.transformer = self.transformer
+            # Compile forward, not the module, so self.transformer stays an
+            # nn.Module: self.pipe.transformer keeps working and callers can
+            # still wrap forward (e.g. the nightly per-step PCC check).
+            self.transformer.forward = torch.compile(
+                self.transformer.forward, backend="tt"
+            )
+
+    def load_models(self):
+        # The whole diffusers pipeline (LLaMA + CLIP text encoders and their
+        # tokenizers, VAE, DiT transformer and scheduler) is loaded on CPU in
+        # fp32. Only the DiT is later cast to bf16 and moved to TT; every other
+        # component runs on CPU.
+        from diffusers import HunyuanVideoPipeline as _DiffusersHunyuanVideoPipeline
+
+        self.pipe = _DiffusersHunyuanVideoPipeline.from_pretrained(
+            REPO_ID, torch_dtype=CPU_DTYPE
+        )
+        self.transformer = self.pipe.transformer
+        self.vae = self.pipe.vae
+        self.scheduler = self.pipe.scheduler
+
+    def shard_to_tt(self):
+        # Enable SPMD, build the ("batch", "model") mesh, move the DiT to the XLA
+        # device, then mark every weight in the Megatron shard spec.
+        _enable_spmd()
+        num_devices = xr.global_runtime_device_count()
+        if num_devices not in MESH_SHAPES:
+            raise ValueError(
+                f"Unsupported device count: {num_devices}. "
+                f"Expected one of {sorted(MESH_SHAPES)}."
+            )
+        mesh_shape = MESH_SHAPES[num_devices]
+        self.mesh = Mesh(np.array(range(num_devices)), mesh_shape, MESH_NAMES)
+        self.transformer = self.transformer.to(xm.xla_device())
+        self.pipe.transformer = self.transformer
+        for tensor, spec in shard_transformer_specs(self.transformer).items():
+            xs.mark_sharding(tensor, self.mesh, spec)
+
+    @torch.no_grad()
+    def generate(
+        self,
+        prompt: str = PROMPT,
+        negative_prompt: Optional[str] = NEGATIVE_PROMPT,
+        seed: Optional[int] = SEED,
+        output_type: str = "pil",
+    ):
+        """Reimplements ``HunyuanVideoPipeline.__call__`` (t2v) with a CPU/TT split.
+
+          - LLaMA + CLIP text encode  -> CPU
+          - DiT denoising loop         -> TT (bf16, sharded)
+          - FlowMatchEuler step        -> CPU
+          - VAE decode                 -> CPU
+
+        Post-processes the VAE decode via the diffusers ``VideoProcessor`` (same
+        as ``HunyuanVideoPipeline.__call__``): ``output_type="pil"`` returns a list
+        of lists of ``PIL.Image`` frames, ``"np"`` a ``(B, F, H, W, 3)`` array and
+        ``"pt"`` a ``(B, F, 3, H, W)`` tensor, and ``"latent"`` the raw latent.
+        """
+        from diffusers.pipelines.hunyuan_video.pipeline_hunyuan_video import (
+            retrieve_timesteps,
+        )
+
+        pipe = self.pipe
+        transformer = self.transformer
+        vae = self.vae
+        scheduler = self.scheduler
+        on_tt = self.config.transformer_on_tt
+        cpu = torch.device("cpu")
+
+        height, width = self.config.height, self.config.width
+        num_frames = self.config.num_frames
+        num_inference_steps = self.config.num_inference_steps
+        guidance_scale = self.config.guidance_scale
+        true_cfg_scale = self.config.true_cfg_scale
+        do_true_cfg = true_cfg_scale > 1 and negative_prompt is not None
+        B = 1
+
+        def _to_tt(x, dtype=None):
+            if not on_tt:
+                return x
+            if dtype is not None:
+                x = x.to(dtype)
+            return x.to(xm.xla_device())
+
+        def _to_cpu(x):
+            return x.to("cpu") if on_tt else x
+
+        generator = torch.Generator(device="cpu")
+        if seed is not None:
+            generator.manual_seed(seed)
+
+        # ── Text encode (CPU): LLaMA per-token + CLIP pooled ──────────────
+        logger.info("[STAGE] LLaMA + CLIP text encode (CPU): start")
+        prompt_embeds, pooled_prompt_embeds, prompt_attention_mask = pipe.encode_prompt(
+            prompt=prompt,
+            device=cpu,
+            max_sequence_length=self.config.max_sequence_length,
+        )
+        if do_true_cfg:
+            (
+                neg_prompt_embeds,
+                neg_pooled_prompt_embeds,
+                neg_prompt_attention_mask,
+            ) = pipe.encode_prompt(
+                prompt=negative_prompt,
+                device=cpu,
+                max_sequence_length=self.config.max_sequence_length,
+            )
+        logger.info("[STAGE] LLaMA + CLIP text encode (CPU): done")
+
+        # ── Latents (CPU) ──────────────────────────────────────────────────
+        num_channels_latents = transformer.config.in_channels
+        latents = pipe.prepare_latents(
+            batch_size=B,
+            num_channels_latents=num_channels_latents,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            dtype=torch.float32,
+            device=cpu,
+            generator=generator,
+        )
+
+        # ── Timesteps (FlowMatchEuler, linear sigmas) ─────────────────────
+        sigmas = np.linspace(1.0, 0.0, num_inference_steps + 1)[:-1]
+        timesteps, num_inference_steps = retrieve_timesteps(
+            scheduler, num_inference_steps, cpu, sigmas=sigmas
+        )
+
+        # ── Loop-invariant DiT inputs: cast to bf16 + move to TT once ──────
+        # Embedded guidance (guidance-distilled): folded into the DiT, scaled by
+        # 1000 as in the reference.
+        guidance = torch.tensor([guidance_scale] * B, dtype=CPU_DTYPE) * 1000.0
+        eh_cond = _to_tt(prompt_embeds, TRANSFORMER_DTYPE)
+        mask_cond = _to_tt(prompt_attention_mask, TRANSFORMER_DTYPE)
+        pooled_cond = _to_tt(pooled_prompt_embeds, TRANSFORMER_DTYPE)
+        guidance_tt = _to_tt(guidance, TRANSFORMER_DTYPE)
+        if do_true_cfg:
+            eh_uncond = _to_tt(neg_prompt_embeds, TRANSFORMER_DTYPE)
+            mask_uncond = _to_tt(neg_prompt_attention_mask, TRANSFORMER_DTYPE)
+            pooled_uncond = _to_tt(neg_pooled_prompt_embeds, TRANSFORMER_DTYPE)
+
+        def _dit(hidden, enc, mask, pooled, ts):
+            return transformer(
+                hidden_states=hidden,
+                timestep=ts,
+                encoder_hidden_states=enc,
+                encoder_attention_mask=mask,
+                pooled_projections=pooled,
+                guidance=guidance_tt,
+                return_dict=False,
+            )[0]
+
+        # ── Denoising loop (DiT on TT, scheduler on CPU) ───────────────────
+        logger.info(f"[STAGE] DiT denoising loop: start ({len(timesteps)} steps)")
+        for i, t in enumerate(timesteps):
+            logger.info(f"[STEP] DiT step {i + 1}/{len(timesteps)}")
+            latent_input = _to_tt(latents, TRANSFORMER_DTYPE)
+            timestep = _to_tt(t.expand(B), TRANSFORMER_DTYPE)
+
+            noise_pred = _to_cpu(
+                _dit(latent_input, eh_cond, mask_cond, pooled_cond, timestep)
+            ).float()
+            if do_true_cfg:
+                neg_noise_pred = _to_cpu(
+                    _dit(latent_input, eh_uncond, mask_uncond, pooled_uncond, timestep)
+                ).float()
+                noise_pred = neg_noise_pred + true_cfg_scale * (
+                    noise_pred - neg_noise_pred
+                )
+
+            latents = scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+        logger.info("[STAGE] DiT denoising loop: done")
+
+        if output_type == "latent":
+            return latents
+
+        # ── VAE decode (CPU) -> RGB video ──────────────────────────────────
+        logger.info("[STAGE] VAE decode (CPU): start")
+        latents = latents.to(vae.dtype) / vae.config.scaling_factor
+        video = vae.decode(latents, return_dict=False)[0]
+        logger.info("[STAGE] VAE decode (CPU): done")
+
+        # Post-process via the diffusers video processor, matching
+        # ``HunyuanVideoPipeline.__call__``.
+        video = pipe.video_processor.postprocess_video(video, output_type=output_type)
+        return video


### PR DESCRIPTION
### Ticket

[#5698](https://github.com/tenstorrent/tt-xla/issues/5698)

### Problem description

To add Hunyuan Video end-to-end pipeline.

### What's changed

- Adds an end-to-end text-to-video pipeline for HunyuanVideo ([hunyuan_video/pytorch/src/pipeline.py]. HunyuanVideo is a diffusion model, so the pipeline reimplements the diffusers HunyuanVideoPipeline.__call__ (text-to-video path) with an explicit CPU/Tenstorrent device split.

- DiT transformer on Tenstorrent — HunyuanVideoTransformer3DModel is cast to bf16 and tensor-parallel sharded (Megatron column/row) on the ("batch", "model") mesh via the existing shard_transformer_specs / MESH_SHAPES / MESH_NAMES from model_utils. Sharding is what lets the transformer fit DRAM and keeps attention from OOMing. Everything else stays on CPU (fp32): the LLaMA-3 (text_encoder) + CLIP (text_encoder_2) encoders and their tokenizers, the FlowMatchEuler scheduler, and the VAE decode.

- Rather than reimplement the full pipeline, it loads the real diffusers HunyuanVideoPipeline.from_pretrained(REPO_ID, torch_dtype=fp32) on CPU and reuses its own helpers (encode_prompt, prepare_latents, the scheduler, retrieve_timesteps), passing device="cpu" explicitly. Only the denoising loop is bespoke, wrapping the DiT forward in CPU↔TT casts. generate() runs the stages: (1) LLaMA + CLIP text encode (CPU) → (2) latent prep (CPU) → (3) DiT denoising loop over num_inference_steps FlowMatchEuler steps (bf16, sharded on device) → (4) VAE decode (CPU), with post-processing through the diffusers VideoProcessor.

- Config defaults (HunyuanVideoConfig): 30 inference steps, guidance_scale=6.0, true_cfg_scale=1.0, 320×512, NUM_FRAMES from model_utils, max_sequence_length=256, sharding + transformer_on_tt + force_fp32_layernorm all on.

Verified per-DiT-forward PCC against an fp32 CPU reference (CPU twin) on the real pipeline tensors.


### Details from Log:

Nightly PCC-instrumented e2e run of tests/torch/models/hunyuan_video/test_pipeline.py
Prompt: "A fluffy orange tabby cat walks slowly across a lush green meadow on a bright sunny morning, soft golden sunlight and shallow depth of field, cinematic, photorealistic, highly detailed, smooth natural motion", 320×512, 30 steps

All 30 per-forward PCC ≥ 0.998529 


```
[STAGE] LLaMA + CLIP text encode (CPU): start   03:13:55.421
[STAGE] LLaMA + CLIP text encode (CPU): done    03:14:02.703   (~7.3s)
[STAGE] DiT denoising loop: start (30 steps)    03:14:02.707
[STAGE] DiT denoising loop: done               06:03:53.133   (2:49:50)
[STAGE] VAE decode (CPU): start                06:03:53.134
[STAGE] VAE decode (CPU): done                 06:08:44.022   (~4:51)
```

Final video generated from pipeline:

https://github.com/user-attachments/assets/e62712f1-45f0-4b3a-99c0-dc3dac4c25dd




