### PR TITLE
Fix the uplift issue

### DIFF
--- a/glm_image/pytorch/src/pipeline.py
+++ b/glm_image/pytorch/src/pipeline.py
@@ -1,4 +1,3 @@
-glm_pipeline.py
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
While uplifting the tt-forge-models in tt-xla, I encountered the following error:
```
==================================== ERRORS ====================================
________ ERROR collecting tests/torch/models/glm_image/test_pipeline.py ________
tests/torch/models/glm_image/test_pipeline.py:35: in <module>
    from third_party.tt_forge_models.glm_image.pytorch.src.pipeline import (
third_party/tt_forge_models/glm_image/pytorch/src/pipeline.py:1: in <module>
    glm_pipeline.py
    ^^^^^^^^^^^^
E   NameError: name 'glm_pipeline' is not defined
=========================== short test summary info 

```
pr link: https://github.com/tenstorrent/tt-xla/pull/5953

### What's changed
Fixed the above-mentioned error by removing the glm_pipeline.py line.

### Checklist
- [ ] New/Existing tests provide coverage for changes
