### PR TITLE
[diffusiongemma] Drop decoder_input_ids uint32-remainder workaround

### DIFF
--- a/diffusiongemma/pytorch/loader.py
+++ b/diffusiongemma/pytorch/loader.py
@@ -11,7 +11,6 @@ MoE backbone that denoises a block of tokens instead of decoding left-to-right.
 
 from typing import Optional
 
-import torch
 from transformers import AutoProcessor
 
 from ...base import ForgeModel
@@ -115,15 +114,6 @@ class ModelLoader(ForgeModel):
         for key in list(inputs):
             value = inputs[key].repeat_interleave(batch_size, dim=0)
             inputs[key] = cast_input_to_type(value, dtype_override)
-        # Workaround: pass decoder_input_ids to skip the model's randint (its
-        # lowering hits unsupported uint32 remainder).
-        # tt-metal ticket - https://github.com/tenstorrent/tt-metal/issues/27621
-        # tt-metal pr - https://github.com/tenstorrent/tt-metal/pull/48697
-        # tt-xla tracker - https://github.com/tenstorrent/tt-xla/issues/5423
-        text_cfg = getattr(self.config, "text_config", self.config)
-        inputs["decoder_input_ids"] = torch.randint(
-            0, text_cfg.vocab_size, (batch_size, self.config.canvas_length)
-        )
         return inputs
 
     def _text_layers(self, model):


### PR DESCRIPTION
### Ticket
- closes https://github.com/tenstorrent/tt-xla/issues/5423

### Problem description

- The DiffusionGemma loader pre-supplied a random `decoder_input_ids` in `load_inputs` to skip the model's internal `torch.randint`, whose lowering hit an unsupported **uint32 remainder** on TT ([tt-metal#27621](https://github.com/tenstorrent/tt-metal/issues/27621)).

### What's changed

- [tt-metal#48697](https://github.com/tenstorrent/tt-metal/pull/48697) ("Add support for uint32 binary remainder") has landed in tt-metal and tracked by tt-xla now, so the workaround is no longer needed.
- Removed the `decoder_input_ids` override (and the now-unused `torch` import) — the model builds its own `decoder_input_ids` again.

### Checklist
- [x] Verify the changes through local testing in llmbox

### Logs

- [jul20_diffgemma_after_unit32_workaround_removal.log.zip](https://github.com/user-attachments/files/30196568/jul20_diffgemma_after_unit32_workaround_removal.log.zip)

