### PR TITLE
Added loader support for Qwen3_5_122B_A10B

### DIFF
--- a/qwen_3_5/causal_lm/pytorch/loader.py
+++ b/qwen_3_5/causal_lm/pytorch/loader.py
@@ -33,11 +33,13 @@ class ModelVariant(StrEnum):
     QWEN_3_5_4B = "4B"
     QWEN_3_5_9B = "9B"
     QWEN_3_5_27B = "27B"
+    QWEN_3_5_122B_A10B = "122B_A10B"
 
 
 # Variants promoted to the RED model group.
 _RED_VARIANTS = {
     ModelVariant.QWEN_3_5_27B,
+    ModelVariant.QWEN_3_5_122B_A10B,
 }
 
 
@@ -63,6 +65,10 @@ class ModelLoader(ForgeModel):
         ),
         ModelVariant.QWEN_3_5_27B: LLMModelConfig(
             pretrained_model_name="Qwen/Qwen3.5-27B",
+            max_length=128,
+        ),
+        ModelVariant.QWEN_3_5_122B_A10B: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3.5-122B-A10B",
             max_length=128,
         ),
     }
@@ -137,9 +143,64 @@ class ModelLoader(ForgeModel):
         # rebuilds its config from the checkpoint.
         model.config.use_cache = False
 
+        if self._variant == ModelVariant.QWEN_3_5_122B_A10B:
+            # Duplicate GQA KV heads up to 8 so full-attention can be
+            # head-parallel-sharded on the galaxy "model" axis (size 8). Qwen3.5
+            # has only 2 KV heads, which don't tile 8; the resulting hidden-dim
+            # sharding is what forced the batch<->model residual reshards
+            # (sdy.collective_permute, tt-mlir #3370). Padding lets attention use
+            # the gpt_oss-style head-parallel layout with a uniform residual axis.
+            self._pad_kv_heads(model, target_kv_heads=8)
+
         self.config = model.config
         self.model = model
         return model
+
+    def _pad_kv_heads(self, model, target_kv_heads=8):
+        """Duplicate GQA key/value heads up to ``target_kv_heads``.
+
+        Numerically identical: GQA already broadcasts each KV head to a fixed
+        group of query heads, so duplicating a KV head (contiguously, matching
+        ``repeat_kv``) and shrinking the group size leaves attention unchanged.
+        Only the weights, ``num_key_value_groups`` and the config are touched --
+        the attention ``forward`` infers the head count from the tensor width,
+        so no method override is needed.
+        """
+        text_cfg = getattr(model.config, "text_config", model.config)
+        orig = text_cfg.num_key_value_heads
+        if orig >= target_kv_heads or target_kv_heads % orig != 0:
+            return
+        rep = target_kv_heads // orig
+        head_dim = getattr(
+            text_cfg,
+            "head_dim",
+            text_cfg.hidden_size // text_cfg.num_attention_heads,
+        )
+        for layer in model.model.layers:
+            sa = getattr(layer, "self_attn", None)
+            if sa is None:
+                continue
+            for name in ("k_proj", "v_proj"):
+                proj = getattr(sa, name)
+                in_f = proj.weight.shape[1]
+                w = (
+                    proj.weight.data.view(orig, head_dim, in_f)
+                    .repeat_interleave(rep, dim=0)
+                    .reshape(target_kv_heads * head_dim, in_f)
+                )
+                proj.weight = torch.nn.Parameter(w, requires_grad=False)
+                proj.out_features = target_kv_heads * head_dim
+                if proj.bias is not None:
+                    b = (
+                        proj.bias.data.view(orig, head_dim)
+                        .repeat_interleave(rep, dim=0)
+                        .reshape(-1)
+                    )
+                    proj.bias = torch.nn.Parameter(b, requires_grad=False)
+            sa.num_key_value_groups = text_cfg.num_attention_heads // target_kv_heads
+            if hasattr(sa, "num_key_value_heads"):
+                sa.num_key_value_heads = target_kv_heads
+        text_cfg.num_key_value_heads = target_kv_heads
 
     def load_inputs(
         self, dtype_override=None, prompt: Optional[str] = None, batch_size=1
@@ -196,23 +257,50 @@ class ModelLoader(ForgeModel):
         )
 
     def get_mesh_config(self, num_devices: int):
-        mesh_shape = (1, num_devices)
+        if num_devices == 32:  # Galaxy
+            mesh_shape = (4, 8)
+        else:
+            mesh_shape = (1, num_devices)
         return mesh_shape, ("batch", "model")
 
     def load_shard_spec(self, model):
         shard_specs = {}
 
         for layer in model.model.layers:
-            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
-            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
-            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+            mlp = layer.mlp
+            if hasattr(mlp, "experts"):
+                # MoE layer (122B-A10B): routed experts are sharded on the
+                # expert dimension by get_tt_moe_shard_specs (inject_custom_moe).
+                # The always-on shared expert is a dense MLP: keep its hidden
+                # dim on "batch" (gate/up input, down output) to stay consistent
+                # with the residual stream.
+                shared = mlp.shared_expert
+                shard_specs[shared.gate_proj.weight] = ("model", "batch")
+                shard_specs[shared.up_proj.weight] = ("model", "batch")
+                shard_specs[shared.down_proj.weight] = ("batch", "model")
+            else:
+                shard_specs[mlp.gate_proj.weight] = ("model", "batch")
+                shard_specs[mlp.up_proj.weight] = ("model", "batch")
+                shard_specs[mlp.down_proj.weight] = ("batch", "model")
 
             if hasattr(layer, "self_attn"):
                 sa = layer.self_attn
-                shard_specs[sa.q_proj.weight] = ("batch", "model")
-                shard_specs[sa.k_proj.weight] = ("batch", "model")
-                shard_specs[sa.v_proj.weight] = ("batch", "model")
-                shard_specs[sa.o_proj.weight] = ("model", "batch")
+                if self._variant == ModelVariant.QWEN_3_5_122B_A10B:
+                    # KV heads padded to 8 (see _pad_kv_heads) so attention is
+                    # head-parallel like gpt_oss: heads sharded on "model",
+                    # hidden contracted on "batch". This keeps the residual on
+                    # "batch" through attention too (matching MLP/gated-delta),
+                    # avoiding the batch<->model reshard that Shardy lowers to
+                    # sdy.collective_permute on the 2D galaxy mesh.
+                    shard_specs[sa.q_proj.weight] = ("model", "batch")
+                    shard_specs[sa.k_proj.weight] = ("model", "batch")
+                    shard_specs[sa.v_proj.weight] = ("model", "batch")
+                    shard_specs[sa.o_proj.weight] = ("batch", "model")
+                else:
+                    shard_specs[sa.q_proj.weight] = ("batch", "model")
+                    shard_specs[sa.k_proj.weight] = ("batch", "model")
+                    shard_specs[sa.v_proj.weight] = ("batch", "model")
+                    shard_specs[sa.o_proj.weight] = ("model", "batch")
 
             elif hasattr(layer, "linear_attn"):
                 la = layer.linear_attn

--- a/qwen_3_5/multimodal/pytorch/loader.py
+++ b/qwen_3_5/multimodal/pytorch/loader.py
@@ -28,6 +28,7 @@ class ModelVariant(StrEnum):
     """Available Qwen 3.5 multimodal model variants."""
 
     QWEN_3_5_27B = "Qwen/Qwen3.5-27B"
+    QWEN_3_5_122B_A10B = "Qwen/Qwen3.5-122B-A10B"
 
 
 class ModelLoader(ForgeModel):
@@ -36,6 +37,10 @@ class ModelLoader(ForgeModel):
     _VARIANTS = {
         ModelVariant.QWEN_3_5_27B: LLMModelConfig(
             pretrained_model_name=str(ModelVariant.QWEN_3_5_27B),
+            max_length=128,
+        ),
+        ModelVariant.QWEN_3_5_122B_A10B: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.QWEN_3_5_122B_A10B),
             max_length=128,
         ),
     }
@@ -138,9 +143,66 @@ class ModelLoader(ForgeModel):
         if getattr(model.config, "text_config", None) is not None:
             model.config.text_config.use_cache = False
 
+        if self._variant == ModelVariant.QWEN_3_5_122B_A10B:
+            # Duplicate GQA KV heads up to 8 so the text decoder's full-attention
+            # can be head-parallel-sharded on the galaxy "model" axis (size 8).
+            # Qwen3.5 has only 2 KV heads, which don't tile 8; the resulting
+            # hidden-dim sharding is what forced the batch<->model residual
+            # reshards (sdy.collective_permute, tt-mlir #3370). Padding lets
+            # attention use the gpt_oss-style head-parallel layout with a uniform
+            # residual axis. Same fix as the causal_lm loader.
+            self._pad_kv_heads(model, target_kv_heads=8)
+
         self.config = model.config
         self.model = model
         return model
+
+    def _pad_kv_heads(self, model, target_kv_heads=8):
+        """Duplicate the text decoder's GQA key/value heads up to ``target_kv_heads``.
+
+        Numerically identical: GQA already broadcasts each KV head to a fixed
+        group of query heads, so duplicating a KV head (contiguously, matching
+        ``repeat_kv``) and shrinking the group size leaves attention unchanged.
+        Only the weights, ``num_key_value_groups`` and the config are touched --
+        the attention ``forward`` infers the head count from the tensor width,
+        so no method override is needed. Operates on the VLM text decoder
+        (``model.model.language_model.layers``); the vision tower is untouched.
+        """
+        text_cfg = getattr(model.config, "text_config", model.config)
+        orig = text_cfg.num_key_value_heads
+        if orig >= target_kv_heads or target_kv_heads % orig != 0:
+            return
+        rep = target_kv_heads // orig
+        head_dim = getattr(
+            text_cfg,
+            "head_dim",
+            text_cfg.hidden_size // text_cfg.num_attention_heads,
+        )
+        for layer in model.model.language_model.layers:
+            sa = getattr(layer, "self_attn", None)
+            if sa is None:
+                continue
+            for name in ("k_proj", "v_proj"):
+                proj = getattr(sa, name)
+                in_f = proj.weight.shape[1]
+                w = (
+                    proj.weight.data.view(orig, head_dim, in_f)
+                    .repeat_interleave(rep, dim=0)
+                    .reshape(target_kv_heads * head_dim, in_f)
+                )
+                proj.weight = torch.nn.Parameter(w, requires_grad=False)
+                proj.out_features = target_kv_heads * head_dim
+                if proj.bias is not None:
+                    b = (
+                        proj.bias.data.view(orig, head_dim)
+                        .repeat_interleave(rep, dim=0)
+                        .reshape(-1)
+                    )
+                    proj.bias = torch.nn.Parameter(b, requires_grad=False)
+            sa.num_key_value_groups = text_cfg.num_attention_heads // target_kv_heads
+            if hasattr(sa, "num_key_value_heads"):
+                sa.num_key_value_heads = target_kv_heads
+        text_cfg.num_key_value_heads = target_kv_heads
 
     def load_inputs(
         self,
@@ -189,7 +251,10 @@ class ModelLoader(ForgeModel):
         return inputs
 
     def get_mesh_config(self, num_devices: int):
-        mesh_shape = (1, num_devices)
+        if num_devices == 32:  # Galaxy
+            mesh_shape = (4, 8)
+        else:
+            mesh_shape = (1, num_devices)
         return mesh_shape, ("batch", "model")
 
     def load_shard_spec(self, model):
@@ -216,16 +281,36 @@ class ModelLoader(ForgeModel):
         shard_specs[merger.linear_fc2.weight] = ("batch", "model")
 
         for layer in model.model.language_model.layers:
-            # Qwen3.5-27B is dense (the MoE variants are not supported here).
-            shard_specs[layer.mlp.gate_proj.weight] = ("model", "batch")
-            shard_specs[layer.mlp.up_proj.weight] = ("model", "batch")
-            shard_specs[layer.mlp.down_proj.weight] = ("batch", "model")
+            mlp = layer.mlp
+            if hasattr(mlp, "experts"):
+                # MoE layer (122B-A10B): routed experts are sharded on the
+                # expert dimension by get_tt_moe_shard_specs (inject_custom_moe).
+                # The always-on shared expert is a dense MLP kept on "batch".
+                shared = mlp.shared_expert
+                shard_specs[shared.gate_proj.weight] = ("model", "batch")
+                shard_specs[shared.up_proj.weight] = ("model", "batch")
+                shard_specs[shared.down_proj.weight] = ("batch", "model")
+            else:
+                # Dense layer (27B): plain gate/up/down MLP.
+                shard_specs[mlp.gate_proj.weight] = ("model", "batch")
+                shard_specs[mlp.up_proj.weight] = ("model", "batch")
+                shard_specs[mlp.down_proj.weight] = ("batch", "model")
 
             if layer.layer_type == "full_attention":
-                shard_specs[layer.self_attn.q_proj.weight] = ("batch", "model")
-                shard_specs[layer.self_attn.k_proj.weight] = ("batch", "model")
-                shard_specs[layer.self_attn.v_proj.weight] = ("batch", "model")
-                shard_specs[layer.self_attn.o_proj.weight] = ("model", "batch")
+                sa = layer.self_attn
+                if self._variant == ModelVariant.QWEN_3_5_122B_A10B:
+                    # KV heads padded to 8 (see _pad_kv_heads) -> head-parallel:
+                    # heads on "model", hidden on "batch" (uniform residual axis,
+                    # no sdy.collective_permute on the 2D galaxy mesh).
+                    shard_specs[sa.q_proj.weight] = ("model", "batch")
+                    shard_specs[sa.k_proj.weight] = ("model", "batch")
+                    shard_specs[sa.v_proj.weight] = ("model", "batch")
+                    shard_specs[sa.o_proj.weight] = ("batch", "model")
+                else:
+                    shard_specs[sa.q_proj.weight] = ("batch", "model")
+                    shard_specs[sa.k_proj.weight] = ("batch", "model")
+                    shard_specs[sa.v_proj.weight] = ("batch", "model")
+                    shard_specs[sa.o_proj.weight] = ("model", "batch")
 
             elif layer.layer_type == "linear_attention":
                 shard_specs[layer.linear_attn.in_proj_qkv.weight] = ("model", "batch")
@@ -238,6 +323,14 @@ class ModelLoader(ForgeModel):
                 shard_specs[layer.linear_attn.dt_bias] = ("model",)
                 shard_specs[layer.linear_attn.A_log] = ("model",)
 
+        # VLM text decoder embedding lives at model.model.language_model
+        # (model.model only exposes .visual / .language_model). Vocab on
+        # "model", hidden on "batch" -> embedding output keeps hidden on
+        # "batch", matching the head-parallel residual axis.
+        shard_specs[model.model.language_model.embed_tokens.weight] = (
+            "model",
+            "batch",
+        )
         shard_specs[model.lm_head.weight] = ("model", "batch")
 
         return shard_specs


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-xla/issues/3508)

### Problem description
Bring up the Qwen3.5-122B-A10B MoE variant (both causal_lm and multimodal/VLM) for tensor-parallel inference on the 32-chip Galaxy.

Qwen3.5-122B-A10B is a hybrid-attention MoE model: decoder layers interleave Gated DeltaNet (linear attention with causal conv1d + chunked delta rule) and standard full attention, with a sparse MoE MLP (routed experts + always-on shared expert) on every layer.

Two things make it non-trivial to shard on the Galaxy's 2D (batch=4, model=8) mesh:

- The default attention layout forces a cross-axis residual reshard. The linear-attention layers, MLP and MoE all carry the residual hidden dimension on the batch axis, but a standard full-attention layout contracts hidden on model. Reconciling batch → model on a 2D mesh makes Shardy emit an sdy.collective_permute, which tt-mlir cannot lower ([tt-mlir #3370](https://github.com/tenstorrent/tt-mlir/issues/3370)) 
- GQA KV heads don't tile the model axis. The model has only 2 KV heads, which can't be evenly head-parallel-sharded across the 8-wide model axis.

### What's changed
Added causal_lm and multimodal loader support for the QWEN_3_5_122B_A10B variant:

- KV-head padding (_pad_kv_heads) - duplicates the 2 GQA KV heads up to 8 contiguously (matching repeat_kv) so full attention can be head-parallel-sharded on the model axis. Numerically identical (verified bit-exact against the un-padded model): only k_proj/v_proj weights, num_key_value_groups and the config are touched - no attention forward override.
- Head-parallel full-attention shard spec for the 122B on Galaxy: q/k/v = ("model","batch"), o = ("batch","model") (heads on model, hidden on batch). This keeps the hidden dim uniformly on batch across linear-attn / full-attn / MLP / MoE, so there's no batch↔model reshard and no collective_permute. Smaller variants keep their existing ("batch","model") layout (unchanged).


### Logs
Causal_lm - [Qwen3_5_122B_causal_lm.log](https://github.com/user-attachments/files/30539816/Qwen3_5_122B_causal_lm.log)
Multimodal CI run - https://github.com/tenstorrent/tt-xla/actions/runs/30518468880/job/90795811268

### Checklist
- [ ] New/Existing tests provide coverage for changes
