### PR TITLE
[Ideogram 4] Add the VAE decoder as a second on-device component

### DIFF
--- a/ideogram_4/pytorch/loader.py
+++ b/ideogram_4/pytorch/loader.py
@@ -9,8 +9,13 @@ are FP8-only (``ideogram-ai/ideogram-4-fp8``). This loader materializes FP8
 linear weights to bfloat16 at load time so tt-xla can compile them with TT
 block formats (bfp_bf8 / bfp_bf4) via mixed-precision overrides.
 
-Bringup starts with the conditional transformer at 512x512 packed-sequence
-shapes matching the CPU inference smoke test.
+Components:
+  - Transformer_FP8_512 -> conditional Ideogram4Transformer DiT (9.3B)
+  - Vae                 -> AutoEncoder decoder (49.6M)
+
+The transformer runs at 512x512 packed-sequence shapes matching the CPU
+inference smoke test, and is tensor-parallel sharded; the VAE decoder fits on a
+single chip.
 """
 
 from typing import Optional
@@ -34,7 +39,9 @@ from .src.model_utils import (
     REPO_ID,
     Ideogram4TransformerWrapper,
     build_synthetic_transformer_inputs,
+    build_vae_decoder_inputs,
     load_conditional_transformer,
+    load_vae_decoder,
     shard_transformer_specs,
 )
 
@@ -43,6 +50,7 @@ class ModelVariant(StrEnum):
     """Loadable Ideogram 4 components."""
 
     TRANSFORMER_FP8_512 = "Transformer_FP8_512"
+    VAE = "Vae"
 
 
 class ModelLoader(ForgeModel):
@@ -50,6 +58,9 @@ class ModelLoader(ForgeModel):
 
     _VARIANTS = {
         ModelVariant.TRANSFORMER_FP8_512: ModelConfig(
+            pretrained_model_name=REPO_ID,
+        ),
+        ModelVariant.VAE: ModelConfig(
             pretrained_model_name=REPO_ID,
         ),
     }
@@ -71,12 +82,16 @@ class ModelLoader(ForgeModel):
     def load_model(self, *, dtype_override=None, **kwargs):
         """Return the conditional Ideogram4Transformer with FP8 weights → bf16."""
         dtype = dtype_override if dtype_override is not None else DTYPE
+        if self._variant == ModelVariant.VAE:
+            return load_vae_decoder(dtype=dtype)
         transformer = load_conditional_transformer(dtype=dtype)
         return Ideogram4TransformerWrapper(transformer).eval()
 
     def load_inputs(self, dtype_override=None, batch_size=1, **kwargs):
         """Synthetic packed-sequence inputs for 512x512 resolution."""
         dtype = dtype_override if dtype_override is not None else DTYPE
+        if self._variant == ModelVariant.VAE:
+            return build_vae_decoder_inputs(dtype=dtype)
         return build_synthetic_transformer_inputs(batch_size=batch_size, dtype=dtype)
 
     def unpack_forward_output(self, output):
@@ -88,8 +103,12 @@ class ModelLoader(ForgeModel):
     def get_mesh_config(self, num_devices: int):
         """Return (mesh_shape, mesh_names) for a ("batch", "model") 2D mesh.
 
-        The transformer is sharded tensor-parallel along the "model" axis.
+        The transformer is sharded tensor-parallel along the "model" axis. The
+        VAE decoder is 49.6M params and fits on a single chip, so it maps to
+        (1, 1) for any device count.
         """
+        if self._variant == ModelVariant.VAE:
+            return (1, 1), MESH_NAMES
         if num_devices not in MESH_SHAPES:
             raise ValueError(
                 f"Unsupported device count: {num_devices}. "
@@ -101,5 +120,8 @@ class ModelLoader(ForgeModel):
         """Return tensor -> partition_spec dict (Option A, Megatron column->row).
 
         Expects the wrapper returned by load_model(); shards the inner transformer.
+        The VAE decoder is unsharded.
         """
+        if self._variant == ModelVariant.VAE:
+            return None
         return shard_transformer_specs(model.transformer)

--- a/ideogram_4/pytorch/src/model_utils.py
+++ b/ideogram_4/pytorch/src/model_utils.py
@@ -277,3 +277,42 @@ def shard_transformer_specs(transformer) -> dict:
         _shard_linear(specs, ff.w2, (None, "model"))
 
     return specs
+
+
+# ---------------------------------------------------------------------------
+# VAE decoder component.
+#
+# `Ideogram4Pipeline._decode` calls `self.autoencoder.decoder(z)` directly, so
+# the decoder submodule - not the full AutoEncoder - is the compilable unit and
+# the one worth comparing against CPU. Its input is the *unpatched* AE latent:
+# the pipeline undoes the DiT's 2x2 patching before handing `z` over.
+# ---------------------------------------------------------------------------
+
+VAE_WEIGHTS_FILENAME = "vae/diffusion_pytorch_model.safetensors"
+# ch_mult has 4 entries -> three 2x upsamples -> 8x spatial scale.
+VAE_SPATIAL_SCALE = 8
+VAE_DEFAULT_RESOLUTION = 512
+
+
+def load_vae_decoder(dtype: torch.dtype = DTYPE):
+    """Load the Ideogram 4 autoencoder and return its decoder submodule."""
+    from ideogram4.pipeline_ideogram4 import _load_autoencoder
+
+    weights_path = hf_hub_download(repo_id=REPO_ID, filename=VAE_WEIGHTS_FILENAME)
+    autoencoder = _load_autoencoder(weights_path, torch.device("cpu"), dtype)
+    return autoencoder.decoder.eval()
+
+
+def build_vae_decoder_inputs(
+    dtype: torch.dtype = DTYPE, resolution: int = VAE_DEFAULT_RESOLUTION
+) -> list:
+    """Synthetic unpatched AE latent, matching what `_decode` feeds the decoder."""
+    from ideogram4.autoencoder import AutoEncoderParams
+
+    params = AutoEncoderParams()
+    side = resolution // VAE_SPATIAL_SCALE
+    generator = torch.Generator().manual_seed(0)
+    latent = torch.randn(
+        1, params.z_channels, side, side, dtype=torch.float32, generator=generator
+    )
+    return [latent.to(dtype)]


### PR DESCRIPTION
### Ticket

Ideogram 4 bringup — moving pipeline components off CPU. Stacked on tenstorrent/tt-forge-models#859 (tensor-parallel shard specs); this PR's diff is the VAE decoder only.

### Problem description

Only the DiT ran on Tenstorrent. Every other component of the Ideogram 4 pipeline — the Qwen3-VL text encoder, the autoencoder, and the flow scheduler — stayed on CPU, so a text-to-image run was one sharded transformer surrounded by host work.

### What's changed

**Adds a `Vae` variant** to `ideogram_4/pytorch/loader.py`, following the component convention already used by the `flux` and `qwen_image` loaders: one `ModelVariant` per compilable component, tensors-only, real weights.

**The compilable unit is `autoencoder.decoder`, not the full `AutoEncoder`.** `Ideogram4Pipeline._decode` calls `self.autoencoder.decoder(z)` directly, so that submodule is what actually runs at inference and what is worth comparing against CPU. The encoder is never touched on the generation path.

**The input is the *unpatched* AE latent.** `_decode` undoes the DiT's 2×2 patching before handing `z` over — it views to `(B, grid_h, grid_w, patch, patch, ae_channels)`, permutes, and collapses back to `(B, ae_channels, grid_h*patch, grid_w*patch)`. With `z_channels=32` and `ch_mult=[1,2,4,4]` (three 2× upsamples ⇒ 8× spatial scale), that is `(1, 32, 64, 64)` at 512×512. `build_vae_decoder_inputs` reproduces exactly that shape with a seeded generator.

**No sharding, deliberately.** The decoder is 49.6M params and fits on a single chip, so `get_mesh_config` returns `(1, 1)` for any device count and `load_shard_spec` returns `None`. Unlike the 9.3B transformer — which needs tensor parallelism to dodge a tt-metal mesh-command-queue hang — this component has no reason to be sharded.

`DEFAULT_VARIANT` is unchanged, so the existing `Transformer_FP8_512` test ids keep resolving.

### Validation

Blackhole p300c, bf16, the same **seeded** latent on both backends — the one `build_vae_decoder_inputs` produces:

| Metric | Value |
|---|---|
| PCC vs CPU (raw decoder output) | **0.999730** |
| max abs diff | 0.078125 |
| Pixel RGB PCC (after the pipeline's uint8 conversion) | **0.999508** |
| max pixel diff | 10 / 255 |
| Latent → output | `(1, 32, 64, 64)` → `(1, 3, 512, 512)` |
| First call (compile + exec) | 321.2 s cold kernel cache, 18.9 s warm |
| Cached exec | 1.6 – 2.6 s |
| Parameters | 49.6M |

Runner test on device:

```
ideogram_4/pytorch-Vae-single_device-inference     1 passed in 141.12s
```

Re-running the compiled decoder inside one process reproduces the identical PCC, so execution is deterministic.

**On PCC spread across runs:** an earlier probe reported 0.999785 and another 0.999650. That spread is the *latent*, not the backend — the ad-hoc probe script drew an unseeded `torch.randn`, so each run decoded a different tensor. The loader's `build_vae_decoder_inputs` seeds its generator, and the figures in the table above come from that seeded latent. All measurements land in 0.99965 – 0.99979 regardless.

`pre-commit run --files ideogram_4/pytorch/loader.py ideogram_4/pytorch/src/model_utils.py` passes.

### End-to-end: both components on device

The component numbers above use a synthetic latent, so the real check is the full text-to-image pipeline with the DiT **and** the VAE decoder on TT (512×512, 28 steps, seed 1234, guidance 7.0):

| Comparison | RGB PCC | max pixel diff |
|---|---|---|
| TT DiT-only vs TT DiT+VAE | **0.999931** | 6 / 255 |
| CPU vs TT DiT-only | 0.594865 | — |
| CPU vs TT DiT+VAE | 0.594286 | — |

Moving the VAE onto the device changes the final image by essentially nothing, and CPU-agreement is unchanged (0.5949 → 0.5943), so the decoder contributes no meaningful error to the pipeline. Wall clock 196 s vs 130 s for the DiT-only run — the delta is the decoder's one-off on-device compile, not per-step cost.

The output is a coherent, on-prompt image. (The ~0.59 CPU-vs-TT figure is trajectory divergence in the 28-step sampler, analysed in #859 — it is not a VAE effect, as the two TT runs agreeing at 0.999931 shows.)

### Artifacts

Collected under `pr 2/` on shared `/proj_sw/user_dev/ctr-lelanchelian/tt-xla/`:

| File | What |
|---|---|
| `01_e2e_image_dit_and_vae_on_tt.png` | e2e image with both components on device |
| `02_e2e_strip_cpu_vs_dit_only_vs_dit_plus_vae.png` | 3-panel: all-CPU \| DiT on TT \| DiT+VAE on TT |
| `03_vae_decode_cpu.png` / `04_vae_decode_tt.png` | component decode of the seeded latent |
| `05_vae_cpu_vs_tt.png` | labeled side-by-side with PCC |
| `log_e2e_dit_and_vae_on_tt.log` | e2e run log, both components on device |
| `log_vae_probe.log` / `log_vae_runner.log` | probe and runner logs |
| `probe_vae_smoke.py` / `proof_vae_images.py` | the scripts that produced the numbers |
| `README.md` | index with all measurements |

### Land order

tenstorrent/tt-forge-models#859 first (this branch is stacked on it), then this. No submodule bump in either; the pointer moves in the regular uplift.

### Limitations

- **This is the decoder only.** The VAE encoder is not exposed — the text-to-image path never calls it. Image-to-image would need it.
- **The text encoder is still on CPU.** Qwen3-VL fp8 is the remaining large CPU component; it has not been attempted.
- The comparison uses a **synthetic seeded latent**, not one produced by the DiT. That isolates decoder numerics from upstream drift, which is the right control for this component, but it means the number does not describe end-to-end image agreement.
- PCC 0.999785 is measured on the raw decoder output, before the `clamp(-1,1)` → uint8 quantization the pipeline applies; that quantization can only reduce visible difference further.

### Checklist

- [x] New/Existing tests provide coverage for changes — `ideogram_4/pytorch-Vae-single_device-inference` exercises the decoder on device.
