### PR TITLE
[deepseek_v4] Use no_grad instead of inference_mode on forward

### DIFF
--- a/deepseek_v4/modified_model/model.py
+++ b/deepseek_v4/modified_model/model.py
@@ -958,7 +958,8 @@ class MTPBlock(Block):
         self.embed: ParallelEmbedding = None
         self.head: ParallelHead = None
 
-    @torch.inference_mode()
+    # no_grad (not inference_mode): latter breaks torch.compile AOT (pytorch#169477)
+    @torch.no_grad()
     def forward(
         self, x: torch.Tensor, start_pos: int, input_ids: torch.Tensor
     ) -> torch.Tensor:
@@ -1004,7 +1005,8 @@ class Transformer(nn.Module):
             self.hc_head_base = nn.Parameter(torch.empty(hc_mult))
             self.hc_head_scale = nn.Parameter(torch.empty(1))
 
-    @torch.inference_mode()
+    # no_grad (not inference_mode): latter breaks torch.compile AOT (pytorch#169477)
+    @torch.no_grad()
     def forward(self, input_ids: torch.Tensor, start_pos: int = 0):
         h = self.embed(input_ids)
         h = h.unsqueeze(2).repeat(1, 1, self.hc_mult, 1)

--- a/deepseek_v4/modified_model/model_decode_opt.py
+++ b/deepseek_v4/modified_model/model_decode_opt.py
@@ -1144,7 +1144,8 @@ class MTPBlock(Block):
         self.embed: ParallelEmbedding = None
         self.head: ParallelHead = None
 
-    @torch.inference_mode()
+    # no_grad (not inference_mode): latter breaks torch.compile AOT (pytorch#169477)
+    @torch.no_grad()
     def forward(
         self, x: torch.Tensor, start_pos, input_ids: torch.Tensor
     ) -> torch.Tensor:
@@ -1190,7 +1191,8 @@ class Transformer(nn.Module):
             self.hc_head_base = nn.Parameter(torch.empty(hc_mult))
             self.hc_head_scale = nn.Parameter(torch.empty(1))
 
-    @torch.inference_mode()
+    # no_grad (not inference_mode): latter breaks torch.compile AOT (pytorch#169477)
+    @torch.no_grad()
     def forward(
         self, input_ids: torch.Tensor, start_pos=0, return_hidden_states: bool = False
     ):


### PR DESCRIPTION
## Summary
- Replace `@torch.inference_mode()` with `@torch.no_grad()` on `Transformer.forward` and `MTPBlock.forward` in the DeepSeek-V4 modified models.
- Decorating `forward` with `inference_mode` causes `torch.compile` AOT Autograd to fail during metadata collection with `RuntimeError: <weakref ... UntypedStorage>` (first hit: `F.linear` in `hc_pre`).
- Matches the known PyTorch issue: https://github.com/pytorch/pytorch/issues/169477



Made with [Cursor](https://cursor.com)