### PR TITLE
[voxtral] Report _perf counts as top-level keys and add the mistral-common requirement

### DIFF
--- a/voxtral/pytorch/pipeline.py
+++ b/voxtral/pytorch/pipeline.py
@@ -25,13 +25,18 @@ does a data-dependent ``.all()`` on it, and plain causal masking is correct for
 right-padded static-window decode (we read logits at real position ``cur-1``,
 which never attends to padded positions).
 
-Per-generate timing is recorded into ``self._perf``::
+Per-generate timing is recorded into ``self._perf``, in the schema the tt-xla
+benchmark harnesses read — ``components`` and ``steps`` hold *seconds*, counts
+live in their own top-level keys (same split as the XTTS-v2 pipeline)::
 
     _perf = {
-        "components": {"prefill_tokens": L},   # host-precomputed prefill length
+        "components": {},                      # no separate on-device stage:
+                                               # the LM decode is all of it
         "steps": [seconds, ...],               # per-token decode times
         "step_metric_name": "decode_step",
         "total": seconds,                      # full generate() wall time
+        "prefill_tokens": L,                   # host-precomputed prefill length
+        "output_tokens": N,                    # tokens the loop emitted
     }
 """
 
@@ -101,10 +106,12 @@ class VoxtralPipeline:
         window = L + n_new
 
         self._perf = {
-            "components": {"prefill_tokens": L},
+            "components": {},
             "steps": [],
             "step_metric_name": "decode_step",
             "total": None,
+            "prefill_tokens": L,
+            "output_tokens": 0,
         }
 
         # Static right-padded window of embeddings -> the forward compiles once.
@@ -127,5 +134,6 @@ class VoxtralPipeline:
             buf[0, cur, :] = self._embed_w[nxt]
             cur += 1
         self._perf["total"] = time.perf_counter() - t_total
+        self._perf["output_tokens"] = len(gen_ids)
 
         return self.tokenizer.decode(gen_ids, skip_special_tokens=True)

--- a/voxtral/pytorch/requirements.txt
+++ b/voxtral/pytorch/requirements.txt
@@ -1,0 +1,4 @@
+# VoxtralProcessor tokenizes through the mistral_common backend (Voxtral ships a
+# tekken.json, not a Jinja chat template); the [audio] extra pulls the soundfile
+# / soxr decoders apply_chat_template needs to read the audio clips.
+mistral-common[audio]


### PR DESCRIPTION
### Ticket

Companion to the tt-xla PR that wires Voxtral-Mini-3B into nightly + benchmark CI (tt-xla policy from tenstorrent/tt-xla#5047: every model that passes bringup runs in both).

### Problem description

Two things block the Voxtral pipeline (#802) from being driven by the tt-xla benchmark harness:

1. **`_perf` mixes units.** `generate()` reports the prefill length inside `components`:
   ```python
   _perf = {"components": {"prefill_tokens": L}, "steps": [...], ...}
   ```
   The benchmark harness sums `components` as *seconds* to derive CPU overhead (`total - (sum(components) + sum(steps))`), so a 765-entry token count in there wipes the overhead figure out and lands on the dashboard as `prefill_tokens_s`. The XTTS-v2 pipeline already established the split this repo uses: `components` and `steps` hold seconds, counts get their own top-level keys (`audio_samples`, `text_tokens`).

2. **The loader has no `requirements.txt`.** `VoxtralProcessor` tokenizes through the `mistral_common` backend — Voxtral ships a `tekken.json`, not a Jinja chat template — so on an environment without `mistral-common` the first `load_inputs()` call dies in `apply_chat_template`:
   ```
   ValueError: Cannot use chat template functions because tokenizer.chat_template
   is not set and no template argument was passed!
   ```
   CI installs per-loader requirements through `RequirementsManager`, so the dependency has to be declared next to the loader.

### What's changed

- **`voxtral/pytorch/pipeline.py`** — move `prefill_tokens` out of `components` into its own top-level key and add `output_tokens` (the number of tokens the loop actually emitted). `components` is now empty for this pipeline, which is accurate: the LM decode loop *is* all of the on-device work, and it is already reported per step in `steps`. Docstring updated to spell out the schema and the seconds/counts split.
- **`voxtral/pytorch/requirements.txt`** (new) — `mistral-common[audio]`; the `[audio]` extra pulls the `soundfile`/`soxr` decoders `apply_chat_template` needs to read the two audio clips.

No behavioural change to generation: the same tokens are produced, only the reported metadata moves.

### Verification

Verified on a Wormhole n150 through the tt-xla audio benchmark harness (`tests/benchmark/test_audio.py::test_voxtral_mini_3b`, 32-token budget, two-pass warmup + steady state) and through the tt-xla nightly pipeline test — both consume the new schema. Prefill is 765 tokens, hidden 3072.

### Checklist
- [x] Pipeline runs end-to-end on n150 with the new `_perf` schema
- [x] `mistral-common` requirement reproduced (the chat-template failure) and fixed
- [x] No change to the generated tokens
