### PR TITLE
[OmniGen] Shard VAE mid-block attention on the model axis only

### DIFF
--- a/omnigen/pytorch/src/model_utils.py
+++ b/omnigen/pytorch/src/model_utils.py
@@ -273,6 +273,54 @@ def _shard_resnet_block_2d(block, specs: dict) -> None:
             specs[block.conv_shortcut.bias] = (None,)
 
 
+def _shard_mid_block_attention(attn, specs: dict) -> None:
+    """Shard specs for an AutoencoderKL mid-block Attention (single-axis).
+
+    The VAE keeps its channel dim on the "model" axis everywhere (see
+    `_shard_resnet_block_2d`), so the attention must stay on that same axis.
+    Using the transformer's two-axis pattern here — ("model", "batch") /
+    ("batch", "model") — puts the channel dim on "batch" inside the attention
+    and on "model" in the surrounding convs. Shardy then has to reshard that
+    dim across axes of different sizes (batch=8, model=4 on a 32-device mesh),
+    which it lowers to an `sdy.collective_permute` whose operand and result
+    local shapes differ, and the verifier rejects it.
+
+    Megatron pair on "model" only:
+      to_q / to_k / to_v → column-parallel ("model", None), bias ("model",)
+      to_out[0]          → row-parallel    (None, "model"), bias replicated
+
+    The mid-block attention is single-head (heads = in_channels //
+    attention_head_dim = 1), so "model" splits the head dim rather than heads.
+    That is still exact: Q@K^T and scores@V contract over the sharded dim, so
+    each device produces a partial sum that Shardy closes with an all_reduce.
+    `group_norm` stays replicated — group statistics need the full channel dim.
+    """
+    if hasattr(attn, "group_norm") and attn.group_norm is not None:
+        specs[attn.group_norm.weight] = (None,)
+        if attn.group_norm.bias is not None:
+            specs[attn.group_norm.bias] = (None,)
+
+    for proj_name in ("to_q", "to_k", "to_v"):
+        if hasattr(attn, proj_name):
+            proj = getattr(attn, proj_name)
+            specs[proj.weight] = ("model", None)
+            if proj.bias is not None:
+                specs[proj.bias] = ("model",)
+
+    if hasattr(attn, "to_out"):
+        out = attn.to_out
+        target = (
+            out[0]
+            if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
+            else out
+        )
+        specs[target.weight] = (None, "model")
+        # bias replicated: the row-parallel output is already replicated after
+        # the all_reduce, so a sharded bias would be summed N times.
+        if target.bias is not None:
+            specs[target.bias] = (None,)
+
+
 def shard_vae_specs(vae) -> dict:
     """Shard specs for AutoencoderKL (decoder-only path).
 
@@ -283,7 +331,8 @@ def shard_vae_specs(vae) -> dict:
       Row-parallel   (second conv in resnet, exit conv):
         weight (None, "model", None, None), bias (None,)
       Replicated (conv_shortcut): all dims None for both weight and bias.
-    Norm / attention specs mirror the transformer conventions.
+    The mid-block attention stays on the same single "model" axis — see
+    `_shard_mid_block_attention`. Norms are replicated.
     """
     specs = {}
 
@@ -303,26 +352,7 @@ def shard_vae_specs(vae) -> dict:
         for attn in getattr(mid_block, "attentions", []) or []:
             if attn is None:
                 continue
-            if hasattr(attn, "group_norm") and attn.group_norm is not None:
-                specs[attn.group_norm.weight] = (None,)
-                if attn.group_norm.bias is not None:
-                    specs[attn.group_norm.bias] = (None,)
-            for proj_name in ("to_q", "to_k", "to_v"):
-                if hasattr(attn, proj_name):
-                    proj = getattr(attn, proj_name)
-                    specs[proj.weight] = ("model", "batch")
-                    if proj.bias is not None:
-                        specs[proj.bias] = ("model",)
-            if hasattr(attn, "to_out"):
-                out = attn.to_out
-                target = (
-                    out[0]
-                    if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
-                    else out
-                )
-                specs[target.weight] = ("batch", "model")
-                if target.bias is not None:
-                    specs[target.bias] = ("batch",)
+            _shard_mid_block_attention(attn, specs)
 
     for up_block in getattr(decoder, "up_blocks", []) or []:
         for resnet in getattr(up_block, "resnets", []) or []:
@@ -355,6 +385,9 @@ def shard_vae_encoder_specs(vae) -> dict:
         weight (None, "model", None, None), bias (None,)
       Replicated (conv_shortcut, norms, post-encoder quant_conv): all None.
 
+    The mid-block attention is sharded on the same single "model" axis — see
+    `_shard_mid_block_attention` for why a "batch"/"model" pair breaks here.
+
     `quant_conv` is a small 1x1 Conv2d (`2*latent_channels -> 2*latent_channels`)
     that re-projects the encoder's (mean, logvar) parameters. Sharding it
     would force resharding right before the distribution is constructed,
@@ -386,26 +419,7 @@ def shard_vae_encoder_specs(vae) -> dict:
         for attn in getattr(mid_block, "attentions", []) or []:
             if attn is None:
                 continue
-            if hasattr(attn, "group_norm") and attn.group_norm is not None:
-                specs[attn.group_norm.weight] = (None,)
-                if attn.group_norm.bias is not None:
-                    specs[attn.group_norm.bias] = (None,)
-            for proj_name in ("to_q", "to_k", "to_v"):
-                if hasattr(attn, proj_name):
-                    proj = getattr(attn, proj_name)
-                    specs[proj.weight] = ("model", "batch")
-                    if proj.bias is not None:
-                        specs[proj.bias] = ("model",)
-            if hasattr(attn, "to_out"):
-                out = attn.to_out
-                target = (
-                    out[0]
-                    if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
-                    else out
-                )
-                specs[target.weight] = ("batch", "model")
-                if target.bias is not None:
-                    specs[target.bias] = ("batch",)
+            _shard_mid_block_attention(attn, specs)
 
     if hasattr(encoder, "conv_norm_out"):
         specs[encoder.conv_norm_out.weight] = (None,)

--- a/omnigen/pytorch/src/model_utils.py
+++ b/omnigen/pytorch/src/model_utils.py
@@ -320,6 +320,54 @@ def _shard_resnet_block_2d(block, specs: dict) -> None:
             specs[block.conv_shortcut.bias] = (None,)
 
 
+def _shard_mid_block_attention(attn, specs: dict) -> None:
+    """Shard specs for an AutoencoderKL mid-block Attention (single-axis).
+
+    The VAE keeps its channel dim on the "model" axis everywhere (see
+    `_shard_resnet_block_2d`), so the attention must stay on that same axis.
+    Using the transformer's two-axis pattern here — ("model", "batch") /
+    ("batch", "model") — puts the channel dim on "batch" inside the attention
+    and on "model" in the surrounding convs. Shardy then has to reshard that
+    dim across axes of different sizes (batch=8, model=4 on a 32-device mesh),
+    which it lowers to an `sdy.collective_permute` whose operand and result
+    local shapes differ, and the verifier rejects it.
+
+    Megatron pair on "model" only:
+      to_q / to_k / to_v → column-parallel ("model", None), bias ("model",)
+      to_out[0]          → row-parallel    (None, "model"), bias replicated
+
+    The mid-block attention is single-head (heads = in_channels //
+    attention_head_dim = 1), so "model" splits the head dim rather than heads.
+    That is still exact: Q@K^T and scores@V contract over the sharded dim, so
+    each device produces a partial sum that Shardy closes with an all_reduce.
+    `group_norm` stays replicated — group statistics need the full channel dim.
+    """
+    if hasattr(attn, "group_norm") and attn.group_norm is not None:
+        specs[attn.group_norm.weight] = (None,)
+        if attn.group_norm.bias is not None:
+            specs[attn.group_norm.bias] = (None,)
+
+    for proj_name in ("to_q", "to_k", "to_v"):
+        if hasattr(attn, proj_name):
+            proj = getattr(attn, proj_name)
+            specs[proj.weight] = ("model", None)
+            if proj.bias is not None:
+                specs[proj.bias] = ("model",)
+
+    if hasattr(attn, "to_out"):
+        out = attn.to_out
+        target = (
+            out[0]
+            if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
+            else out
+        )
+        specs[target.weight] = (None, "model")
+        # bias replicated: the row-parallel output is already replicated after
+        # the all_reduce, so a sharded bias would be summed N times.
+        if target.bias is not None:
+            specs[target.bias] = (None,)
+
+
 def shard_vae_specs(vae) -> dict:
     """Shard specs for AutoencoderKL (decoder-only path).
 
@@ -330,7 +378,8 @@ def shard_vae_specs(vae) -> dict:
       Row-parallel   (second conv in resnet, exit conv):
         weight (None, "model", None, None), bias (None,)
       Replicated (conv_shortcut): all dims None for both weight and bias.
-    Norm / attention specs mirror the transformer conventions.
+    The mid-block attention stays on the same single "model" axis — see
+    `_shard_mid_block_attention`. Norms are replicated.
     """
     specs = {}
 
@@ -350,26 +399,7 @@ def shard_vae_specs(vae) -> dict:
         for attn in getattr(mid_block, "attentions", []) or []:
             if attn is None:
                 continue
-            if hasattr(attn, "group_norm") and attn.group_norm is not None:
-                specs[attn.group_norm.weight] = (None,)
-                if attn.group_norm.bias is not None:
-                    specs[attn.group_norm.bias] = (None,)
-            for proj_name in ("to_q", "to_k", "to_v"):
-                if hasattr(attn, proj_name):
-                    proj = getattr(attn, proj_name)
-                    specs[proj.weight] = ("model", "batch")
-                    if proj.bias is not None:
-                        specs[proj.bias] = ("model",)
-            if hasattr(attn, "to_out"):
-                out = attn.to_out
-                target = (
-                    out[0]
-                    if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
-                    else out
-                )
-                specs[target.weight] = ("batch", "model")
-                if target.bias is not None:
-                    specs[target.bias] = ("batch",)
+            _shard_mid_block_attention(attn, specs)
 
     for up_block in getattr(decoder, "up_blocks", []) or []:
         for resnet in getattr(up_block, "resnets", []) or []:
@@ -402,6 +432,9 @@ def shard_vae_encoder_specs(vae) -> dict:
         weight (None, "model", None, None), bias (None,)
       Replicated (conv_shortcut, norms, post-encoder quant_conv): all None.
 
+    The mid-block attention is sharded on the same single "model" axis — see
+    `_shard_mid_block_attention` for why a "batch"/"model" pair breaks here.
+
     `quant_conv` is a small 1x1 Conv2d (`2*latent_channels -> 2*latent_channels`)
     that re-projects the encoder's (mean, logvar) parameters. Sharding it
     would force resharding right before the distribution is constructed,
@@ -433,26 +466,7 @@ def shard_vae_encoder_specs(vae) -> dict:
         for attn in getattr(mid_block, "attentions", []) or []:
             if attn is None:
                 continue
-            if hasattr(attn, "group_norm") and attn.group_norm is not None:
-                specs[attn.group_norm.weight] = (None,)
-                if attn.group_norm.bias is not None:
-                    specs[attn.group_norm.bias] = (None,)
-            for proj_name in ("to_q", "to_k", "to_v"):
-                if hasattr(attn, proj_name):
-                    proj = getattr(attn, proj_name)
-                    specs[proj.weight] = ("model", "batch")
-                    if proj.bias is not None:
-                        specs[proj.bias] = ("model",)
-            if hasattr(attn, "to_out"):
-                out = attn.to_out
-                target = (
-                    out[0]
-                    if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
-                    else out
-                )
-                specs[target.weight] = ("batch", "model")
-                if target.bias is not None:
-                    specs[target.bias] = ("batch",)
+            _shard_mid_block_attention(attn, specs)
 
     if hasattr(encoder, "conv_norm_out"):
         specs[encoder.conv_norm_out.weight] = (None,)


### PR DESCRIPTION
### Ticket
Fixes [#5903](https://github.com/tenstorrent/tt-xla/issues/5903)

### Problem description
`test_vae_encoder_sharded` fails to compile with

`loc("reshape.2533"): error: 'sdy.collective_permute' op requires the same type for all operands and results`

### What's changed

- model_utils.py gains a shared `_shard_mid_block_attention` helper that keeps the attention on the same single "model" axis as the convs:

- to_out[0].bias becomes replicated because the row-parallel output is already replicated after the all_reduce; a "batch"-sharded bias would have been summed N times. The helper replaces the inlined blocks in both shard_vae_encoder_specs and shard_vae_specs.

- This is exact even though the mid-block attention is single-head (heads = in_channels // attention_head_dim = 1): Q@Kᵀ and scores@V contract over the sharded head dim, so each device holds a partial sum that Shardy closes with an all_reduce. It also matches the convention already documented in the lumina_image VAE specs. shard_transformer_specs is untouched — its two-axis pattern is self-consistent across every linear, which is what makes it legal there.

- Post these changes, model fails with pcc drop which is solved by [this](https://github.com/tenstorrent/tt-mlir/pull/9174) PR


### Checklist
- [x] Verify the changes through local testing in N150

### Logs
[omnigen_vae_decoder_before_fix_aug6.log](https://github.com/user-attachments/files/30779489/omnigen_vae_decoder_before_fix_aug6.log)
[omnigen_vae_decoder_after_fix_aug6.log](https://github.com/user-attachments/files/30779484/omnigen_vae_decoder_after_fix_aug6.log)