### PR TITLE
[deepseek_v4] Use torch.no_grad() instead of torch.inference_mode() (fixes torch 2.11 TP compile regression)

### DIFF
--- a/deepseek_v4/modified_model/model.py
+++ b/deepseek_v4/modified_model/model.py
@@ -958,7 +958,7 @@ class MTPBlock(Block):
         self.embed: ParallelEmbedding = None
         self.head: ParallelHead = None
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def forward(
         self, x: torch.Tensor, start_pos: int, input_ids: torch.Tensor
     ) -> torch.Tensor:
@@ -1004,7 +1004,7 @@ class Transformer(nn.Module):
             self.hc_head_base = nn.Parameter(torch.empty(hc_mult))
             self.hc_head_scale = nn.Parameter(torch.empty(1))
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def forward(self, input_ids: torch.Tensor, start_pos: int = 0):
         h = self.embed(input_ids)
         h = h.unsqueeze(2).repeat(1, 1, self.hc_mult, 1)

--- a/deepseek_v4/modified_model/model_decode_opt.py
+++ b/deepseek_v4/modified_model/model_decode_opt.py
@@ -1144,7 +1144,7 @@ class MTPBlock(Block):
         self.embed: ParallelEmbedding = None
         self.head: ParallelHead = None
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def forward(
         self, x: torch.Tensor, start_pos, input_ids: torch.Tensor
     ) -> torch.Tensor:
@@ -1190,7 +1190,7 @@ class Transformer(nn.Module):
             self.hc_head_base = nn.Parameter(torch.empty(hc_mult))
             self.hc_head_scale = nn.Parameter(torch.empty(1))
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def forward(
         self, input_ids: torch.Tensor, start_pos=0, return_hidden_states: bool = False
     ):


### PR DESCRIPTION
## What

Replace `@torch.inference_mode()` with `@torch.no_grad()` on the `deepseek_v4` modified-model forwards (`model_decode_opt.py` and `model.py`).

## Why

Under **PyTorch 2.11**, inference-mode tensors are incompatible with the tt-xla (torch-xla PJRT) backend's AOTAutograd functionalization path. The tensor-parallel `deepseek_v4` tests fail during compile with a cryptic:

```
torch._dynamo.exc.BackendCompilerFailed: backend='tt' raised:
RuntimeError: <weakref at 0x...; to 'torch.storage.UntypedStorage' at 0x...>
```

That `RuntimeError` is `torch.fx.Interpreter` re-raising (with just the weakref as its message) an underlying **`KeyError`** from:

```
torch/_subclasses/functional_tensor.py:171, in __new__
    out._inference_mode_base = mode._storage_to_base[out.elem.untyped_storage()]
```

This branch only runs when `torch.is_inference_mode_enabled()` (plus `auto_functionalized_v2`) is true. For a **sharded** parameter (`hc_attn_fn`), the tensor is a non-base view whose base storage was never registered in `_storage_to_base`, so the weak-dict lookup `KeyError`s. Bypassing that branch only surfaces a second inference-mode conflict: `RuntimeError: Cannot set version_counter for inference tensor`.

`torch.no_grad()` produces normal tensors (with version counters and no `_storage_to_base` tracking), which functionalization handles correctly, while preserving identical forward-only semantics for these tests.

## Validation

On n300-llmbox, all three previously-failing Group-C tests now pass:

- `test_deepseek_v4_tp.py::test_transformer_prefill[2-deepseek-ai/DeepSeek-V4-Flash]`
- `test_deepseek_v4_tp.py::test_transformer_prefill[3-deepseek-ai/DeepSeek-V4-Flash]`
- `test_deepseek_v4_tp.py::test_transformer_decode[1-4-expected_pcc0-deepseek-ai/DeepSeek-V4-Flash]`

This is one of the new-this-week (2026-07-09→07-15 window) n300-llmbox nightly regressions; it reproduces deterministically and was traced to the PyTorch 2.11 uplift. `model.py` is changed for the same latent reason (same decorator pattern), though it is not exercised by the failing TP tests.

> Note for the consuming repo: after this merges, the `tt-forge-models` submodule pin in `tenstorrent/tt-xla` must be uplifted to pick up the fix.

---
*Change identified and validated by Claude (Claude Code) during llmbox nightly regression triage.*
