### PR TITLE
[HiDream-I1] Add shard specs for stacked MoE experts

### DIFF
--- a/hidream_i1/pytorch/src/model_utils.py
+++ b/hidream_i1/pytorch/src/model_utils.py
@@ -440,6 +440,15 @@ def shard_hidream_transformer_specs(transformer) -> dict:
         # every device needs to see all expert scores to pick the same top-2
         # indices, so it must be replicated (not sharded). It's tiny (~10 KB)
         # so replication has negligible memory cost.
+        if hasattr(ff, "mlp"):
+            # Swapped by enable_sparse_mlp: the 4 experts are stacked into one
+            # tensor each, sharded on the expert dim (expert-parallel) instead
+            # of per-expert column/row-parallel.
+            experts = ff.mlp.experts
+            specs[experts.gate_proj] = (MESH_NAMES, None, None)
+            specs[experts.up_proj] = (MESH_NAMES, None, None)
+            specs[experts.down_proj] = (MESH_NAMES, None, None)
+            return
         for expert in ff.experts:
             _shard_swiglu(expert)
 


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/5947

### Problem description

- Step 1/10 of the denoising loop in HiDream-I1-Full took **4h 14m**, caused by a graph break in the MoE. Full root cause analysis documented here: [Root cause analysis](https://github.com/tenstorrent/tt-xla/issues/5947#issuecomment-5306192623)

### What's changed

- The fix itself lands in tt-xla: `enable_sparse_mlp` replaces each `MOEFeedForwardSwiGLU` with `A2aSparseMLP`, which has no data-dependent shapes and so no `bincount` graph break. This PR is the tt_forge_models half of that pair.
- After the swap, the per-expert `w1`/`w3`/`w2` Linears no longer exist — the 4 experts are stacked into single `gate_proj` / `up_proj` / `down_proj` tensors. `_shard_moe` now emits specs for those, sharded on the expert dim (expert-parallel, 1 expert per device on the (1, 4) mesh).
- Without it, `load_shard_spec` raises `AttributeError: 'A2aSparseMLPWithSharedExperts' object has no attribute 'experts'`.
- The stock path is unchanged. The branch keys off the module layout, so a transformer loaded without `enable_sparse_mlp` still gets the original per-expert column/row-parallel specs.
- Effect on compilation, same e2e test, measured within step 1 of the denoising loop:

  | | before | after |
  | --- | --- | --- |
  | `PJRT_Client_Compile` | 564 | **1** |
  | `bincount` graph breaks | 149 | **0** |
  | distinct ragged `[K, 2560]` shapes | 191 | **none** |

- The two runs do not cover the same span — the before run completed step 1 and died in step 2, while the after run hits the rope OOM partway through step 1. Restricting to step 1 keeps the comparison like-for-like. Since the after run still does not complete a denoising step, whether this resolves the duration issue can only be confirmed once that OOM is fixed.

### Checklist

- [x] Verify the changes through local testing on QB2

### Logs

- [before_fix.zip](https://github.com/user-attachments/files/31113495/org.zip)
- [after_fix.zip](https://github.com/user-attachments/files/31113491/after_fix.zip)


