### PR TITLE
[HunyuanVideo] Constrain VAE decoder channel dimension to a single mesh axis

### DIFF
--- a/hunyuan_video/pytorch/src/model_utils.py
+++ b/hunyuan_video/pytorch/src/model_utils.py
@@ -347,11 +347,22 @@ def _shard_resnet_block(block, specs: dict) -> None:
         # conv2 produces a replicated output; the residual add
         # `conv2_out + shortcut_out` requires the shortcut to also be
         # replicated, so we don't shard it.
+
+      norm1 / norm2 (replicated):
+        weight (None,), bias (None,)
+        # the group-norm scale/shift are per-channel, so Shardy propagates the
+        # activation's channel sharding onto them. The convs keep that dim on
+        # "model", so pinning the norms to "batch" makes Shardy reshard across
+        # axes of different sizes ("batch"=2, "model"=4 on an 8-device mesh),
+        # which lowers to an `sdy.collective_permute` whose operand and result
+        # local shapes differ — the verifier rejects it, and tt-mlir has no
+        # lowering for that op anyway (tt-mlir#3370). Replicated needs only a
+        # local slice.
     """
     if hasattr(block, "norm1"):
-        specs[block.norm1.weight] = ("batch",)
+        specs[block.norm1.weight] = (None,)
         if block.norm1.bias is not None:
-            specs[block.norm1.bias] = ("batch",)
+            specs[block.norm1.bias] = (None,)
 
     w1, b1 = _causal_conv3d_weight(block.conv1)
     specs[w1] = ("model", None, None, None, None)
@@ -359,9 +370,9 @@ def _shard_resnet_block(block, specs: dict) -> None:
         specs[b1] = ("model",)
 
     if hasattr(block, "norm2"):
-        specs[block.norm2.weight] = ("batch",)
+        specs[block.norm2.weight] = (None,)
         if block.norm2.bias is not None:
-            specs[block.norm2.bias] = ("batch",)
+            specs[block.norm2.bias] = (None,)
 
     w2, b2 = _causal_conv3d_weight(block.conv2)
     specs[w2] = (None, "model", None, None, None)
@@ -373,6 +384,54 @@ def _shard_resnet_block(block, specs: dict) -> None:
         specs[ws] = (None, None, None, None, None)
         if bs is not None:
             specs[bs] = (None,)
+
+
+def _shard_mid_block_attention(attn, specs: dict) -> None:
+    """Shard specs for the decoder mid-block Attention (single-axis).
+
+    The VAE keeps its channel dim on the "model" axis everywhere (see
+    `_shard_resnet_block`), so the attention must stay on that same axis.
+    Using the transformer's two-axis pattern here — ("model", "batch") /
+    ("batch", "model") — puts the channel dim on "batch" inside the attention
+    and on "model" in the surrounding convs. Shardy then has to reshard that
+    dim across axes of different sizes ("batch"=2, "model"=4 on an 8-device
+    mesh), which it lowers to an `sdy.collective_permute` whose operand and
+    result local shapes differ, and the verifier rejects it.
+
+    Megatron pair on "model" only:
+      to_q / to_k / to_v → column-parallel ("model", None), bias ("model",)
+      to_out[0]          → row-parallel    (None, "model"), bias replicated
+
+    The mid-block attention is single-head (heads = in_channels //
+    attention_head_dim = 1), so "model" splits the head dim rather than heads.
+    That is still exact: Q@K^T and scores@V contract over the sharded dim, so
+    each device produces a partial sum that Shardy closes with an all_reduce.
+    `group_norm` stays replicated — see `_shard_resnet_block`.
+    """
+    if hasattr(attn, "group_norm") and attn.group_norm is not None:
+        specs[attn.group_norm.weight] = (None,)
+        if attn.group_norm.bias is not None:
+            specs[attn.group_norm.bias] = (None,)
+
+    for proj_name in ("to_q", "to_k", "to_v"):
+        if hasattr(attn, proj_name):
+            proj = getattr(attn, proj_name)
+            specs[proj.weight] = ("model", None)
+            if proj.bias is not None:
+                specs[proj.bias] = ("model",)
+
+    if hasattr(attn, "to_out"):
+        out = attn.to_out
+        target = (
+            out[0]
+            if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
+            else out
+        )
+        specs[target.weight] = (None, "model")
+        # bias replicated: the row-parallel output is already replicated after
+        # the all_reduce, so a sharded bias would be summed N times.
+        if target.bias is not None:
+            specs[target.bias] = (None,)
 
 
 def shard_vae_specs(vae) -> dict:
@@ -390,7 +449,8 @@ def shard_vae_specs(vae) -> dict:
       Replicated (conv_shortcut): all dims None for both weight and bias.
         # must match the post-all_reduce replicated state of conv2 so the
         # residual add doesn't need a re-shard.
-    Norm / attention specs mirror the LLaMA / transformer conventions.
+    The mid-block attention stays on the same single "model" axis — see
+    `_shard_mid_block_attention`. Norms are replicated.
     """
     specs = {}
 
@@ -411,26 +471,7 @@ def shard_vae_specs(vae) -> dict:
         for attn in getattr(mid_block, "attentions", []) or []:
             if attn is None:
                 continue
-            if hasattr(attn, "group_norm") and attn.group_norm is not None:
-                specs[attn.group_norm.weight] = ("batch",)
-                if attn.group_norm.bias is not None:
-                    specs[attn.group_norm.bias] = ("batch",)
-            for proj_name in ("to_q", "to_k", "to_v"):
-                if hasattr(attn, proj_name):
-                    proj = getattr(attn, proj_name)
-                    specs[proj.weight] = ("model", "batch")
-                    if proj.bias is not None:
-                        specs[proj.bias] = ("model",)
-            if hasattr(attn, "to_out"):
-                out = attn.to_out
-                target = (
-                    out[0]
-                    if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
-                    else out
-                )
-                specs[target.weight] = ("batch", "model")
-                if target.bias is not None:
-                    specs[target.bias] = ("batch",)
+            _shard_mid_block_attention(attn, specs)
 
     for up_block in getattr(decoder, "up_blocks", []) or []:
         for resnet in getattr(up_block, "resnets", []) or []:
@@ -442,9 +483,9 @@ def shard_vae_specs(vae) -> dict:
                 specs[b] = ("model",)
 
     if hasattr(decoder, "conv_norm_out"):
-        specs[decoder.conv_norm_out.weight] = ("batch",)
+        specs[decoder.conv_norm_out.weight] = (None,)
         if decoder.conv_norm_out.bias is not None:
-            specs[decoder.conv_norm_out.bias] = ("batch",)
+            specs[decoder.conv_norm_out.bias] = (None,)
 
     if hasattr(decoder, "conv_out"):
         w, b = _causal_conv3d_weight(decoder.conv_out)


### PR DESCRIPTION
### Ticket

[#4792](https://github.com/tenstorrent/tt-xla/issues/4792)

### Problem description

test_vae_decoder_sharded fails to compile with

`loc("reshape.811"): error: 'sdy.collective_permute' op requires the same type for all operands and results`

### What's changed

- _shard_resnet_block replicates norm1 and norm2 weight and bias — ("batch",) -> (None,) — and shard_vae_specs does the same for conv_norm_out. A replicated parameter reaches the activation's channel sharding with a local slice, so no collective is emitted regardless of which axis the surrounding convs land on.

- The mid-block attention is factored out of shard_vae_specs into a new _shard_mid_block_attention, mirroring the helper OmniGen already has, and moved onto the "model" axis only: to_q / to_k / to_v become column-parallel ("model", None) with bias ("model",), to_out[0] becomes row-parallel (None, "model") with replicated bias, and group_norm is replicated. This attention is single-head (heads = in_channels // attention_head_dim, and the SDPA operands are 1x1x2560x512), so "model" splits the head dim rather than heads — still exact, since Q@K^T and scores@V contract over the sharded dim and Shardy closes each with an all_reduce.

- The conv specs, the Megatron column/row pairing, and the replicated conv_shortcut are unchanged; docstrings now record why the VAE stays on one axis instead of following the transformer convention. Post this change the module partitions cleanly — every in_sharding uses _axis_1 only, the norm parameters reach it through sdy.all_slice rather than sdy.collective_permute, and the SDPA custom call keeps full 1x1x2560x512 operands.

- Post this model fails with pcc drop which is solved by a corresponding mlir PR.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs
[hunyuan_vae_decoder_before_fix1_aug13.log](https://github.com/user-attachments/files/31013885/hunyuan_vae_decoder_before_fix1_aug13.log)
[hunyuan_vae_decoder_after_fix1_aug13.log](https://github.com/user-attachments/files/31013900/hunyuan_vae_decoder_after_fix1_aug13.log)
