### PR TITLE
[Mochi] update loader inputs to num_frames=24 config

### DIFF
--- a/mochi/pytorch/src/utils.py
+++ b/mochi/pytorch/src/utils.py
@@ -282,11 +282,16 @@ def load_text_encoder_inputs(dtype: torch.dtype = torch.bfloat16) -> dict:
 
 ORIGINAL_LATENT_HEIGHT = 60  # 480 / 8
 ORIGINAL_LATENT_WIDTH = 106  # 848 / 8
-ORIGINAL_LATENT_DEPTH = 14  # (num_frames=84 - 1) // 6 + 1
+ORIGINAL_LATENT_DEPTH = 4  # (num_frames=24 - 1) // 6 + 1
 ORIGINAL_MAX_SEQ_LEN = 256
 ORIGINAL_TEXT_EMBED_DIM = 4096
 ORIGINAL_LATENT_CHANNELS = 12
 ORIGINAL_T5_VOCAB_SIZE = 32128
+# Transformer batch = (2 if guidance_scale > 1.0 else 1). The default
+# guidance_scale=4.5 enables classifier-free guidance, so the pipeline runs
+# torch.cat([latents] * 2) and the transformer sees cond+uncond in one batch.
+# The text encoder and VAE decoder stay at batch 1.
+ORIGINAL_CFG_BATCH = 2
 
 
 def load_transformer_inputs_full_res(
@@ -294,7 +299,7 @@ def load_transformer_inputs_full_res(
 ) -> list:
     """Original-resolution positional inputs for MochiTransformer3DModel."""
     hidden_states = torch.randn(
-        1,
+        ORIGINAL_CFG_BATCH,
         ORIGINAL_LATENT_CHANNELS,
         ORIGINAL_LATENT_DEPTH,
         ORIGINAL_LATENT_HEIGHT,
@@ -302,10 +307,12 @@ def load_transformer_inputs_full_res(
         dtype=dtype,
     )
     encoder_hidden_states = torch.randn(
-        1, ORIGINAL_MAX_SEQ_LEN, ORIGINAL_TEXT_EMBED_DIM, dtype=dtype
+        ORIGINAL_CFG_BATCH, ORIGINAL_MAX_SEQ_LEN, ORIGINAL_TEXT_EMBED_DIM, dtype=dtype
     )
-    timestep = torch.tensor([500], dtype=dtype)
-    encoder_attention_mask = torch.ones(1, ORIGINAL_MAX_SEQ_LEN, dtype=torch.bool)
+    timestep = torch.full((ORIGINAL_CFG_BATCH,), 500, dtype=dtype)
+    encoder_attention_mask = torch.ones(
+        ORIGINAL_CFG_BATCH, ORIGINAL_MAX_SEQ_LEN, dtype=torch.bool
+    )
     return [hidden_states, encoder_hidden_states, timestep, encoder_attention_mask]
 
 
@@ -331,7 +338,8 @@ def load_text_encoder_inputs_full_res(
     input_ids = torch.randint(
         0, ORIGINAL_T5_VOCAB_SIZE, (1, ORIGINAL_MAX_SEQ_LEN), dtype=torch.long
     )
-    attention_mask = torch.ones(1, ORIGINAL_MAX_SEQ_LEN, dtype=torch.long)
+    # The pipeline casts the mask to bool before calling the encoder.
+    attention_mask = torch.ones(1, ORIGINAL_MAX_SEQ_LEN, dtype=torch.bool)
     return [input_ids, attention_mask]
 
 


### PR DESCRIPTION
### Ticket

- closes https://github.com/tenstorrent/tt-xla/issues/5863

### Problem description

- The Mochi loader targets `num_frames=84`, the HF model-card configuration. On CPU that needs ~19 h at the model's default 64 denoising steps, which is impractical for the PCC-gated nightly since it compares against a CPU reference run. See [this comment](https://github.com/tenstorrent/tt-xla/issues/4638#issue-4428421471) for the full timing breakdown.
- While capturing the real shapes from an instrumented pipeline run, two input specs turned out to differ from what the pipeline actually passes: the transformer receives batch 2 rather than 1, since classifier-free guidance is enabled by default (`guidance_scale=4.5` → `torch.cat([latents] * 2)`); and the text encoder receives a `bool` attention mask, since the pipeline casts it before the call.

### What's changed

- Retargeted the full-res helpers to `num_frames=24` and fixed both specs. Shapes were captured from an instrumented CPU pipeline run.
  - `ORIGINAL_LATENT_DEPTH` 14 → 4, i.e. `(24 - 1) // 6 + 1`
  - Added `ORIGINAL_CFG_BATCH = 2`, used by all four transformer inputs
  - Text encoder `attention_mask` dtype `long` → `bool`
- The VAE compresses time 6×, so latent depth is `(num_frames - 1) // 6 + 1` — 4 for anything from 19 to 24 — and the decoder always expands back to 24 frames with no trim. 19 and 24 therefore cost exactly the same; 24 is used because it gives the longer clip (1.6 s vs 1.27 s at `fps=15`).
- Full pipeline now completes in ~31 min on CPU (10 steps) versus ~19 h at model-card settings, with meaningful output — video attached in [this comment](https://github.com/tenstorrent/tt-xla/issues/4638#issue-4428421471).
- With this change the transformer OOM is resolved; the test now fails with PCC = 0.021

### Checklist
- [x] Verify the changes through local testing on QB2

### Logs

- [aug12_mochi_transformer.log](https://github.com/user-attachments/files/30991417/aug12_mochi_transformer.log)

