### PR TITLE
[lumina_image] Use single-axis Megatron for transformer sharding and add pipeline

### DIFF
--- a/lumina_image/pytorch/loader.py
+++ b/lumina_image/pytorch/loader.py
@@ -140,13 +140,19 @@ class ModelLoader(ForgeModel):
                          encoder_hidden_states (1,256,2304) bf16,
                          encoder_attention_mask (1,256) int64]
         VAE           → [z (1,16,128,128) bf16]
+
+        TRANSFORMER accepts ``caption_len`` (default 256), the number of real
+        caption tokens in ``encoder_attention_mask``. It is not just a magnitude
+        knob -- it selects whether the refiners' softmax mask has any ``False``
+        entries and whether the joint sequence and slice offsets are
+        tile-aligned; see ``load_transformer_inputs``.
         """
         dtype = dtype_override if dtype_override is not None else DTYPE
 
         if self._variant == ModelVariant.TEXT_ENCODER:
             return load_text_encoder_inputs(dtype)
         if self._variant == ModelVariant.TRANSFORMER:
-            return load_transformer_inputs(dtype)
+            return load_transformer_inputs(dtype, **kwargs)
         if self._variant == ModelVariant.VAE:
             return load_vae_inputs(dtype)
 

--- a/lumina_image/pytorch/src/model_utils.py
+++ b/lumina_image/pytorch/src/model_utils.py
@@ -59,16 +59,208 @@ def load_text_encoder(pretrained_model_name: str, dtype: torch.dtype):
     ).eval()
 
 
+def _lumina_apply_rotary_emb_real(x, freqs_cis, **_upstream_kwargs):
+    """Real-valued drop-in for diffusers' ``apply_rotary_emb``.
+
+    Implements the complex path only -- the one both ``transformer_lumina2`` call
+    sites use. Since the swap is installed on that module's own binding (see
+    ``_patch_lumina_rope_real``), the real-valued callers elsewhere in diffusers
+    -- Flux, HunyuanDiT, CogVideoX -- keep the upstream function and never reach
+    this one, so there is no second path to select and no ``use_real`` to branch
+    on. Upstream's remaining keywords (``use_real``, ``use_real_unbind_dim``,
+    ``sequence_dim``) are swallowed so the swap stays call-compatible: the call
+    sites pass ``use_real=False`` explicitly, which would otherwise be a
+    ``TypeError``.
+
+    diffusers' Lumina branch does::
+
+        x_rotated = torch.view_as_complex(x.float().reshape(*x.shape[:-1], -1, 2))
+        x_out = torch.view_as_real(x_rotated * freqs_cis.unsqueeze(2)).flatten(3)
+
+    which lowers to ``stablehlo.complex`` (the real->complex build) plus a complex
+    ``stablehlo.multiply``. tt-mlir has no TTIR legalization for either, so the
+    SHLO->TTIR conversion leaves a live ``tensor<2xf32> -> complex<f32>``
+    materialization and fails ("failed to legalize unresolved materialization
+    from tensor<2xf32> to tensor<complex<f32>>").
+
+    Expand the complex product ``(a+bi)(c+di) = (ac-bd) + (ad+bc)i`` into real
+    elementwise ops, preserving the interleaved ``[real, imag]`` output layout
+    that ``view_as_real`` produces. ``freqs_cis`` may still be complex (default)
+    or already real-stacked ``[..., D//2, 2]`` (see
+    ``_patch_lumina_freqs_cis_real``). Verified bit-exact against the original in
+    tests/torch/models/lumina_image/verify_freqs.py.
+    """
+    x_ = x.float().reshape(*x.shape[:-1], -1, 2)  # [B, S, H, D//2, 2]
+    a, b = x_[..., 0], x_[..., 1]
+    if torch.is_complex(freqs_cis):
+        fr, fi = freqs_cis.real, freqs_cis.imag
+    else:  # real-stacked [..., D//2, 2]
+        fr, fi = freqs_cis[..., 0], freqs_cis[..., 1]
+    c, d = fr.unsqueeze(2), fi.unsqueeze(2)  # broadcast over the head dim
+    out = torch.stack([a * c - b * d, a * d + b * c], dim=-1).flatten(3)
+    return out.type_as(x)
+
+
+def _patch_lumina_rope_real():
+    """Swap in the real-valued RoPE so no complex arithmetic reaches tt-mlir.
+
+    ``apply_rotary_emb`` is imported by name into ``transformer_lumina2`` at
+    module load, so the attention processor calls the module-local binding --
+    patch it there. That is both necessary (patching
+    ``diffusers.models.embeddings`` would be too late) and sufficient: it leaves
+    every other model's RoPE on the upstream function.
+
+    Applied unconditionally -- rebinding the same object, so repeat calls are a
+    no-op and there is no first-call-only state to protect.
+    """
+    from diffusers.models.transformers import transformer_lumina2
+
+    transformer_lumina2.apply_rotary_emb = _lumina_apply_rotary_emb_real
+
+
+def _patch_lumina_freqs_cis_real(model):
+    """Make the RoPE ``freqs_cis`` real-valued end to end, from the gather on.
+
+    tt-mlir's ComplexDataTypeConversion pass decomposes complex ``Gather``,
+    ``Concatenate``, ``Reshape``, ``Slice``, ``BroadcastInDim``, ``Real`` and
+    ``Imag`` into a trailing ``2xf32``, but it does NOT handle complex ``Pad`` or
+    ``Select``. The embedder builds ``cap_freqs_cis``/``img_freqs_cis`` with
+    ``torch.zeros(..., dtype=complex)`` + slice-assignment, which lowers to
+    complex ``pad`` + ``select`` -- those can't be decomposed, so SHLO->TTIR
+    fails with an unresolved ``tensor<...xcomplex<f32>> -> tensor<...x2xf32>``
+    materialization (this is the pipeline failure the transformer test dodged
+    because its freqs_cis path is only gather/concat/reshape/slice).
+    """
+    import types
+
+    emb = model.rope_embedder
+    if getattr(emb, "_tt_real_freqs", False):
+        return
+
+    def _get_freqs_cis(self, ids):
+        """Real-stacked ``[B, S, sum(d_i)//2, 2]`` gather, no complex tensor.
+
+        Mirrors the upstream gather one-for-one: the index is still broadcast
+        across the frequency axis of a per-batch-repeated table, only now that
+        axis is ``d`` (interleaved real/imag) instead of ``d//2`` complex.
+        """
+        result = []
+        for i in range(len(self.axes_dim)):
+            # [axes_len, d//2, 2] -> [axes_len, d], interleaved [real, imag].
+            freqs = self.freqs_cis[i].to(ids.device).flatten(1)
+            index = ids[:, :, i : i + 1].repeat(1, 1, freqs.shape[-1]).to(torch.int64)
+            gathered = torch.gather(
+                freqs.unsqueeze(0).repeat(index.shape[0], 1, 1), dim=1, index=index
+            )
+            result.append(gathered.reshape(*gathered.shape[:-1], -1, 2))
+        # Concatenate on the frequency axis, not the [real, imag] pair axis.
+        return torch.cat(result, dim=-2)
+
+    def forward(self, hidden_states, attention_mask):
+        batch_size, channels, height, width = hidden_states.shape
+        p = self.patch_size
+        post_patch_height, post_patch_width = height // p, width // p
+        image_seq_len = post_patch_height * post_patch_width
+        device = hidden_states.device
+
+        encoder_seq_len = attention_mask.shape[1]
+        l_effective_cap_len = attention_mask.sum(dim=1).tolist()
+        seq_lengths = [cap + image_seq_len for cap in l_effective_cap_len]
+        max_seq_len = max(seq_lengths)
+
+        position_ids = torch.zeros(
+            batch_size, max_seq_len, 3, dtype=torch.int32, device=device
+        )
+        for i, (cap_seq_len, seq_len) in enumerate(
+            zip(l_effective_cap_len, seq_lengths)
+        ):
+            position_ids[i, :cap_seq_len, 0] = torch.arange(
+                cap_seq_len, dtype=torch.int32, device=device
+            )
+            position_ids[i, cap_seq_len:seq_len, 0] = cap_seq_len
+            row_ids = (
+                torch.arange(post_patch_height, dtype=torch.int32, device=device)
+                .view(-1, 1)
+                .repeat(1, post_patch_width)
+                .flatten()
+            )
+            col_ids = (
+                torch.arange(post_patch_width, dtype=torch.int32, device=device)
+                .view(1, -1)
+                .repeat(post_patch_height, 1)
+                .flatten()
+            )
+            position_ids[i, cap_seq_len:seq_len, 1] = row_ids
+            position_ids[i, cap_seq_len:seq_len, 2] = col_ids
+
+        # Already real-stacked [B, max_seq_len, D//2, 2] -- the patched
+        # _get_freqs_cis gathers from real tables, so the zeros/pad/select below
+        # (which tt-mlir cannot decompose on a complex type) stay real.
+        freqs_cis = self._get_freqs_cis(position_ids)
+
+        cap_freqs_cis = torch.zeros(
+            batch_size,
+            encoder_seq_len,
+            *freqs_cis.shape[2:],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+        img_freqs_cis = torch.zeros(
+            batch_size,
+            image_seq_len,
+            *freqs_cis.shape[2:],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+        for i, (cap_seq_len, seq_len) in enumerate(
+            zip(l_effective_cap_len, seq_lengths)
+        ):
+            cap_freqs_cis[i, :cap_seq_len] = freqs_cis[i, :cap_seq_len]
+            img_freqs_cis[i, :image_seq_len] = freqs_cis[i, cap_seq_len:seq_len]
+
+        hidden_states = (
+            hidden_states.view(
+                batch_size, channels, post_patch_height, p, post_patch_width, p
+            )
+            .permute(0, 2, 4, 3, 5, 1)
+            .flatten(3)
+            .flatten(1, 2)
+        )
+
+        return (
+            hidden_states,
+            cap_freqs_cis,
+            img_freqs_cis,
+            freqs_cis,
+            l_effective_cap_len,
+            seq_lengths,
+        )
+
+    emb._get_freqs_cis = types.MethodType(_get_freqs_cis, emb)
+    emb.forward = types.MethodType(forward, emb)
+    emb._tt_real_freqs = True
+
+
 def load_transformer(pretrained_model_name: str, dtype: torch.dtype):
     """Load Lumina2Transformer2DModel from the transformer subfolder."""
     from diffusers import Lumina2Transformer2DModel
 
-    return Lumina2Transformer2DModel.from_pretrained(
+    model = Lumina2Transformer2DModel.from_pretrained(
         pretrained_model_name,
         subfolder="transformer",
         torch_dtype=dtype,
         device_map="cpu",
     ).eval()
+
+    model.rope_embedder.freqs_cis = [
+        torch.view_as_real(f.to(torch.complex64)).contiguous()
+        for f in model.rope_embedder.freqs_cis
+    ]
+
+    _patch_lumina_rope_real()
+    _patch_lumina_freqs_cis_real(model)
+
+    return model
 
 
 def load_vae(pretrained_model_name: str, dtype: torch.dtype):
@@ -100,7 +292,7 @@ def load_text_encoder_inputs(dtype: torch.dtype):
     return [input_ids, attention_mask]
 
 
-def load_transformer_inputs(dtype: torch.dtype):
+def load_transformer_inputs(dtype: torch.dtype, caption_len: int = MAX_SEQ_LEN):
     """Inputs for Lumina2Transformer2DModel: [hidden_states, timestep,
     encoder_hidden_states, encoder_attention_mask].
 
@@ -108,11 +300,34 @@ def load_transformer_inputs(dtype: torch.dtype):
       hidden_states          (1, 16, 128, 128)   — 1024x1024 image latent
       timestep               (1,)  == tensor([0.])
       encoder_hidden_states  (1, 256, 2304)      — Gemma-2 hidden_size
-      encoder_attention_mask (1, 256)            — sourced from
-                              load_text_encoder_inputs so it stays aligned
-                              with the text encoder's attention_mask.
+      encoder_attention_mask (1, 256)            — ``caption_len`` leading ones
+                              then zeros, i.e. the padding mask the pipeline's
+                              tokenizer produces for a prompt of that length.
+
+    ``caption_len`` selects how much of the fixed 256-slot caption buffer is
+    real, and it changes *which code paths run* -- not just magnitudes:
+
+      - ``256`` (the default, and what the pipeline never sees): the mask is
+        all-ones, so the bool ``attn_mask`` the context refiners hand to
+        ``scaled_dot_product_attention`` contains no ``False`` at all and is a
+        semantic no-op. The joint sequence is 256 + 4096 = 4352 and the
+        slice-assign offset is 256 -- both exact multiples of the 32-row tile.
+      - anything smaller: 256 - caption_len keys must actually be masked out in
+        the refiners, and the joint sequence (caption_len + 4096) and the
+        joint-assembly / unpatchify slice offsets become caption_len-dependent,
+        and tile-unaligned whenever caption_len % 32 != 0.
+
+    A real prompt lands in the tens (see PROMPT in ``pipeline.py``), so pick
+    values that separate those two effects: an aligned length < 256 keeps the
+    slices tile-aligned while still exercising a masked softmax, whereas an
+    unaligned length exercises both.
     """
-    _, encoder_attention_mask = load_text_encoder_inputs(dtype)
+    if not 0 < caption_len <= MAX_SEQ_LEN:
+        raise ValueError(
+            f"caption_len must be in (0, {MAX_SEQ_LEN}], got {caption_len}"
+        )
+    encoder_attention_mask = torch.zeros(1, MAX_SEQ_LEN, dtype=torch.long)
+    encoder_attention_mask[:, :caption_len] = 1
     encoder_hidden_states = torch.randn(1, MAX_SEQ_LEN, TEXT_EMBED_DIM, dtype=dtype)
 
     hidden_states = torch.randn(
@@ -239,45 +454,45 @@ def shard_text_encoder_specs(encoder) -> dict:
 def _shard_lumina_block(block, specs: dict, has_adaln: bool) -> None:
     """Add shard specs for a single Lumina2TransformerBlock in-place.
 
-    has_adaln distinguishes blocks that include the adaptive-norm path
-    (noise_refiner / layers) from context_refiner blocks where norm1 is a
-    plain RMSNorm without a learned modulation linear.
+    Single-axis Megatron tensor parallelism on the "model" axis only. Each
+    block is two column->row pairs (attention Q/K/V -> O, FFN gate/up -> down),
+    so it emits exactly two all-reduces and never a reshard. The block's input
+    and output stay replicated (post-all-reduce), which lets the next block's
+    column-parallel ops consume them directly.
     """
     attn = block.attn
-    specs[attn.to_q.weight] = ("model", "batch")
-    specs[attn.to_k.weight] = ("model", "batch")
-    specs[attn.to_v.weight] = ("model", "batch")
-    specs[attn.to_out[0].weight] = ("batch", "model")
+    # Column-parallel: shard output (head) dim. GQA-safe (24 q-heads, 8 kv-heads
+    # both divide by the model-axis size); to_q/k/v take a replicated input.
+    specs[attn.to_q.weight] = ("model", None)
+    specs[attn.to_k.weight] = ("model", None)
+    specs[attn.to_v.weight] = ("model", None)
+    # Row-parallel: shard contraction dim -> one all-reduce, replicated output.
+    specs[attn.to_out[0].weight] = (None, "model")
 
     ff = block.feed_forward
-    specs[ff.linear_1.weight] = ("model", "batch")
-    specs[ff.linear_3.weight] = ("model", "batch")
-    specs[ff.linear_2.weight] = ("batch", "model")
-
-    if has_adaln:
-        specs[block.norm1.linear.weight] = ("model", "batch")
-        specs[block.norm1.linear.bias] = ("model",)
+    # SwiGLU column->row pair: gate/up column-parallel, down row-parallel.
+    specs[ff.linear_1.weight] = ("model", None)
+    specs[ff.linear_3.weight] = ("model", None)
+    specs[ff.linear_2.weight] = (None, "model")
 
 
 def shard_transformer_specs(transformer) -> dict:
     """Shard specs for Lumina2Transformer2DModel.
 
-    Mesh axes: ("batch", "model")
-    Column-parallel (Q, K, V, FFN up/gate): ("model", "batch")
-    Row-parallel   (O, FFN down):           ("batch", "model")
-    """
-    specs = {
-        transformer.x_embedder.weight: ("model", "batch"),
-        transformer.x_embedder.bias: ("model",),
-    }
+    Mesh axes: ("batch", "model"). Strategy: single-axis Megatron tensor
+    parallelism on "model" for the 30 transformer blocks; everything else
+    replicated.
+      Column-parallel (Q, K, V, FFN up/gate): ("model", None)
+      Row-parallel    (O, FFN down):          (None, "model")
 
-    tce = transformer.time_caption_embed
-    specs[tce.timestep_embedder.linear_1.weight] = ("model", "batch")
-    specs[tce.timestep_embedder.linear_1.bias] = ("model",)
-    specs[tce.timestep_embedder.linear_2.weight] = ("batch", "model")
-    specs[tce.timestep_embedder.linear_2.bias] = ("batch",)
-    specs[tce.caption_embedder[1].weight] = ("model", "batch")
-    specs[tce.caption_embedder[1].bias] = ("model",)
+    Embedders and the output projection (x_embedder, time_caption_embed,
+    norm_out) are replicated: they sit at graph boundaries, are tiny relative to
+    the blocks, and replicating them keeps block inputs/outputs replicated so no
+    boundary reshard or final all-gather is needed. CCL budget: 60 all-reduces
+    (2 per block x 30), 0 collective_permute, 0 all-gather. See
+    sharding_analysis.md.
+    """
+    specs: dict = {}
 
     for block in transformer.noise_refiner:
         _shard_lumina_block(block, specs, has_adaln=True)
@@ -285,11 +500,6 @@ def shard_transformer_specs(transformer) -> dict:
         _shard_lumina_block(block, specs, has_adaln=False)
     for block in transformer.layers:
         _shard_lumina_block(block, specs, has_adaln=True)
-
-    specs[transformer.norm_out.linear_1.weight] = ("model", "batch")
-    specs[transformer.norm_out.linear_1.bias] = ("model",)
-    specs[transformer.norm_out.linear_2.weight] = ("batch", "model")
-    specs[transformer.norm_out.linear_2.bias] = ("batch",)
 
     return specs
 

--- a/lumina_image/pytorch/src/model_utils.py
+++ b/lumina_image/pytorch/src/model_utils.py
@@ -13,6 +13,8 @@ Components:
 """
 
 import torch
+import random
+import numpy as np
 
 # ---------------------------------------------------------------------------
 # Model identity
@@ -59,16 +61,259 @@ def load_text_encoder(pretrained_model_name: str, dtype: torch.dtype):
     ).eval()
 
 
+_ORIG_APPLY_ROTARY_EMB = None
+
+
+def _lumina_apply_rotary_emb_real(
+    x, freqs_cis, use_real=True, use_real_unbind_dim=-1, sequence_dim=2
+):
+    """Real-valued drop-in for diffusers' ``apply_rotary_emb``.
+
+    Only the Lumina path (``use_real=False``) is rewritten; every other caller
+    is delegated to the original implementation unchanged.
+
+    diffusers' Lumina branch does::
+
+        x_rotated = torch.view_as_complex(x.float().reshape(*x.shape[:-1], -1, 2))
+        x_out = torch.view_as_real(x_rotated * freqs_cis.unsqueeze(2)).flatten(3)
+
+    which lowers to ``stablehlo.complex`` (the real->complex build) plus a complex
+    ``stablehlo.multiply``. tt-mlir has no TTIR legalization for either, so the
+    SHLO->TTIR conversion leaves a live ``tensor<2xf32> -> complex<f32>``
+    materialization and fails ("failed to legalize unresolved materialization
+    from tensor<2xf32> to tensor<complex<f32>>").
+
+    Expand the complex product ``(a+bi)(c+di) = (ac-bd) + (ad+bc)i`` into real
+    elementwise ops, preserving the interleaved ``[real, imag]`` output layout
+    that ``view_as_real`` produces. ``freqs_cis`` may still be complex (default)
+    or already real-stacked ``[..., D//2, 2]`` (see
+    ``_patch_lumina_freqs_cis_real``). Verified bit-exact against the original in
+    tests/torch/models/lumina_image/verify_freqs.py.
+    """
+    if use_real:
+        return _ORIG_APPLY_ROTARY_EMB(
+            x,
+            freqs_cis,
+            use_real=use_real,
+            use_real_unbind_dim=use_real_unbind_dim,
+            sequence_dim=sequence_dim,
+        )
+
+    x_ = x.float().reshape(*x.shape[:-1], -1, 2)  # [B, S, H, D//2, 2]
+    a, b = x_[..., 0], x_[..., 1]
+    if torch.is_complex(freqs_cis):
+        fr, fi = freqs_cis.real, freqs_cis.imag
+    else:  # real-stacked [..., D//2, 2]
+        fr, fi = freqs_cis[..., 0], freqs_cis[..., 1]
+    c, d = fr.unsqueeze(2), fi.unsqueeze(2)  # broadcast over the head dim
+    out = torch.stack([a * c - b * d, a * d + b * c], dim=-1).flatten(3)
+    return out.type_as(x)
+
+
+_lumina_apply_rotary_emb_real._tt_real_patch = True
+
+
+def _patch_lumina_rope_real():
+    """Swap in the real-valued RoPE so no complex arithmetic reaches tt-mlir.
+
+    ``apply_rotary_emb`` is imported by name into ``transformer_lumina2`` at
+    module load, so the attention processor calls the module-local binding --
+    patch it there (patching ``diffusers.models.embeddings`` would be too late).
+    Idempotent.
+    """
+    global _ORIG_APPLY_ROTARY_EMB
+    from diffusers.models.transformers import transformer_lumina2
+
+    if getattr(transformer_lumina2.apply_rotary_emb, "_tt_real_patch", False):
+        return
+    _ORIG_APPLY_ROTARY_EMB = transformer_lumina2.apply_rotary_emb
+    transformer_lumina2.apply_rotary_emb = _lumina_apply_rotary_emb_real
+
+
+def _patch_lumina_freqs_cis_real(model):
+    """Make the RoPE ``freqs_cis`` real-valued end to end, from the gather on.
+
+    tt-mlir's ComplexDataTypeConversion pass decomposes complex ``Gather``,
+    ``Concatenate``, ``Reshape``, ``Slice``, ``BroadcastInDim``, ``Real`` and
+    ``Imag`` into a trailing ``2xf32``, but it does NOT handle complex ``Pad`` or
+    ``Select``. The embedder builds ``cap_freqs_cis``/``img_freqs_cis`` with
+    ``torch.zeros(..., dtype=complex)`` + slice-assignment, which lowers to
+    complex ``pad`` + ``select`` -- those can't be decomposed, so SHLO->TTIR
+    fails with an unresolved ``tensor<...xcomplex<f32>> -> tensor<...x2xf32>``
+    materialization (this is the pipeline failure the transformer test dodged
+    because its freqs_cis path is only gather/concat/reshape/slice).
+
+    The natural fix -- ``torch.view_as_real`` on the gather/concat result -- is
+    itself unavailable: ``aten::view_as_real`` is a view op that reinterprets the
+    underlying storage, and PyTorch/XLA rejects every such op outright ("appears
+    to be a view operator, but it has no implementation for the backend xla:0"),
+    because an XLA tensor's storage lives on device and cannot be aliased with a
+    different element type. So the complex->real conversion cannot happen inside
+    the traced graph at all.
+
+    Instead, do the conversion on the host: ``load_transformer`` rewrites the
+    precomputed ``freqs_cis`` tables (plain CPU constants, not part of the graph)
+    to real-stacked ``[axes_len, d//2, 2]``, and ``_get_freqs_cis`` is rewritten
+    here to gather from those real tables directly. The gather keeps the exact op
+    structure of the original -- the table is flattened to ``[axes_len, d]`` so
+    the interleaved ``[real, imag]`` pair rides along the frequency axis -- so no
+    complex tensor is ever created on device and ``zeros``/``pad``/``select``
+    downstream are real and legalize normally. The three real-stacked outputs are
+    consumed transparently by the patched ``apply_rotary_emb``
+    (``_patch_lumina_rope_real`` must also be applied). Idempotent.
+    """
+    import types
+
+    emb = model.rope_embedder
+    if getattr(emb, "_tt_real_freqs", False):
+        return
+
+    def _get_freqs_cis(self, ids):
+        """Real-stacked ``[B, S, sum(d_i)//2, 2]`` gather, no complex tensor.
+
+        Mirrors the upstream gather one-for-one: the index is still broadcast
+        across the frequency axis of a per-batch-repeated table, only now that
+        axis is ``d`` (interleaved real/imag) instead of ``d//2`` complex.
+        """
+        result = []
+        for i in range(len(self.axes_dim)):
+            # [axes_len, d//2, 2] -> [axes_len, d], interleaved [real, imag].
+            freqs = self.freqs_cis[i].to(ids.device).flatten(1)
+            index = ids[:, :, i : i + 1].repeat(1, 1, freqs.shape[-1]).to(torch.int64)
+            gathered = torch.gather(
+                freqs.unsqueeze(0).repeat(index.shape[0], 1, 1), dim=1, index=index
+            )
+            result.append(gathered.reshape(*gathered.shape[:-1], -1, 2))
+        # Concatenate on the frequency axis, not the [real, imag] pair axis.
+        return torch.cat(result, dim=-2)
+
+    def forward(self, hidden_states, attention_mask):
+        batch_size, channels, height, width = hidden_states.shape
+        p = self.patch_size
+        post_patch_height, post_patch_width = height // p, width // p
+        image_seq_len = post_patch_height * post_patch_width
+        device = hidden_states.device
+
+        encoder_seq_len = attention_mask.shape[1]
+        l_effective_cap_len = attention_mask.sum(dim=1).tolist()
+        seq_lengths = [cap + image_seq_len for cap in l_effective_cap_len]
+        max_seq_len = max(seq_lengths)
+
+        position_ids = torch.zeros(
+            batch_size, max_seq_len, 3, dtype=torch.int32, device=device
+        )
+        for i, (cap_seq_len, seq_len) in enumerate(
+            zip(l_effective_cap_len, seq_lengths)
+        ):
+            position_ids[i, :cap_seq_len, 0] = torch.arange(
+                cap_seq_len, dtype=torch.int32, device=device
+            )
+            position_ids[i, cap_seq_len:seq_len, 0] = cap_seq_len
+            row_ids = (
+                torch.arange(post_patch_height, dtype=torch.int32, device=device)
+                .view(-1, 1)
+                .repeat(1, post_patch_width)
+                .flatten()
+            )
+            col_ids = (
+                torch.arange(post_patch_width, dtype=torch.int32, device=device)
+                .view(1, -1)
+                .repeat(post_patch_height, 1)
+                .flatten()
+            )
+            position_ids[i, cap_seq_len:seq_len, 1] = row_ids
+            position_ids[i, cap_seq_len:seq_len, 2] = col_ids
+
+        # Already real-stacked [B, max_seq_len, D//2, 2] -- the patched
+        # _get_freqs_cis gathers from real tables, so the zeros/pad/select below
+        # (which tt-mlir cannot decompose on a complex type) stay real.
+        freqs_cis = self._get_freqs_cis(position_ids)
+
+        cap_freqs_cis = torch.zeros(
+            batch_size,
+            encoder_seq_len,
+            *freqs_cis.shape[2:],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+        img_freqs_cis = torch.zeros(
+            batch_size,
+            image_seq_len,
+            *freqs_cis.shape[2:],
+            device=device,
+            dtype=freqs_cis.dtype,
+        )
+        for i, (cap_seq_len, seq_len) in enumerate(
+            zip(l_effective_cap_len, seq_lengths)
+        ):
+            cap_freqs_cis[i, :cap_seq_len] = freqs_cis[i, :cap_seq_len]
+            img_freqs_cis[i, :image_seq_len] = freqs_cis[i, cap_seq_len:seq_len]
+
+        hidden_states = (
+            hidden_states.view(
+                batch_size, channels, post_patch_height, p, post_patch_width, p
+            )
+            .permute(0, 2, 4, 3, 5, 1)
+            .flatten(3)
+            .flatten(1, 2)
+        )
+
+        return (
+            hidden_states,
+            cap_freqs_cis,
+            img_freqs_cis,
+            freqs_cis,
+            l_effective_cap_len,
+            seq_lengths,
+        )
+
+    emb._get_freqs_cis = types.MethodType(_get_freqs_cis, emb)
+    emb.forward = types.MethodType(forward, emb)
+    emb._tt_real_freqs = True
+
+
 def load_transformer(pretrained_model_name: str, dtype: torch.dtype):
     """Load Lumina2Transformer2DModel from the transformer subfolder."""
     from diffusers import Lumina2Transformer2DModel
 
-    return Lumina2Transformer2DModel.from_pretrained(
+    model = Lumina2Transformer2DModel.from_pretrained(
         pretrained_model_name,
         subfolder="transformer",
         torch_dtype=dtype,
         device_map="cpu",
     ).eval()
+
+    # Lumina2RotaryPosEmbed precomputes freqs_cis in float64 (-> complex128) on
+    # non-MPS hosts, so RoPE's apply_rotary_emb emits a complex<f64> multiply.
+    # tt-mlir's complex legalization only handles complex<f32> (tt-mlir #8874),
+    # leaving an unresolved complex<f64> -> float-pair materialization that fails
+    # to legalize. Downcast to complex64 -- TT hardware has no native f64 compute,
+    # so this is also the correct precision to run at -- and immediately stack the
+    # real/imag pair into a trailing dim of 2, giving real tables of shape
+    # [axes_len, d//2, 2]. These are plain CPU constants built at load time, so
+    # view_as_real is legal here; it is not legal on an XLA tensor (see
+    # _patch_lumina_freqs_cis_real), which is exactly why the conversion is done
+    # here rather than inside the traced graph. contiguous() drops the aliasing
+    # with the complex storage so the table owns its memory.
+    model.rope_embedder.freqs_cis = [
+        torch.view_as_real(f.to(torch.complex64)).contiguous()
+        for f in model.rope_embedder.freqs_cis
+    ]
+
+    # Even at complex<f32>, tt-mlir has no TTIR lowering for the real->complex
+    # build (view_as_complex) or the complex multiply that RoPE's apply_rotary_emb
+    # emits, so SHLO->TTIR fails with an unresolved "tensor<2xf32> ->
+    # tensor<complex<f32>>" materialization. Replace apply_rotary_emb with a
+    # real-valued (bit-exact) form so no complex arithmetic reaches the backend.
+    _patch_lumina_rope_real()
+
+    # The embedder still builds cap/img freqs_cis via complex pad+select, which
+    # tt-mlir's complex decomposition pass does not handle (only gather/concat/
+    # reshape/slice/broadcast/real/imag). Teach the embedder to gather from the
+    # real tables above so nothing complex is ever created on device.
+    _patch_lumina_freqs_cis_real(model)
+
+    return model
 
 
 def load_vae(pretrained_model_name: str, dtype: torch.dtype):
@@ -95,12 +340,16 @@ def load_text_encoder_inputs(dtype: torch.dtype):
     encoder when max_sequence_length=256: input_ids (1, 256) and
     attention_mask (1, 256), both int64.
     """
+    seed = 42
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
     input_ids = torch.randint(0, GEMMA_VOCAB_SIZE, (1, MAX_SEQ_LEN), dtype=torch.long)
     attention_mask = torch.ones(1, MAX_SEQ_LEN, dtype=torch.long)
     return [input_ids, attention_mask]
 
 
-def load_transformer_inputs(dtype: torch.dtype):
+def load_transformer_inputs(dtype: torch.dtype, caption_len: int = MAX_SEQ_LEN):
     """Inputs for Lumina2Transformer2DModel: [hidden_states, timestep,
     encoder_hidden_states, encoder_attention_mask].
 
@@ -108,11 +357,38 @@ def load_transformer_inputs(dtype: torch.dtype):
       hidden_states          (1, 16, 128, 128)   — 1024x1024 image latent
       timestep               (1,)  == tensor([0.])
       encoder_hidden_states  (1, 256, 2304)      — Gemma-2 hidden_size
-      encoder_attention_mask (1, 256)            — sourced from
-                              load_text_encoder_inputs so it stays aligned
-                              with the text encoder's attention_mask.
+      encoder_attention_mask (1, 256)            — ``caption_len`` leading ones
+                              then zeros, i.e. the padding mask the pipeline's
+                              tokenizer produces for a prompt of that length.
+
+    ``caption_len`` selects how much of the fixed 256-slot caption buffer is
+    real, and it changes *which code paths run* -- not just magnitudes:
+
+      - ``256`` (the default, and what the pipeline never sees): the mask is
+        all-ones, so the bool ``attn_mask`` the context refiners hand to
+        ``scaled_dot_product_attention`` contains no ``False`` at all and is a
+        semantic no-op. The joint sequence is 256 + 4096 = 4352 and the
+        slice-assign offset is 256 -- both exact multiples of the 32-row tile.
+      - anything smaller: 256 - caption_len keys must actually be masked out in
+        the refiners, and the joint sequence (caption_len + 4096) and the
+        joint-assembly / unpatchify slice offsets become caption_len-dependent,
+        and tile-unaligned whenever caption_len % 32 != 0.
+
+    A real prompt lands in the tens (see PROMPT in ``pipeline.py``), so pick
+    values that separate those two effects: an aligned length < 256 keeps the
+    slices tile-aligned while still exercising a masked softmax, whereas an
+    unaligned length exercises both.
     """
-    _, encoder_attention_mask = load_text_encoder_inputs(dtype)
+    seed = 42
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if not 0 < caption_len <= MAX_SEQ_LEN:
+        raise ValueError(
+            f"caption_len must be in (0, {MAX_SEQ_LEN}], got {caption_len}"
+        )
+    encoder_attention_mask = torch.zeros(1, MAX_SEQ_LEN, dtype=torch.long)
+    encoder_attention_mask[:, :caption_len] = 1
     encoder_hidden_states = torch.randn(1, MAX_SEQ_LEN, TEXT_EMBED_DIM, dtype=dtype)
 
     hidden_states = torch.randn(
@@ -239,45 +515,63 @@ def shard_text_encoder_specs(encoder) -> dict:
 def _shard_lumina_block(block, specs: dict, has_adaln: bool) -> None:
     """Add shard specs for a single Lumina2TransformerBlock in-place.
 
-    has_adaln distinguishes blocks that include the adaptive-norm path
-    (noise_refiner / layers) from context_refiner blocks where norm1 is a
-    plain RMSNorm without a learned modulation linear.
+    Single-axis Megatron tensor parallelism on the "model" axis only. Each
+    block is two column->row pairs (attention Q/K/V -> O, FFN gate/up -> down),
+    so it emits exactly two all-reduces and never a reshard. The block's input
+    and output stay replicated (post-all-reduce), which lets the next block's
+    column-parallel ops consume them directly.
+
+    We deliberately do NOT shard on the "batch" axis. The earlier 2-D scheme
+    (("model","batch") column, ("batch","model") row) alternated axis order, so
+    a row output feeding the next column op had to swap its sharded dim from the
+    "model" axis to the "batch" axis -- an axis-swap reshard that Shardy lowers
+    to sdy.collective_permute, which tt-mlir cannot lower yet (tt-mlir #3370).
+    Single-axis "model" keeps every contraction dim on the same axis, so only
+    all-reduce is emitted. Mirrors shard_vae_specs and examples/pytorch/llama.py.
+
+    has_adaln only documents which blocks carry the AdaLN modulation linear
+    (noise_refiner / layers); that linear is left replicated (see below), so the
+    flag no longer changes the specs.
     """
     attn = block.attn
-    specs[attn.to_q.weight] = ("model", "batch")
-    specs[attn.to_k.weight] = ("model", "batch")
-    specs[attn.to_v.weight] = ("model", "batch")
-    specs[attn.to_out[0].weight] = ("batch", "model")
+    # Column-parallel: shard output (head) dim. GQA-safe (24 q-heads, 8 kv-heads
+    # both divide by the model-axis size); to_q/k/v take a replicated input.
+    specs[attn.to_q.weight] = ("model", None)
+    specs[attn.to_k.weight] = ("model", None)
+    specs[attn.to_v.weight] = ("model", None)
+    # Row-parallel: shard contraction dim -> one all-reduce, replicated output.
+    specs[attn.to_out[0].weight] = (None, "model")
 
     ff = block.feed_forward
-    specs[ff.linear_1.weight] = ("model", "batch")
-    specs[ff.linear_3.weight] = ("model", "batch")
-    specs[ff.linear_2.weight] = ("batch", "model")
+    # SwiGLU column->row pair: gate/up column-parallel, down row-parallel.
+    specs[ff.linear_1.weight] = ("model", None)
+    specs[ff.linear_3.weight] = ("model", None)
+    specs[ff.linear_2.weight] = (None, "model")
 
-    if has_adaln:
-        specs[block.norm1.linear.weight] = ("model", "batch")
-        specs[block.norm1.linear.bias] = ("model",)
+    # block.norm1.linear (AdaLN modulation) is intentionally left replicated:
+    # its chunked scale/gate vectors multiply a replicated normalized activation,
+    # so sharding it would force a reshard. Likewise all RMSNorm weights
+    # (norm1.norm, norm2, ffn_norm1, ffn_norm2, norm_q, norm_k) stay replicated
+    # because they act on replicated activations / the unsharded head_dim.
 
 
 def shard_transformer_specs(transformer) -> dict:
     """Shard specs for Lumina2Transformer2DModel.
 
-    Mesh axes: ("batch", "model")
-    Column-parallel (Q, K, V, FFN up/gate): ("model", "batch")
-    Row-parallel   (O, FFN down):           ("batch", "model")
-    """
-    specs = {
-        transformer.x_embedder.weight: ("model", "batch"),
-        transformer.x_embedder.bias: ("model",),
-    }
+    Mesh axes: ("batch", "model"). Strategy: single-axis Megatron tensor
+    parallelism on "model" for the 30 transformer blocks; everything else
+    replicated.
+      Column-parallel (Q, K, V, FFN up/gate): ("model", None)
+      Row-parallel    (O, FFN down):          (None, "model")
 
-    tce = transformer.time_caption_embed
-    specs[tce.timestep_embedder.linear_1.weight] = ("model", "batch")
-    specs[tce.timestep_embedder.linear_1.bias] = ("model",)
-    specs[tce.timestep_embedder.linear_2.weight] = ("batch", "model")
-    specs[tce.timestep_embedder.linear_2.bias] = ("batch",)
-    specs[tce.caption_embedder[1].weight] = ("model", "batch")
-    specs[tce.caption_embedder[1].bias] = ("model",)
+    Embedders and the output projection (x_embedder, time_caption_embed,
+    norm_out) are replicated: they sit at graph boundaries, are tiny relative to
+    the blocks, and replicating them keeps block inputs/outputs replicated so no
+    boundary reshard or final all-gather is needed. CCL budget: 60 all-reduces
+    (2 per block x 30), 0 collective_permute, 0 all-gather. See
+    sharding_analysis.md.
+    """
+    specs: dict = {}
 
     for block in transformer.noise_refiner:
         _shard_lumina_block(block, specs, has_adaln=True)
@@ -285,11 +579,6 @@ def shard_transformer_specs(transformer) -> dict:
         _shard_lumina_block(block, specs, has_adaln=False)
     for block in transformer.layers:
         _shard_lumina_block(block, specs, has_adaln=True)
-
-    specs[transformer.norm_out.linear_1.weight] = ("model", "batch")
-    specs[transformer.norm_out.linear_1.bias] = ("model",)
-    specs[transformer.norm_out.linear_2.weight] = ("batch", "model")
-    specs[transformer.norm_out.linear_2.bias] = ("batch",)
 
     return specs
 

--- a/lumina_image/pytorch/src/pipeline.py
+++ b/lumina_image/pytorch/src/pipeline.py
@@ -1,0 +1,703 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lumina-Image-2.0 — end-to-end text-to-image pipeline for the imagegen harness.
+
+Lumina-Image-2.0 is a flow-matching text-to-image diffusion model, so a single
+generation is:
+
+  1. Gemma-2 text encoding of the (system-prompt-prefixed) prompt, and of the
+     negative prompt for classifier-free guidance.
+  2. A DiT denoising loop -- ``Lumina2Transformer2DModel`` denoises the latent
+     over ``num_inference_steps`` FlowMatchEuler steps, two forwards per step
+     (conditional + unconditional) with normalization-based guidance.
+  3. A single VAE decode of the final latent to an RGB image.
+
+This reimplements the diffusers ``Lumina2Pipeline.__call__`` with an explicit
+CPU/TT device split, and -- like the GLM-Image pipeline in this package --
+reuses the diffusers pipeline's *own* helper methods so that only the device
+split is bespoke. Concretely, a real ``Lumina2Pipeline`` is constructed around
+the already-loaded components (``_build_diffusers_pipeline``) and the pipeline's
+``encode_prompt`` / ``prepare_latents`` / ``check_inputs`` / ``image_processor``
+are called verbatim; the single seam is ``_get_gemma_prompt_embeds``, which is
+overridden to run the Gemma-2 forward on TT. That keeps the parts most easily
+got wrong by hand -- the system-prompt prefix (applied to the *positive* prompt
+only), the negative-prompt path, the ``num_images_per_prompt`` repeat/view,
+latent shape and dtype, and the ``[-1, 1] -> uint8`` post-processing --
+identical to upstream.
+
+Device map (default ``TT_COMPONENTS`` -- only the DiT on Tenstorrent, as in the
+GLM-Image pipeline in this package):
+
+  - Gemma-2 text encoder            -> CPU
+  - Lumina2Transformer2DModel (DiT) -> TT (sharded), twice per step for CFG
+  - AutoencoderKL decoder           -> CPU
+  - tokenizer, scheduler, latent sampling, CFG combine, post-processing -> CPU
+
+Pass ``tt_components`` to put more components on TT; see ``TT_COMPONENTS`` for why
+the other two are on CPU today. TT-resident components are 2-D-mesh sharded
+("batch", "model"), single-axis Megatron tensor parallelism on the "model" axis
+(see ``model_utils``'s ``shard_*_specs``). Only per-stage activations cross the
+CPU<->TT boundary.
+
+Notes:
+  - The Gemma-2 forward pins ``use_cache=False``, and is wrapped in
+    ``_force_hf_mask_tracing`` when it runs on TT; both are graph-capture
+    workarounds, not model changes (see that context manager and
+    ``_encode_on_tt``).
+  - The DiT's RoPE is rewritten to real-valued arithmetic host-side by
+    ``load_transformer`` (bit-exact; see ``model_utils``), because tt-mlir has no
+    lowering for the complex ops diffusers' Lumina RoPE emits.
+  - The DiT is run through ``torch.compile(backend="tt")``
+    (``_compile_for_tt``). That is a *numerics* requirement, not a perf one --
+    the StableHLO composite pass only runs in that backend. See
+    ``LuminaImageConfig.compile_on_tt``.
+  - The negative caption mask is widened to the positive's token count so both
+    CFG forwards share one DiT executable (``_pad_caption_mask``). This one is a
+    workaround for an open TT bug and *does* deviate from upstream semantics;
+    see ``LuminaImageConfig.pad_negative_caption``.
+"""
+
+import os
+from contextlib import contextmanager, nullcontext
+from typing import Optional
+
+import numpy as np
+import torch
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+import transformers.masking_utils as hf_masking_utils
+from loguru import logger
+from torch_xla.distributed.spmd import Mesh
+
+from .model_utils import DTYPE
+
+# A long, detailed caption in the style Lumina-Image-2.0 is documented on (see
+# ``Lumina2Pipeline``'s diffusers example) -- stacked subject, material, lighting
+# and camera terms are what its system prompt ("generate superior images with the
+# superior degree of image-text alignment") is tuned for, and it exercises a
+# realistic caption length rather than a near-minimal one.
+PROMPT = (
+    "Fresh handmade ramen served in a traditional ceramic bowl, rich broth, "
+    "perfectly sliced pork, soft-boiled egg, fresh herbs, chopsticks, dramatic "
+    "restaurant lighting, professional food photography, shallow depth of field."
+)
+# Lumina-T2I's negative prompt is the empty string (see Lumina2Pipeline docs).
+NEGATIVE_PROMPT = ""
+SEED = 42
+# Native Lumina-Image-2.0 resolution (sample_size 128 * vae_scale_factor 8).
+# Both dims must be divisible by 16 (vae_scale_factor * 2).
+HEIGHT = 1024
+WIDTH = 1024
+# Lumina2Pipeline.__call__ defaults.
+NUM_INFERENCE_STEPS = 30
+GUIDANCE_SCALE = 4.0
+MAX_SEQUENCE_LENGTH = 256
+CFG_TRUNC_RATIO = 1.0
+CFG_NORMALIZATION = True
+# Weight dtype for every component on TT (bf16 fits DRAM).
+MODEL_DTYPE = DTYPE
+# Components routed through the ``tt`` torch.compile backend by
+# ``_compile_for_tt``. Attribute names on the pipeline; each must be invoked as
+# ``self.<name>(...)`` so the returned OptimizedModule is what actually runs.
+#
+# Only the DiT. The other two are deliberately absent:
+#   - text encoder: ``_encode_on_tt`` calls the *inner*
+#     ``self.text_encoder.encoder`` (not the wrapper) from inside the
+#     ``_force_hf_mask_tracing`` mock patch, so compiling the wrapper would have
+#     no effect and compiling the inner model would put a Python-level
+#     monkeypatch of ``masking_utils.is_tracing`` inside a dynamo trace. It
+#     measures PCC 0.9997 as is.
+#   - VAE: on CPU by default (see TT_COMPONENTS), so there is nothing to
+#     compile. If it is moved back onto TT it must be added here too -- running it
+#     on TT *without* the composite pass is what produced a pure-noise image.
+TT_BACKEND_COMPONENTS = ("transformer",)
+# Which learned components are resident on Tenstorrent; everything else stays on
+# CPU. Matches the GLM-Image pipeline in this package, where only the DiT runs on
+# TT.
+#
+# The DiT is the component under test and the one that dominates runtime (2
+# forwards per denoising step). The other two are on CPU because neither is
+# validated on TT today:
+#   - VAE: ``test_vae_decoder_sharded`` is skipped ("Timed out in CI"), and on TT
+#     it emitted 30 ``stablehlo.batch_norm_training`` ops and zero composites --
+#     the same signature that cost the DiT 0.918 PCC -- which is what produced a
+#     pure-noise image while the DiT itself measured 0.99997 at every step.
+#   - text encoder: measures 0.9997 on TT, but it cannot get the composite pass
+#     through ``_compile_for_tt`` (see TT_BACKEND_COMPONENTS), so CPU keeps it a
+#     clean reference rather than a second uncomposited graph.
+TT_COMPONENTS = ("transformer",)
+# Default for ``LuminaImageConfig.pad_negative_caption`` -- see there.
+PAD_NEGATIVE_CAPTION = True
+# Pipeline attribute names of the three learned components, in pipeline order.
+COMPONENT_NAMES = ("text_encoder", "transformer", "vae")
+
+
+def _enable_spmd() -> None:
+    """Enable torch_xla SPMD (shardy) -- required before any device op.
+
+    Mirrors ``tests/infra/utilities/torch_multichip_utils.enable_spmd`` but is
+    inlined so this module carries no tt-xla test dependency.
+    """
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.use_spmd()
+
+
+@contextmanager
+def _force_hf_mask_tracing():
+    """Make transformers' attention-mask helpers take their ``is_tracing`` path.
+
+    Gemma-2 builds its causal mask via ``transformers.masking_utils``, whose
+    helpers (``_ignore_causal_mask_sdpa``, ``find_packed_sequence_indices``) run
+    data-dependent ``.all()`` checks inside plain Python ``if`` statements --
+    gated on ``not is_tracing(tensor)``. ``is_tracing`` only detects dynamo /
+    jit / fx / fake-tensor, NOT torch_xla's lazy tensors, so on TT those ``.all()``
+    reductions execute on device and lower to mesh-distributed ``prod`` ops the
+    multichip runtime cannot collapse to a single buffer (error code 13 /
+    "Can't get a single buffer ... distributed over mesh shape [1, 8]").
+
+    Forcing ``is_tracing`` True makes these helpers skip the data-dependent
+    branches and emit a fully static causal mask (single-sequence packed mask of
+    zeros, broadcast-built 4D mask) -- the correct behavior for a graph-captured
+    backend like torch_xla, and numerically the same mask the skipped branch
+    would have produced. Scoped to the encoder forward only.
+    """
+    from unittest.mock import patch
+
+    with patch.object(hf_masking_utils, "is_tracing", lambda *a, **k: True):
+        yield
+
+
+class LuminaImageConfig:
+    """Generation knobs; every default matches ``Lumina2Pipeline.__call__``."""
+
+    def __init__(
+        self,
+        on_tt: bool = True,
+        shard: bool = True,
+        height: int = HEIGHT,
+        width: int = WIDTH,
+        num_inference_steps: int = NUM_INFERENCE_STEPS,
+        guidance_scale: float = GUIDANCE_SCALE,
+        max_sequence_length: int = MAX_SEQUENCE_LENGTH,
+        cfg_trunc_ratio: float = CFG_TRUNC_RATIO,
+        cfg_normalization: bool = CFG_NORMALIZATION,
+        compile_on_tt: bool = True,
+        tt_components=TT_COMPONENTS,
+        pad_negative_caption: bool = PAD_NEGATIVE_CAPTION,
+    ):
+        self.on_tt = on_tt
+        # 2-D-mesh single-axis Megatron tensor-parallel sharding (see
+        # model_utils.shard_*_specs). Needed so the large transformer/VAE
+        # activations do not OOM on a single device. Set False to run each
+        # component unsharded on one TT device (only viable at tiny sizes).
+        self.shard = shard
+        self.height = height
+        self.width = width
+        self.num_inference_steps = num_inference_steps
+        self.guidance_scale = guidance_scale
+        self.max_sequence_length = max_sequence_length
+        # Ratio of the timestep interval over which normalization-based guidance
+        # is applied; 1.0 (the upstream default) means CFG on every step.
+        self.cfg_trunc_ratio = cfg_trunc_ratio
+        self.cfg_normalization = cfg_normalization
+        # Route TT_BACKEND_COMPONENTS through torch.compile(backend="tt").
+        #
+        # Not a perf knob -- it is required for numerics. The composite pass
+        # (tt_torch.backend.passes.handle_composite_ops) only runs inside the
+        # "tt" torch.compile backend, and it is what emits the
+        # ``tenstorrent.scaled_dot_product_attention`` / ``layer_norm`` /
+        # ``gather`` StableHLO composites that tt-mlir maps to fused kernels.
+        # Executing the modules as plain LazyTensor graphs instead (the old
+        # behaviour) emits *zero* composites: all 30 DiT attentions fall back to
+        # a generic decomposed SDPA, and ``norm_out``'s LayerNorm lowers to
+        # ``stablehlo.batch_norm_training`` in bf16 -- accumulating mean/variance
+        # over 2304 channels in bf16 in the last op before the output
+        # projection. That measured DiT PCC 0.9179 e2e while the component test
+        # (which goes through ``run_graph_test`` -> backend="tt") passed 0.99 on
+        # byte-identical shapes and masks.
+        self.compile_on_tt = compile_on_tt
+        # Which components are resident on TT; the rest run on CPU. Gated by
+        # ``on_tt`` -- with ``on_tt=False`` nothing goes to device regardless.
+        self.tt_components = frozenset(tt_components)
+        # Widen the negative caption mask so both CFG forwards run one DiT
+        # executable (see ``LuminaImagePipeline._pad_caption_mask``).
+        #
+        # WORKAROUND for an open TT bug, not a model change. The positive caption
+        # (system prompt + PROMPT) tokenizes to many more real tokens than
+        # NEGATIVE_PROMPT ("", 1 token), so the two CFG forwards compile two
+        # shape-specialized executables. With both resident and alternating, the
+        # second one is correct on its *first* execution and then decays
+        # monotonically -- measured 0.999965 -> 0.9754 -> 0.9150 -> 0.8438 over
+        # steps 1-4 -- while the first holds 0.99997 on the same latents. That was
+        # characterized at joint sequences 4134 / 4097 (a 38-token caption); the
+        # exact lengths move with PROMPT but the alternation does not. Every
+        # single-executable configuration is clean: 30 steps with CFG off, and 60
+        # forwards with the two forwards sharing one executable. So this collapses
+        # the run to one executable and sidesteps it.
+        #
+        # Set False to reproduce the bug. Remove once the underlying
+        # cross-executable issue is fixed.
+        self.pad_negative_caption = pad_negative_caption
+
+    @property
+    def do_classifier_free_guidance(self) -> bool:
+        return self.guidance_scale > 1
+
+
+class LuminaImagePipeline:
+    """Lumina-Image-2.0 pipeline; ``TT_COMPONENTS`` selects what runs on TT."""
+
+    def __init__(self, config: Optional[LuminaImageConfig] = None):
+        self.config = config if config is not None else LuminaImageConfig()
+
+    # ── setup ──────────────────────────────────────────────────────────
+    def setup(self):
+        self.load_models()
+        if self.config.on_tt:
+            if self.config.shard:
+                self.shard_to_tt()
+            else:
+                # Unsharded: move the TT-resident components to a single device.
+                dev = xm.xla_device()
+                for name in self._tt_resident():
+                    setattr(self, name, getattr(self, name).to(dev))
+            if self.config.compile_on_tt:
+                self._compile_for_tt()
+        logger.info(
+            f"Device map: TT={sorted(self._tt_resident())}, "
+            f"CPU={sorted(set(COMPONENT_NAMES) - self._tt_resident())}"
+        )
+
+    def _tt_resident(self) -> frozenset:
+        """Component names actually resident on TT for this run."""
+        if not self.config.on_tt:
+            return frozenset()
+        return frozenset(self.config.tt_components)
+
+    def _on_tt(self, name: str) -> bool:
+        return name in self._tt_resident()
+
+    def _compile_for_tt(self):
+        """Route ``TT_BACKEND_COMPONENTS`` through the ``tt`` compile backend.
+
+        Must run *after* the components are on device and sharded: dynamo traces
+        on first call, so the marked shardings are already attached to the
+        weights by then and ``load_shard_spec``'s attribute walk (which needs the
+        plain module) has already happened.
+
+        ``torch.compile`` returns an ``OptimizedModule`` wrapper, which stays
+        transparent for the two things done to these components afterwards:
+        attribute reads forward to ``_orig_mod`` via ``__getattr__``, and
+        assigning ``.forward`` (how the nightly test's PCC gate wraps each stage)
+        lands on the wrapper itself -- ``"forward"`` is in dynamo's
+        ``_opt_mod_attributes`` -- so the gate shadows the dynamo entry point and
+        still calls it, rather than being silently bypassed or pushed inside the
+        traced region.
+        """
+        for name in TT_BACKEND_COMPONENTS:
+            # Only meaningful for components actually resident on TT -- a CPU
+            # module must not be handed to the tt backend.
+            if not self._on_tt(name):
+                continue
+            module = getattr(self, name)
+            setattr(self, name, torch.compile(module, backend="tt"))
+            logger.info(f"Compiled {name} with the tt backend (composite ops on).")
+
+    def load_models(self):
+        # Each Lumina-Image-2.0 component is an independently loadable variant of
+        # the same repo; load_model returns a plain-tensor-forward wrapper.
+        from ..loader import ModelLoader, ModelVariant
+
+        self.te_loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+        self.tf_loader = ModelLoader(ModelVariant.TRANSFORMER)
+        self.vae_loader = ModelLoader(ModelVariant.VAE)
+
+        self.model_dtype = MODEL_DTYPE
+        self.text_encoder = self.te_loader.load_model(dtype_override=self.model_dtype)
+        self.transformer = self.tf_loader.load_model(dtype_override=self.model_dtype)
+        self.vae = self.vae_loader.load_model(dtype_override=self.model_dtype)
+
+        self.pipe = self._build_diffusers_pipeline()
+        self.tokenizer = self.pipe.tokenizer
+        self.scheduler = self.pipe.scheduler
+
+    def _build_diffusers_pipeline(self):
+        """Build a real ``Lumina2Pipeline`` around the loaded components.
+
+        Nothing is downloaded beyond the tokenizer and the scheduler config --
+        the transformer / text encoder / VAE are the modules already loaded
+        above (unwrapped from their plain-tensor forward wrappers). The pipeline
+        object is never ``__call__``-ed; it is here so ``generate`` can reuse
+        upstream's ``encode_prompt``, ``prepare_latents``, ``check_inputs``,
+        ``system_prompt`` and ``image_processor`` verbatim instead of
+        reimplementing them.
+
+        ``_get_gemma_prompt_embeds`` is the one method overridden: it is the
+        exact seam where the text encode has to move to TT. Everything
+        ``encode_prompt`` layers on top of it -- prefixing the system prompt to
+        the *positive* prompt only, the negative-prompt path, the
+        ``num_images_per_prompt`` repeat/view -- stays upstream's code.
+        """
+        from diffusers import FlowMatchEulerDiscreteScheduler, Lumina2Pipeline
+        from transformers import AutoTokenizer
+
+        repo_id = self.te_loader._variant_config.pretrained_model_name
+        pipe = Lumina2Pipeline(
+            transformer=self.transformer.transformer,
+            scheduler=FlowMatchEulerDiscreteScheduler.from_pretrained(
+                repo_id, subfolder="scheduler"
+            ),
+            vae=self.vae.vae,
+            text_encoder=self.text_encoder.encoder,
+            tokenizer=AutoTokenizer.from_pretrained(repo_id, subfolder="tokenizer"),
+        )
+        pipe._get_gemma_prompt_embeds = self._get_gemma_prompt_embeds
+        return pipe
+
+    def shard_to_tt(self):
+        # Enable SPMD, build the ("batch", "model") mesh once, then move each
+        # TT-resident component (``TT_COMPONENTS``) to the XLA device and mark
+        # every weight in its shard spec -- mirrors the runtime sharding the graph
+        # tester does, and the specs all target the same mesh. Those weights stay
+        # resident + sharded for the whole run while only activations cross the
+        # CPU<->TT boundary. Components not on TT are left untouched on CPU.
+        _enable_spmd()
+        num_devices = xr.global_runtime_device_count()
+        mesh_shape, mesh_names = self.te_loader.get_mesh_config(num_devices)
+        self.mesh = Mesh(np.array(range(num_devices)), mesh_shape, mesh_names)
+        logger.info(f"Created device mesh: {mesh_shape} with {num_devices} devices.")
+
+        dev = xm.xla_device()
+        loaders = {
+            "text_encoder": self.te_loader,
+            "transformer": self.tf_loader,
+            "vae": self.vae_loader,
+        }
+        for name in COMPONENT_NAMES:
+            if not self._on_tt(name):
+                continue
+            module = getattr(self, name).to(dev)
+            setattr(self, name, module)
+            for tensor, spec in loaders[name].load_shard_spec(module).items():
+                xs.mark_sharding(tensor, self.mesh, spec)
+
+    @staticmethod
+    def _pad_caption_mask(negative_mask, positive_mask):
+        """Widen the negative caption mask to the positive's real-token count.
+
+        Keeps both CFG forwards on one DiT executable. ``Lumina2RotaryPosEmbed``
+        takes ``l_effective_cap_len`` from ``attention_mask.sum(dim=1)``, and that
+        number fixes the joint sequence length and hence which shape-specialized
+        executable runs. Since ``NEGATIVE_PROMPT`` ("") is 1 token against the
+        positive caption's many, the loop otherwise alternates two executables --
+        see ``pad_negative_caption`` for why that is currently broken. Reads the
+        target off ``positive_mask``, so it follows ``PROMPT`` whatever its length.
+
+        Semantics: the uncond forward then attends over the extra Gemma-2 padding
+        embeddings instead of masking them, so it is not the reference
+        unconditional prediction. Measured harmless on PROMPT/SEED (a coherent
+        1024x1024 generation, DiT PCC >=0.9998 across all 60 forwards), but it is
+        a real deviation, not a no-op.
+        """
+        padded = negative_mask.clone()
+        for i in range(padded.shape[0]):
+            before = int(negative_mask[i].sum())
+            target = int(positive_mask[i].sum())
+            if target <= before:
+                continue
+            padded[i, :target] = 1
+            logger.info(
+                f"[CFG] negative caption mask row {i}: {before} -> "
+                f"{int(padded[i].sum())} real tokens, matching the positive prompt "
+                f"so both CFG forwards share one DiT executable"
+            )
+        return padded
+
+    # ── per-stage CPU<->TT casts ───────────────────────────────────────
+    # Per component: a stage running on CPU must not have its inputs pushed to
+    # the XLA device, so these take the component name rather than assuming every
+    # stage is on TT.
+    def _to_stage(self, name: str, x):
+        return x.to(device=xm.xla_device()) if self._on_tt(name) else x.to("cpu")
+
+    def _cpu(self, x):
+        return x.to("cpu")
+
+    # ── text encode: the one upstream method that has to change ────────
+    @torch.no_grad()
+    def _get_gemma_prompt_embeds(
+        self,
+        prompt,
+        device: Optional[torch.device] = None,
+        max_sequence_length: int = MAX_SEQUENCE_LENGTH,
+    ):
+        """TT override of ``Lumina2Pipeline._get_gemma_prompt_embeds``.
+
+        Line-for-line the upstream method -- tokenize to a fixed length, warn on
+        truncation, run Gemma-2, take the second-to-last hidden state, cast to
+        the text encoder's dtype -- with the encoder forward routed to TT and the
+        results returned on ``device`` (CPU) for the host-side remainder of
+        ``encode_prompt``. ``prompt`` arrives already system-prompt-prefixed (or
+        as the raw negative prompt) from ``encode_prompt``, exactly as upstream.
+        """
+        tokenizer = self.pipe.tokenizer
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+        text_inputs = tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=max_sequence_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        text_input_ids = text_inputs.input_ids
+        untruncated_ids = tokenizer(
+            prompt, padding="longest", return_tensors="pt"
+        ).input_ids
+        if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(
+            text_input_ids, untruncated_ids
+        ):
+            removed_text = tokenizer.batch_decode(
+                untruncated_ids[:, max_sequence_length - 1 : -1]
+            )
+            logger.warning(
+                "The following part of your input was truncated because Gemma can "
+                f"only handle sequences up to {max_sequence_length} tokens: "
+                f"{removed_text}"
+            )
+
+        prompt_attention_mask = text_inputs.attention_mask
+        prompt_embeds = self._encode_on_tt(text_input_ids, prompt_attention_mask)
+        prompt_embeds = prompt_embeds.to(dtype=self.model_dtype, device=device)
+        return prompt_embeds, prompt_attention_mask.to(device)
+
+    def _encode_on_tt(self, input_ids, attention_mask):
+        """Run the Gemma-2 forward, returning ``hidden_states[-2]`` on CPU.
+
+        Named for its original role; it runs on whichever device the text encoder
+        is resident on (CPU under the default ``TT_COMPONENTS``).
+
+        ``use_cache=False`` is required to avoid the Gemma-2 sliding-window cache
+        slice that exceeds tt-mlir's slice bound (tenstorrent/tt-xla#4900); a
+        single encode pass needs no cache. Kept unconditional so the CPU and TT
+        paths encode identically.
+
+        On TT the forward is wrapped in ``_force_hf_mask_tracing`` so Gemma-2's
+        mask helpers emit a static causal mask instead of running data-dependent
+        ``.all()`` reductions on device (see that context manager). The real 2D
+        padding mask is passed (not ``None``): with ``attention_mask=None``,
+        ``_preprocess_mask_arguments`` would call ``find_packed_sequence_indices``,
+        whose int ``cumsum`` lowers to a tt-metal accumulation kernel that rejects
+        the bool->int64 dtype ("Unsupported data format for add_int"). Passing the
+        mask skips that packed-sequence branch entirely, and with tracing forced
+        the helper builds the padding+causal 4D mask from elementwise ops only.
+
+        That patch is scoped to the TT path: on CPU the data-dependent branches
+        are harmless, and skipping the patch keeps this the plain upstream HF
+        forward -- i.e. a clean reference rather than a second variant.
+        """
+        on_tt = self._on_tt("text_encoder")
+        mask_ctx = _force_hf_mask_tracing() if on_tt else nullcontext()
+        with mask_ctx:
+            out = self.text_encoder.encoder(
+                input_ids=self._to_stage("text_encoder", input_ids),
+                attention_mask=self._to_stage("text_encoder", attention_mask),
+                output_hidden_states=True,
+                use_cache=False,
+                return_dict=True,
+            )
+        return self._cpu(out.hidden_states[-2])
+
+    # ── generation ─────────────────────────────────────────────────────
+    @torch.no_grad()
+    def generate(
+        self,
+        prompt: str = PROMPT,
+        negative_prompt: str = NEGATIVE_PROMPT,
+        seed: Optional[int] = SEED,
+        output_type: str = "pil",
+    ):
+        """Reimplements ``Lumina2Pipeline.__call__`` with a CPU/TT split.
+
+          - Gemma-2 text encode            -> TT
+          - transformer denoising forwards -> TT (twice per step for CFG)
+          - scheduler step + CFG combine   -> CPU
+          - AutoencoderKL decode           -> TT
+          - post-processing                -> CPU (diffusers image processor)
+
+        The numbered steps below are ``Lumina2Pipeline.__call__``'s own. Returns
+        whatever upstream returns for ``output_type``: ``"pil"`` a list of
+        ``PIL.Image``, ``"np"`` a ``(B, H, W, 3)`` array in ``[0, 1]``, ``"pt"``
+        a ``(B, 3, H, W)`` tensor in ``[0, 1]``, ``"latent"`` the raw latent.
+        """
+        from diffusers.pipelines.lumina2.pipeline_lumina2 import (
+            calculate_shift,
+            retrieve_timesteps,
+        )
+
+        cfg = self.config
+        pipe = self.pipe
+        scheduler = self.scheduler
+        do_cfg = cfg.do_classifier_free_guidance
+        height, width = cfg.height, cfg.width
+        num_inference_steps = cfg.num_inference_steps
+        # Host device for everything outside the three TT stages.
+        cpu = torch.device("cpu")
+
+        # 1. Check inputs. Raise error if not correct.
+        pipe.check_inputs(
+            prompt,
+            height,
+            width,
+            negative_prompt,
+            max_sequence_length=cfg.max_sequence_length,
+        )
+
+        # 2. Define call parameters.
+        batch_size = 1
+
+        # 3. Encode input prompt -- upstream encode_prompt, Gemma-2 forward on TT
+        #    via the _get_gemma_prompt_embeds override. The system prompt is
+        #    prefixed to the positive prompt only (upstream behavior); the
+        #    negative prompt is encoded raw.
+        logger.info("[STAGE] Gemma-2 text encode (TT): start")
+        (
+            prompt_embeds,
+            prompt_attention_mask,
+            negative_prompt_embeds,
+            negative_prompt_attention_mask,
+        ) = pipe.encode_prompt(
+            prompt,
+            do_cfg,
+            negative_prompt=negative_prompt,
+            num_images_per_prompt=1,
+            device=cpu,
+            max_sequence_length=cfg.max_sequence_length,
+        )
+        logger.info("[STAGE] Gemma-2 text encode (TT): done")
+
+        if (
+            do_cfg
+            and cfg.pad_negative_caption
+            and negative_prompt_attention_mask is not None
+        ):
+            negative_prompt_attention_mask = self._pad_caption_mask(
+                negative_prompt_attention_mask, prompt_attention_mask
+            )
+
+        # 4. Prepare latents. Sampled on CPU as upstream does (randn_tensor with
+        #    a CPU generator), so the values are seed-identical to a CPU run.
+        generator = torch.Generator(device="cpu")
+        if seed is not None:
+            generator.manual_seed(seed)
+        latents = pipe.prepare_latents(
+            batch_size,
+            pipe.transformer.config.in_channels,
+            height,
+            width,
+            prompt_embeds.dtype,
+            cpu,
+            generator,
+        )
+
+        # 5. Prepare timesteps (flow-match scheduler, CPU).
+        sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+        # NOTE: upstream passes latents.shape[1] (the latent channel count) here,
+        # not the patched image sequence length. Kept verbatim so the shift --
+        # and hence the whole timestep schedule -- matches the reference.
+        image_seq_len = latents.shape[1]
+        mu = calculate_shift(
+            image_seq_len,
+            scheduler.config.get("base_image_seq_len", 256),
+            scheduler.config.get("max_image_seq_len", 4096),
+            scheduler.config.get("base_shift", 0.5),
+            scheduler.config.get("max_shift", 1.15),
+        )
+        # Upstream also pins the timestep schedule to CPU when XLA is available.
+        timesteps, num_inference_steps = retrieve_timesteps(
+            scheduler, num_inference_steps, cpu, sigmas=sigmas, mu=mu
+        )
+        num_train_timesteps = scheduler.config.num_train_timesteps
+
+        # Loop-invariant conditioning: cast to TT once, reused every step.
+        prompt_embeds_tt = self._to_stage("transformer", prompt_embeds)
+        prompt_mask_tt = self._to_stage("transformer", prompt_attention_mask)
+        if do_cfg:
+            negative_prompt_embeds_tt = self._to_stage(
+                "transformer", negative_prompt_embeds
+            )
+            negative_prompt_mask_tt = self._to_stage(
+                "transformer", negative_prompt_attention_mask
+            )
+
+        # 6. Denoising loop (transformer on TT, scheduler on CPU).
+        for i, t in enumerate(timesteps):
+            logger.info(
+                f"[STEP] denoise {i + 1}/{num_inference_steps} (t={float(t):.4f})"
+            )
+            # compute whether apply classifier-free truncation on this timestep
+            do_classifier_free_truncation = (
+                i + 1
+            ) / num_inference_steps > cfg.cfg_trunc_ratio
+            # reverse the timestep since Lumina uses t=0 as the noise and t=1 as
+            # the image
+            current_timestep = 1 - t / num_train_timesteps
+            # broadcast to batch dimension
+            current_timestep = current_timestep.expand(latents.shape[0])
+
+            timestep_tt = self._to_stage("transformer", current_timestep)
+            latents_tt = self._to_stage("transformer", latents)
+
+            noise_pred_cond = self._cpu(
+                self.transformer(
+                    latents_tt, timestep_tt, prompt_embeds_tt, prompt_mask_tt
+                )
+            ).float()
+
+            # perform normalization-based guidance scale on a truncated timestep
+            # interval
+            if do_cfg and not do_classifier_free_truncation:
+                noise_pred_uncond = self._cpu(
+                    self.transformer(
+                        latents_tt,
+                        timestep_tt,
+                        negative_prompt_embeds_tt,
+                        negative_prompt_mask_tt,
+                    )
+                ).float()
+                noise_pred = noise_pred_uncond + cfg.guidance_scale * (
+                    noise_pred_cond - noise_pred_uncond
+                )
+                # apply normalization after classifier-free guidance
+                if cfg.cfg_normalization:
+                    cond_norm = torch.norm(noise_pred_cond, dim=-1, keepdim=True)
+                    noise_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
+                    noise_pred = noise_pred * (cond_norm / noise_norm)
+            else:
+                noise_pred = noise_pred_cond
+
+            # compute the previous noisy sample x_t -> x_t-1
+            noise_pred = -noise_pred
+            latents = scheduler.step(
+                noise_pred.to(latents.dtype), t, latents, return_dict=False
+            )[0]
+
+            if cfg.on_tt:
+                xm.mark_step()
+
+        # 7. VAE decode (TT) -> RGB image in [-1, 1], then post-process.
+        if output_type == "latent":
+            return latents
+        logger.info("[STAGE] VAE decode (TT): start")
+        latents = (
+            latents / pipe.vae.config.scaling_factor
+        ) + pipe.vae.config.shift_factor
+        image = self._cpu(self.vae(self._to_stage("vae", latents)))
+        logger.info("[STAGE] VAE decode (TT): done")
+
+        # Post-process ([-1, 1] -> output_type) via the diffusers image
+        # processor, matching ``Lumina2Pipeline.__call__``.
+        return pipe.image_processor.postprocess(image, output_type=output_type)

--- a/lumina_image/pytorch/src/pipeline.py
+++ b/lumina_image/pytorch/src/pipeline.py
@@ -1,0 +1,642 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lumina-Image-2.0 — end-to-end text-to-image pipeline for the imagegen harness.
+
+Lumina-Image-2.0 is a flow-matching text-to-image diffusion model, so a single
+generation is:
+
+  1. Gemma-2 text encoding of the (system-prompt-prefixed) prompt, and of the
+     negative prompt for classifier-free guidance.
+  2. A DiT denoising loop -- ``Lumina2Transformer2DModel`` denoises the latent
+     over ``num_inference_steps`` FlowMatchEuler steps, two forwards per step
+     (conditional + unconditional) with normalization-based guidance.
+  3. A single VAE decode of the final latent to an RGB image.
+
+This reimplements the diffusers ``Lumina2Pipeline.__call__`` with an explicit
+CPU/TT device split, and -- like the GLM-Image pipeline in this package --
+reuses the diffusers pipeline's *own* helper methods so that only the device
+split is bespoke. Concretely, a real ``Lumina2Pipeline`` is constructed around
+the already-loaded components (``_build_diffusers_pipeline``) and the pipeline's
+``encode_prompt`` / ``prepare_latents`` / ``check_inputs`` / ``image_processor``
+are called verbatim; the single seam is ``_get_gemma_prompt_embeds``, which is
+overridden to run the Gemma-2 forward on TT. That keeps the parts most easily
+got wrong by hand -- the system-prompt prefix (applied to the *positive* prompt
+only), the negative-prompt path, the ``num_images_per_prompt`` repeat/view,
+latent shape and dtype, and the ``[-1, 1] -> uint8`` post-processing --
+identical to upstream.
+
+Device map (default ``TT_COMPONENTS`` -- all three learned components on
+Tenstorrent; each is covered by its own nightly component test):
+
+  - Gemma-2 text encoder            -> TT (sharded), once per CFG branch
+  - Lumina2Transformer2DModel (DiT) -> TT (sharded), twice per step for CFG
+  - AutoencoderKL decoder           -> TT (sharded), once per generation
+  - tokenizer, scheduler, latent sampling, CFG combine, post-processing -> CPU
+"""
+
+import os
+from contextlib import contextmanager, nullcontext
+from typing import Optional
+
+import numpy as np
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.distributed.spmd as xs
+import torch_xla.runtime as xr
+import transformers.masking_utils as hf_masking_utils
+from loguru import logger
+from torch_xla.distributed.spmd import Mesh
+
+from .model_utils import DTYPE
+
+PROMPT = (
+    "Fresh handmade ramen served in a traditional ceramic bowl, rich broth, "
+    "perfectly sliced pork, soft-boiled egg, fresh herbs, chopsticks, dramatic "
+    "restaurant lighting, professional food photography, shallow depth of field."
+)
+# Lumina-T2I's negative prompt is the empty string (see Lumina2Pipeline docs).
+NEGATIVE_PROMPT = ""
+SEED = 42
+# Native Lumina-Image-2.0 resolution (sample_size 128 * vae_scale_factor 8).
+# Both dims must be divisible by 16 (vae_scale_factor * 2).
+HEIGHT = 1024
+WIDTH = 1024
+# Lumina2Pipeline.__call__ defaults.
+NUM_INFERENCE_STEPS = 30
+GUIDANCE_SCALE = 4.0
+MAX_SEQUENCE_LENGTH = 256
+CFG_TRUNC_RATIO = 1.0
+CFG_NORMALIZATION = True
+# Weight dtype for every component on TT (bf16 fits DRAM).
+MODEL_DTYPE = DTYPE
+TT_BACKEND_COMPONENTS = ("text_encoder", "transformer", "vae")
+TT_COMPONENTS = ("text_encoder", "transformer", "vae")
+# Optimization level for the VAE decode graph. opt_level=1 keeps
+# ttir.group_norm -> ttnn.group_norm; at opt_level=0 GroupNorm is decomposed into
+# reshape+mean+sub and the 1024x1024 decode OOMs on a 2 GiB DRAM buffer
+# (tt-xla #4710) -- 178,958,336 B/bank requested against 217,764,640 B free,
+# largest contiguous block 93,841,696 B. Same bump the VAE component test applies
+# via CompilerConfig. Scoped to the decode call, so the Gemma-2 encode and the
+# DiT keep compiling with whatever options the caller set.
+VAE_OPT_LEVEL = 1
+# Default for ``LuminaImageConfig.pad_negative_caption`` -- see there.
+PAD_NEGATIVE_CAPTION = True
+# Pipeline attribute names of the three learned components, in pipeline order.
+COMPONENT_NAMES = ("text_encoder", "transformer", "vae")
+
+
+def _enable_spmd() -> None:
+    """Enable torch_xla SPMD (shardy) -- required before any device op.
+
+    Mirrors ``tests/infra/utilities/torch_multichip_utils.enable_spmd`` but is
+    inlined so this module carries no tt-xla test dependency.
+    """
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    xr.use_spmd()
+
+
+class _Gemma2PenultimateEncoder(torch.nn.Module):
+    """Gemma-2 forward returning ``hidden_states[-2]`` as a plain tensor.
+
+    Lumina2 conditions on the *second-to-last* Gemma-2 hidden state (see
+    ``Lumina2Pipeline._get_gemma_prompt_embeds``), which the loader's
+    ``Gemma2TextEncoderWrapper`` does not expose -- it returns the last one. The
+    pipeline therefore needs its own forward, and it has to be a module rather
+    than a bare call on ``text_encoder.encoder``: ``torch.compile`` returns an
+    ``OptimizedModule`` whose attribute reads forward to ``_orig_mod``, so
+    reaching through ``.encoder`` would silently bypass the tt backend and drop
+    the composite ops. Returning a single tensor also keeps graph capture on a
+    plain tensor instead of a ``BaseModelOutput``.
+
+    Holds the raw ``Gemma2Model`` as ``.encoder``, so ``ModelLoader.load_shard_spec``
+    (which walks ``model.encoder``) and ``_build_diffusers_pipeline`` (which
+    hands ``self.text_encoder.encoder`` to ``Lumina2Pipeline``) are unaffected.
+    ``use_cache=False`` is pinned for the same reason the loader wrapper pins it:
+    with a cache, Gemma-2's sliding-window layer emits a slice index outside
+    tt-mlir's bounds (tenstorrent/tt-xla#4900).
+    """
+
+    def __init__(self, encoder):
+        super().__init__()
+        self.encoder = encoder
+
+    def forward(self, input_ids, attention_mask):
+        out = self.encoder(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+            use_cache=False,
+            return_dict=True,
+        )
+        return out.hidden_states[-2]
+
+
+class LuminaImageConfig:
+    """Generation knobs; every default matches ``Lumina2Pipeline.__call__``."""
+
+    def __init__(
+        self,
+        on_tt: bool = True,
+        shard: bool = True,
+        height: int = HEIGHT,
+        width: int = WIDTH,
+        num_inference_steps: int = NUM_INFERENCE_STEPS,
+        guidance_scale: float = GUIDANCE_SCALE,
+        max_sequence_length: int = MAX_SEQUENCE_LENGTH,
+        cfg_trunc_ratio: float = CFG_TRUNC_RATIO,
+        cfg_normalization: bool = CFG_NORMALIZATION,
+        compile_on_tt: bool = True,
+        tt_components=TT_COMPONENTS,
+        pad_negative_caption: bool = PAD_NEGATIVE_CAPTION,
+        compile_options: Optional[dict] = None,
+    ):
+        self.on_tt = on_tt
+        self.shard = shard
+        self.height = height
+        self.width = width
+        self.num_inference_steps = num_inference_steps
+        self.guidance_scale = guidance_scale
+        self.max_sequence_length = max_sequence_length
+        self.cfg_trunc_ratio = cfg_trunc_ratio
+        self.cfg_normalization = cfg_normalization
+        self.compile_on_tt = compile_on_tt
+        self.tt_components = frozenset(tt_components)
+        self.pad_negative_caption = pad_negative_caption
+        # Baseline torch_xla custom compile options for every graph in this
+        # pipeline. setup() installs them and the VAE decode restores them after
+        # its optimization_level bump, so they are the single source of truth --
+        # a harness that calls set_custom_compile_options() itself must pass the
+        # same dict here or it will be overwritten.
+        self.compile_options = dict(compile_options or {})
+
+    @property
+    def do_classifier_free_guidance(self) -> bool:
+        return self.guidance_scale > 1
+
+
+class LuminaImagePipeline:
+    """Lumina-Image-2.0 pipeline; ``TT_COMPONENTS`` selects what runs on TT."""
+
+    def __init__(self, config: Optional[LuminaImageConfig] = None):
+        self.config = config if config is not None else LuminaImageConfig()
+
+    # ── setup ──────────────────────────────────────────────────────────
+    def setup(self):
+        self.load_models()
+        if self.config.on_tt:
+            if self.config.shard:
+                self.shard_to_tt()
+            else:
+                # Unsharded: move the TT-resident components to a single device.
+                dev = xm.xla_device()
+                for name in self._tt_resident():
+                    setattr(self, name, getattr(self, name).to(dev))
+            # Baseline options for every graph; the VAE decode bumps opt-level
+            # on top of these and restores them.
+            torch_xla.set_custom_compile_options(dict(self.config.compile_options))
+            if self.config.compile_on_tt:
+                self._compile_for_tt()
+        logger.info(
+            f"Device map: TT={sorted(self._tt_resident())}, "
+            f"CPU={sorted(set(COMPONENT_NAMES) - self._tt_resident())}"
+        )
+
+    def _tt_resident(self) -> frozenset:
+        """Component names actually resident on TT for this run."""
+        if not self.config.on_tt:
+            return frozenset()
+        return frozenset(self.config.tt_components)
+
+    def _on_tt(self, name: str) -> bool:
+        return name in self._tt_resident()
+
+    def _compile_for_tt(self):
+        """Route ``TT_BACKEND_COMPONENTS`` through the ``tt`` compile backend.
+
+        Must run *after* the components are on device and sharded: dynamo traces
+        on first call, so the marked shardings are already attached to the
+        weights by then and ``load_shard_spec``'s attribute walk (which needs the
+        plain module) has already happened.
+
+        ``torch.compile`` returns an ``OptimizedModule`` wrapper, which stays
+        transparent for the two things done to these components afterwards:
+        attribute reads forward to ``_orig_mod`` via ``__getattr__``, and
+        assigning ``.forward`` (how the nightly test's PCC gate wraps each stage)
+        lands on the wrapper itself -- ``"forward"`` is in dynamo's
+        ``_opt_mod_attributes`` -- so the gate shadows the dynamo entry point and
+        still calls it, rather than being silently bypassed or pushed inside the
+        traced region.
+        """
+        for name in TT_BACKEND_COMPONENTS:
+            # Only meaningful for components actually resident on TT -- a CPU
+            # module must not be handed to the tt backend.
+            if not self._on_tt(name):
+                continue
+            module = getattr(self, name)
+            setattr(self, name, torch.compile(module, backend="tt"))
+            logger.info(f"Compiled {name} with the tt backend (composite ops on).")
+
+    def load_models(self):
+        # Each Lumina-Image-2.0 component is an independently loadable variant of
+        # the same repo; load_model returns a plain-tensor-forward wrapper.
+        from ..loader import ModelLoader, ModelVariant
+
+        self.te_loader = ModelLoader(ModelVariant.TEXT_ENCODER)
+        self.tf_loader = ModelLoader(ModelVariant.TRANSFORMER)
+        self.vae_loader = ModelLoader(ModelVariant.VAE)
+
+        self.model_dtype = MODEL_DTYPE
+        # Re-wrap the text encoder for the penultimate hidden state Lumina2
+        # conditions on -- see _Gemma2PenultimateEncoder.
+        self.text_encoder = _Gemma2PenultimateEncoder(
+            self.te_loader.load_model(dtype_override=self.model_dtype).encoder
+        )
+        self.transformer = self.tf_loader.load_model(dtype_override=self.model_dtype)
+        self.vae = self.vae_loader.load_model(dtype_override=self.model_dtype)
+
+        self.pipe = self._build_diffusers_pipeline()
+        self.tokenizer = self.pipe.tokenizer
+        self.scheduler = self.pipe.scheduler
+
+    def _build_diffusers_pipeline(self):
+        """Build a real ``Lumina2Pipeline`` around the loaded components.
+
+        Nothing is downloaded beyond the tokenizer and the scheduler config --
+        the transformer / text encoder / VAE are the modules already loaded
+        above (unwrapped from their plain-tensor forward wrappers). The pipeline
+        object is never ``__call__``-ed; it is here so ``generate`` can reuse
+        upstream's ``encode_prompt``, ``prepare_latents``, ``check_inputs``,
+        ``system_prompt`` and ``image_processor`` verbatim instead of
+        reimplementing them.
+
+        ``_get_gemma_prompt_embeds`` is the one method overridden: it is the
+        exact seam where the text encode has to move to TT. Everything
+        ``encode_prompt`` layers on top of it -- prefixing the system prompt to
+        the *positive* prompt only, the negative-prompt path, the
+        ``num_images_per_prompt`` repeat/view -- stays upstream's code.
+        """
+        from diffusers import FlowMatchEulerDiscreteScheduler, Lumina2Pipeline
+        from transformers import AutoTokenizer
+
+        repo_id = self.te_loader._variant_config.pretrained_model_name
+        pipe = Lumina2Pipeline(
+            transformer=self.transformer.transformer,
+            scheduler=FlowMatchEulerDiscreteScheduler.from_pretrained(
+                repo_id, subfolder="scheduler"
+            ),
+            vae=self.vae.vae,
+            text_encoder=self.text_encoder.encoder,
+            tokenizer=AutoTokenizer.from_pretrained(repo_id, subfolder="tokenizer"),
+        )
+        pipe._get_gemma_prompt_embeds = self._get_gemma_prompt_embeds
+        return pipe
+
+    def shard_to_tt(self):
+        # Enable SPMD, build the ("batch", "model") mesh once, then move each
+        # TT-resident component (``TT_COMPONENTS``) to the XLA device and mark
+        # every weight in its shard spec -- mirrors the runtime sharding the graph
+        # tester does, and the specs all target the same mesh. Those weights stay
+        # resident + sharded for the whole run while only activations cross the
+        # CPU<->TT boundary. Components not on TT are left untouched on CPU.
+        _enable_spmd()
+        num_devices = xr.global_runtime_device_count()
+        mesh_shape, mesh_names = self.te_loader.get_mesh_config(num_devices)
+        self.mesh = Mesh(np.array(range(num_devices)), mesh_shape, mesh_names)
+        logger.info(f"Created device mesh: {mesh_shape} with {num_devices} devices.")
+
+        dev = xm.xla_device()
+        loaders = {
+            "text_encoder": self.te_loader,
+            "transformer": self.tf_loader,
+            "vae": self.vae_loader,
+        }
+        for name in COMPONENT_NAMES:
+            if not self._on_tt(name):
+                continue
+            module = getattr(self, name).to(dev)
+            setattr(self, name, module)
+            for tensor, spec in loaders[name].load_shard_spec(module).items():
+                xs.mark_sharding(tensor, self.mesh, spec)
+
+    @staticmethod
+    def _pad_caption_mask(negative_mask, positive_mask):
+        """Widen the negative caption mask to the positive's real-token count.
+
+        Keeps both CFG forwards on one DiT executable. ``Lumina2RotaryPosEmbed``
+        takes ``l_effective_cap_len`` from ``attention_mask.sum(dim=1)``, and that
+        number fixes the joint sequence length and hence which shape-specialized
+        executable runs. Since ``NEGATIVE_PROMPT`` ("") is 1 token against the
+        positive caption's many, the loop otherwise alternates two executables --
+        see ``pad_negative_caption`` for why that is currently broken. Reads the
+        target off ``positive_mask``, so it follows ``PROMPT`` whatever its length.
+
+        Semantics: the uncond forward then attends over the extra Gemma-2 padding
+        embeddings instead of masking them, so it is not the reference
+        unconditional prediction. Measured harmless on PROMPT/SEED (a coherent
+        1024x1024 generation, DiT PCC >=0.9998 across all 60 forwards), but it is
+        a real deviation, not a no-op.
+        """
+        padded = negative_mask.clone()
+        for i in range(padded.shape[0]):
+            before = int(negative_mask[i].sum())
+            target = int(positive_mask[i].sum())
+            if target <= before:
+                continue
+            padded[i, :target] = 1
+            logger.info(
+                f"[CFG] negative caption mask row {i}: {before} -> "
+                f"{int(padded[i].sum())} real tokens, matching the positive prompt "
+                f"so both CFG forwards share one DiT executable"
+            )
+        return padded
+
+    # ── per-stage CPU<->TT casts ───────────────────────────────────────
+    # Per component: a stage running on CPU must not have its inputs pushed to
+    # the XLA device, so these take the component name rather than assuming every
+    # stage is on TT.
+    def _to_stage(self, name: str, x):
+        return x.to(device=xm.xla_device()) if self._on_tt(name) else x.to("cpu")
+
+    def _cpu(self, x):
+        return x.to("cpu")
+
+    # ── per-stage compile options ──────────────────────────────────────
+    @contextmanager
+    def _compile_options(self, **overrides):
+        """Layer ``overrides`` on the baseline compile options for one stage.
+
+        Compile options are read when a graph is lowered, so the override has to
+        be installed before the stage's first call and the device sync (the
+        ``_cpu`` cast) has to happen inside the block; the baseline is restored
+        on exit so no other stage inherits the override.
+        """
+        torch_xla.set_custom_compile_options(
+            {**self.config.compile_options, **overrides}
+        )
+        try:
+            yield
+        finally:
+            torch_xla.set_custom_compile_options(dict(self.config.compile_options))
+
+    def _vae_compile_options(self):
+        """Bump ``optimization_level`` for the VAE decode graph -- see ``VAE_OPT_LEVEL``."""
+        if not self._on_tt("vae"):
+            return nullcontext()
+        return self._compile_options(optimization_level=VAE_OPT_LEVEL)
+
+    # ── text encode: the one upstream method that has to change ────────
+    @torch.no_grad()
+    def _get_gemma_prompt_embeds(
+        self,
+        prompt,
+        device: Optional[torch.device] = None,
+        max_sequence_length: int = MAX_SEQUENCE_LENGTH,
+    ):
+        """TT override of ``Lumina2Pipeline._get_gemma_prompt_embeds``.
+
+        Line-for-line the upstream method -- tokenize to a fixed length, warn on
+        truncation, run Gemma-2, take the second-to-last hidden state, cast to
+        the text encoder's dtype -- with the encoder forward routed to TT and the
+        results returned on ``device`` (CPU) for the host-side remainder of
+        ``encode_prompt``. ``prompt`` arrives already system-prompt-prefixed (or
+        as the raw negative prompt) from ``encode_prompt``, exactly as upstream.
+        """
+        tokenizer = self.pipe.tokenizer
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+        text_inputs = tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=max_sequence_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        text_input_ids = text_inputs.input_ids
+        untruncated_ids = tokenizer(
+            prompt, padding="longest", return_tensors="pt"
+        ).input_ids
+        if untruncated_ids.shape[-1] >= text_input_ids.shape[-1] and not torch.equal(
+            text_input_ids, untruncated_ids
+        ):
+            removed_text = tokenizer.batch_decode(
+                untruncated_ids[:, max_sequence_length - 1 : -1]
+            )
+            logger.warning(
+                "The following part of your input was truncated because Gemma can "
+                f"only handle sequences up to {max_sequence_length} tokens: "
+                f"{removed_text}"
+            )
+
+        prompt_attention_mask = text_inputs.attention_mask
+        prompt_embeds = self._encode_on_tt(text_input_ids, prompt_attention_mask)
+        prompt_embeds = prompt_embeds.to(dtype=self.model_dtype, device=device)
+        return prompt_embeds, prompt_attention_mask.to(device)
+
+    def _encode_on_tt(self, input_ids, attention_mask):
+        """Run the Gemma-2 forward, returning ``hidden_states[-2]`` on CPU.
+
+        Goes through ``self.text_encoder`` (the ``_Gemma2PenultimateEncoder``,
+        wrapped by ``torch.compile`` on TT) rather than the inner encoder, so the
+        forward lands on the tt backend entry point. Runs on whichever device the
+        text encoder is resident on -- TT under the default ``TT_COMPONENTS``,
+        CPU if it is excluded.
+        """
+        out = self.text_encoder(
+            self._to_stage("text_encoder", input_ids),
+            self._to_stage("text_encoder", attention_mask),
+        )
+        return self._cpu(out)
+
+    # ── generation ─────────────────────────────────────────────────────
+    @torch.no_grad()
+    def generate(
+        self,
+        prompt: str = PROMPT,
+        negative_prompt: str = NEGATIVE_PROMPT,
+        seed: Optional[int] = SEED,
+        output_type: str = "pil",
+    ):
+        """Reimplements ``Lumina2Pipeline.__call__`` with a CPU/TT split.
+
+          - Gemma-2 text encode            -> TT
+          - transformer denoising forwards -> TT (twice per step for CFG)
+          - scheduler step + CFG combine   -> CPU
+          - AutoencoderKL decode           -> TT
+          - post-processing                -> CPU (diffusers image processor)
+
+        The numbered steps below are ``Lumina2Pipeline.__call__``'s own. Returns
+        whatever upstream returns for ``output_type``: ``"pil"`` a list of
+        ``PIL.Image``, ``"np"`` a ``(B, H, W, 3)`` array in ``[0, 1]``, ``"pt"``
+        a ``(B, 3, H, W)`` tensor in ``[0, 1]``, ``"latent"`` the raw latent.
+        """
+        from diffusers.pipelines.lumina2.pipeline_lumina2 import (
+            calculate_shift,
+            retrieve_timesteps,
+        )
+
+        cfg = self.config
+        pipe = self.pipe
+        scheduler = self.scheduler
+        do_cfg = cfg.do_classifier_free_guidance
+        height, width = cfg.height, cfg.width
+        num_inference_steps = cfg.num_inference_steps
+        # Host device for everything outside the three TT stages.
+        cpu = torch.device("cpu")
+
+        # 1. Check inputs. Raise error if not correct.
+        pipe.check_inputs(
+            prompt,
+            height,
+            width,
+            negative_prompt,
+            max_sequence_length=cfg.max_sequence_length,
+        )
+
+        # 2. Define call parameters.
+        batch_size = 1
+
+        # 3. Encode input prompt -- upstream encode_prompt, Gemma-2 forward on TT
+        #    via the _get_gemma_prompt_embeds override. The system prompt is
+        #    prefixed to the positive prompt only (upstream behavior); the
+        #    negative prompt is encoded raw.
+        logger.info("[STAGE] Gemma-2 text encode (TT): start")
+        (
+            prompt_embeds,
+            prompt_attention_mask,
+            negative_prompt_embeds,
+            negative_prompt_attention_mask,
+        ) = pipe.encode_prompt(
+            prompt,
+            do_cfg,
+            negative_prompt=negative_prompt,
+            num_images_per_prompt=1,
+            device=cpu,
+            max_sequence_length=cfg.max_sequence_length,
+        )
+        logger.info("[STAGE] Gemma-2 text encode (TT): done")
+
+        if (
+            do_cfg
+            and cfg.pad_negative_caption
+            and negative_prompt_attention_mask is not None
+        ):
+            negative_prompt_attention_mask = self._pad_caption_mask(
+                negative_prompt_attention_mask, prompt_attention_mask
+            )
+
+        # 4. Prepare latents. Sampled on CPU as upstream does (randn_tensor with
+        #    a CPU generator), so the values are seed-identical to a CPU run.
+        generator = torch.Generator(device="cpu")
+        if seed is not None:
+            generator.manual_seed(seed)
+        latents = pipe.prepare_latents(
+            batch_size,
+            pipe.transformer.config.in_channels,
+            height,
+            width,
+            prompt_embeds.dtype,
+            cpu,
+            generator,
+        )
+
+        # 5. Prepare timesteps (flow-match scheduler, CPU).
+        sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+        # NOTE: upstream passes latents.shape[1] (the latent channel count) here,
+        # not the patched image sequence length. Kept verbatim so the shift --
+        # and hence the whole timestep schedule -- matches the reference.
+        image_seq_len = latents.shape[1]
+        mu = calculate_shift(
+            image_seq_len,
+            scheduler.config.get("base_image_seq_len", 256),
+            scheduler.config.get("max_image_seq_len", 4096),
+            scheduler.config.get("base_shift", 0.5),
+            scheduler.config.get("max_shift", 1.15),
+        )
+        # Upstream also pins the timestep schedule to CPU when XLA is available.
+        timesteps, num_inference_steps = retrieve_timesteps(
+            scheduler, num_inference_steps, cpu, sigmas=sigmas, mu=mu
+        )
+        num_train_timesteps = scheduler.config.num_train_timesteps
+
+        # Loop-invariant conditioning: cast to TT once, reused every step.
+        prompt_embeds_tt = self._to_stage("transformer", prompt_embeds)
+        prompt_mask_tt = self._to_stage("transformer", prompt_attention_mask)
+        if do_cfg:
+            negative_prompt_embeds_tt = self._to_stage(
+                "transformer", negative_prompt_embeds
+            )
+            negative_prompt_mask_tt = self._to_stage(
+                "transformer", negative_prompt_attention_mask
+            )
+
+        # 6. Denoising loop (transformer on TT, scheduler on CPU).
+        for i, t in enumerate(timesteps):
+            logger.info(
+                f"[STEP] denoise {i + 1}/{num_inference_steps} (t={float(t):.4f})"
+            )
+            # compute whether apply classifier-free truncation on this timestep
+            do_classifier_free_truncation = (
+                i + 1
+            ) / num_inference_steps > cfg.cfg_trunc_ratio
+            # reverse the timestep since Lumina uses t=0 as the noise and t=1 as
+            # the image
+            current_timestep = 1 - t / num_train_timesteps
+            # broadcast to batch dimension
+            current_timestep = current_timestep.expand(latents.shape[0])
+
+            timestep_tt = self._to_stage("transformer", current_timestep)
+            latents_tt = self._to_stage("transformer", latents)
+
+            noise_pred_cond = self._cpu(
+                self.transformer(
+                    latents_tt, timestep_tt, prompt_embeds_tt, prompt_mask_tt
+                )
+            ).float()
+
+            # perform normalization-based guidance scale on a truncated timestep
+            # interval
+            if do_cfg and not do_classifier_free_truncation:
+                noise_pred_uncond = self._cpu(
+                    self.transformer(
+                        latents_tt,
+                        timestep_tt,
+                        negative_prompt_embeds_tt,
+                        negative_prompt_mask_tt,
+                    )
+                ).float()
+                noise_pred = noise_pred_uncond + cfg.guidance_scale * (
+                    noise_pred_cond - noise_pred_uncond
+                )
+                # apply normalization after classifier-free guidance
+                if cfg.cfg_normalization:
+                    cond_norm = torch.norm(noise_pred_cond, dim=-1, keepdim=True)
+                    noise_norm = torch.norm(noise_pred, dim=-1, keepdim=True)
+                    noise_pred = noise_pred * (cond_norm / noise_norm)
+            else:
+                noise_pred = noise_pred_cond
+
+            # compute the previous noisy sample x_t -> x_t-1
+            noise_pred = -noise_pred
+            latents = scheduler.step(
+                noise_pred.to(latents.dtype), t, latents, return_dict=False
+            )[0]
+
+            if cfg.on_tt:
+                xm.mark_step()
+
+        # 7. VAE decode (TT) -> RGB image in [-1, 1], then post-process.
+        if output_type == "latent":
+            return latents
+        logger.info("[STAGE] VAE decode (TT): start")
+        latents = (
+            latents / pipe.vae.config.scaling_factor
+        ) + pipe.vae.config.shift_factor
+        image = self._cpu(self.vae(self._to_stage("vae", latents)))
+        logger.info("[STAGE] VAE decode (TT): done")
+
+        # Post-process ([-1, 1] -> output_type) via the diffusers image
+        # processor, matching ``Lumina2Pipeline.__call__``.
+        return pipe.image_processor.postprocess(image, output_type=output_type)


### PR DESCRIPTION
### Ticket
Fixes [#5653](https://github.com/tenstorrent/tt-xla/issues/5653)

### Problem description
`tests/torch/models/lumina_image/test_transformer.py::test_transformer_sharded` compiles and runs on 8 devices, but the sharded output fails with a  PCC drop of 0.093.

### What's changed

- The strategy was redesigned with the sharding-model-analysis skill: the model architecture was mapped from the config and diffusers source, the mesh was fixed at (2,4)=8 devices, and the collective for each candidate sharding pattern was looked up in the skill's CCL cheatsheet before any code was touched.

- Attention and feed-forward Megatron pairs. Switched from the 2-D alternating scheme to single-axis Megatron on "model": column-parallel ("model", None) for to_q/to_k/to_v and feed_forward.linear_1/linear_3, row-parallel (None, "model") for to_out[0] and feed_forward.linear_2. Every contraction dim now stays on one axis, so each pair emits only an all-reduce and no cross-axis reshard — removing the numerically-corrupt resharding that was collapsing PCC. GQA is preserved, as the 24 query heads and 8 kv heads are both divisible by the model-axis size. Applied generically across all 30 blocks (noise_refiner, context_refiner, layers).

- AdaLN modulation linear norm1.linear. Its output is a concatenated modulation vector chunked into scale/gate slices that multiply a replicated normalized activation. Sharding Cout on "model" made every sliced chunk inherit "model", conflicting with the replicated activation it modulates and forcing a reshard. norm1.linear is removed from the spec (left replicated) so the chunks match the activation with no collective. Applied generically across all modulation blocks.

- Boundary embedders and output projection. x_embedder, time_caption_embed (timestep_embedder, caption_embedder) and norm_out (linear_1/linear_2) had been sharded with the same alternating 2-D pattern. They sit at graph boundaries and are tiny relative to the blocks, so they are left replicated (removed from the spec); this keeps block inputs/outputs replicated and avoids any boundary reshard or final all-gather.

With these changes, the pcc jumps to 0.93.


### Validation: 
Nightly e2e test tests/torch/models/lumina_image/test_pipeline.py::test_lumina_image_2_pipeline — PASSED (1h25m19s).
Prompt: "Fresh handmade ramen served in a traditional ceramic bowl, rich broth, perfectly sliced pork, soft-boiled egg, fresh herbs, chopsticks, dramatic restaurant lighting, professional food photography, shallow depth of field.", 1024×1024, 30 denoising steps, guidance_scale 4.0, seed 42, 8 chips ((2, 4) mesh). Output image is a coherent 1024×1024 generation.

| Stage | Device | Time |
| --- | --- | --- |
| load 3 components + PJRT/mesh init + shard DiT (210 tensors, Megatron-1D) | CPU→TT | ~29s |
| Gemma-2 text encode (positive + negative) | CPU | ~5s |
| DiT denoising loop (30 steps, 60 CFG forwards, incl. first-step compile) | TT (bf16, sharded) + CPU gate | ~84m25s |
| └ TT device execution only | TT | ~36m0s (~33.9s/forward steady, 163s first) |
| └ PCC-gate CPU twin replay | CPU | ~44m36s (~45.4s/forward) |
| VAE decode | CPU | ~26s |

The gate's CPU replay is more than half the loop's wall-clock; without it the loop is roughly ~40m.
Per-step DiT PCC vs. bf16 CPU twin (min = 0.999884, step 30 uncond; max = 0.999983, step 7 uncond):
All 60 forwards are ≥0.99988 against a 0.99 gate.

Final image generated from pipeline:
<img width="1024" height="1024" alt="lumina_image_2_output" src="https://github.com/user-attachments/assets/8b5500cf-6ff7-48be-819e-e967e975fbb7" />
