### PR TITLE
[Cogvideox] Run T5 encoder and VAE decoder on TT

### DIFF
--- a/cog_videox/pytorch/src/pipeline.py
+++ b/cog_videox/pytorch/src/pipeline.py
@@ -22,21 +22,40 @@ CogVideoX is a *diffusion* text-to-video model. A single generation is:
 This reimplements the diffusers ``CogVideoXPipeline.__call__`` (text-to-video
 path) with an explicit CPU/TT device split, reusing the diffusers pipeline's own
 helper methods (``encode_prompt``, ``prepare_latents``,
-``_prepare_rotary_positional_embeddings``, ``decode_latents`` and the scheduler)
-so only the device split is bespoke:
+``_prepare_rotary_positional_embeddings`` and the scheduler) so only the device
+split is bespoke. All three weight-bearing components run on Tenstorrent,
+tensor-parallel sharded on a single shared ``("batch", "model")`` mesh and each
+executed through ``torch.compile(backend="tt")`` (Dynamo), not the lazy-tensor
+path:
 
-  - DiT transformer on Tenstorrent, tensor-parallel sharded on the
-    ``("batch", "model")`` mesh (Megatron column/row from
-    ``shard_transformer_specs``; see ``model_utils``), executed through
-    ``torch.compile(backend="tt")`` (Dynamo), not the lazy-tensor path.
-  - T5 text encoding, the scheduler step and the VAE decode all stay on CPU.
+  - T5 v1.1-XXL text encoder -- Megatron column/row from
+    ``shard_text_encoder_specs``. Tokenization stays on CPU; only the encoder
+    forward runs on device.
+  - DiT transformer -- Megatron column/row from ``shard_transformer_specs``.
+  - VAE decoder -- channel-axis Conv3D sharding from ``shard_vae_specs``, driven
+    through ``VAEDecoderWrapper`` so the decode is a single compiled
+    ``(z) -> frames`` call.
+
+Only the scheduler step, the CFG combine, the rotary tables and the latent
+preparation stay on CPU (all cheap, all fp32).
+
+Each component has its own ``*_on_tt`` config flag, so any of them can be put
+back on CPU independently for triage.
 
 Notes:
   - fp32 timestep: the discrete timestep tensor is moved to TT in fp32 (not bf16)
     so the sinusoidal time embedding sees the exact timestep value -- bf16 cannot
     represent e.g. 999 exactly, which would perturb the embedding.
+  - DRAM: the three components do NOT fit on device simultaneously. Their bf16
+    weights are ~4.8 B (T5) + ~5.0 B (DiT) + ~0.2 B (VAE) params sharded only on
+    the "model" mesh axis (width 4 on QB/loudbox/galaxy), which pins the device at
+    99.6% DRAM and kills the VAE decode's first conv2d on a 27 MB allocation.
+    ``offload_after_use`` (on by default) is what makes the all-TT path fit: each
+    component's device buffers are freed when its phase ends, since generate()
+    uses them in strictly sequential phases. See ``_release_from_tt``.
 """
 
+import gc
 import inspect
 import os
 from typing import Optional
@@ -56,7 +75,10 @@ from .model_utils import (
     MESH_SHAPES,
     NUM_FRAMES,
     REPO_ID,
+    VAEDecoderWrapper,
+    shard_text_encoder_specs,
     shard_transformer_specs,
+    shard_vae_specs,
 )
 
 PROMPT = "A panda, dressed in a small red jacket, sits on a wooden stool in a serene bamboo forest. "
@@ -67,8 +89,10 @@ SEED = 42
 # CogVideoX-5b default spatial resolution. height/width must be divisible by 8.
 HEIGHT = 480
 WIDTH = 720
-# DiT weight dtype on TT (bf16 fits DRAM); CPU components stay fp32.
+# Weight dtypes on TT (bf16 fits DRAM); anything left on CPU stays fp32.
 TRANSFORMER_DTYPE = torch.bfloat16
+TEXT_ENCODER_DTYPE = torch.bfloat16
+VAE_DTYPE = torch.bfloat16
 CPU_DTYPE = torch.float32
 
 DEFAULT_COMPILE_OPTIONS = {
@@ -329,15 +353,39 @@ class _RankPreservingQKLayerNorm(nn.Module):
     into dim 1, so Shardy cannot keep the shard across it: it emits an
     ``all_gather`` back to all 48 heads before the norm and a ``mesh_partition``
     after, per norm, per block -- 84 collectives moving ~218 MB each.
+
+    Worse, the flattened mean becomes ``sum(1x1706496x64xf32, dims=[0, 2])``,
+    and TTNN lowers a multi-dim reduce through ``ttnn::transpose``. The transpose
+    output is 64 x 1706496 x 1, whose size-1 last dim is padded to a full 32-row
+    tile: 64 * 1706496 * 32 * 2 B = **6,989,807,616 B**. That is exactly the
+    allocation that dies with "Out of Memory: Not enough space to allocate
+    6989807616 B DRAM buffer across 12 banks" -- a 0.44 GB tensor inflated 16x by
+    tile padding.
+
+    Reducing over the last dim of the rank-4 tensor directly sidesteps all of
+    it: the reduction is local to each device's head shard (no collective), and
+    it is TTNN's natural reduce-over-W case (no transpose, no tile padding).
+
+    The 3072-dim LayerNorms (norm1/norm2/norm_final/norm_out) are left alone --
+    they survive as ``ttir.layer_norm`` because the residual stream is
+    TP-replicated, so their flatten crosses no shard boundary.
     """
 
     def __init__(self, src: nn.LayerNorm):
         super().__init__()
         self.eps = src.eps
+        # Same Parameter objects, so shard_transformer_specs' `specs[qk_norm.weight]`
+        # keys (model_utils.py:556) still resolve -- assigning a Parameter to an
+        # nn.Module attribute re-registers it, and `.to()` mutates .data in place
+        # rather than rebinding, so the identity survives the device move.
         self.weight = src.weight
         self.bias = src.bias
 
     def forward(self, x):
+        # fp32 for the reduction, matching what native_layer_norm does today
+        # (the current TTIR upcasts to f32 before the mean), so numerics -- and
+        # therefore the test's per-step PCC -- are unchanged. Dropping this to
+        # bf16 would halve these activations if DRAM is still tight.
         dtype = x.dtype
         xf = x.float()
         centered = xf - xf.mean(-1, keepdim=True)
@@ -385,6 +433,9 @@ class CogVideoXConfig:
         eta: float = 0.0,
         shard: bool = True,
         transformer_on_tt: bool = True,
+        text_encoder_on_tt: bool = True,
+        vae_on_tt: bool = True,
+        offload_after_use: bool = True,
         rank_preserving_attention: bool = False,
         rank_preserving_qk_norm: bool = True,
         split_half_rope: bool = True,
@@ -400,12 +451,49 @@ class CogVideoXConfig:
         self.max_sequence_length = max_sequence_length
         # DDIM eta (ignored by schedulers that don't accept it).
         self.eta = eta
-        # Tensor-parallel sharding of the DiT (needed so the transformer fits DRAM
-        # and the attention does not OOM).
+        # Tensor-parallel sharding of every TT component (needed so the transformer
+        # fits DRAM and the attention does not OOM). Applies to the text encoder and
+        # the VAE decoder too -- they share one mesh with the DiT.
         self.shard = shard
+        # Per-component device placement. All three default to TT; flip one off to
+        # bisect a numerics or compile failure against its CPU fp32 equivalent.
         self.transformer_on_tt = transformer_on_tt
+        self.text_encoder_on_tt = text_encoder_on_tt
+        self.vae_on_tt = vae_on_tt
+        # Release each TT component's device buffers when its phase of generate()
+        # ends and a later TT component still has to run. Required to fit all
+        # three: with the encoder, the DiT and the VAE all resident the device
+        # sits at 99.6% DRAM and the VAE's first conv2d cannot allocate a 27 MB
+        # buffer. Costs one re-upload + recompile per component if generate() is
+        # called a second time on the same pipeline.
+        self.offload_after_use = offload_after_use
+        # Off on the torch.compile path, and it must stay off: keeping stock
+        # ``F.scaled_dot_product_attention`` is what lets tt_torch wrap the
+        # attention in the opaque ``tenstorrent.scaled_dot_product_attention``
+        # composite (handle_composite_ops, run before AOTAutograd), so the
+        # [B, H, S, S] score matrix is never materialized at all.
+        #
+        # _RankPreservingAttnProcessor substitutes an explicit matmul -> softmax
+        # -> matmul, which leaves no SDPA node for the composite to match. On the
+        # eager lazy-tensor path that was still a win (the matmul kept the head
+        # shard alive where SDPA's lowering collapsed it), but under Dynamo
+        # AOTAutograd then decomposes the softmax into max/sub/exp/sum/div, so
+        # tt-mlir's TTIR SDPA fusion cannot match either -- leaving a live
+        # 2x12x17776x17776 bf16 score buffer (15.2 GB/device at 49 frames) that
+        # dies with std::bad_alloc during compile.
         self.rank_preserving_attention = rank_preserving_attention
+        # On by default and required to run: stock nn.LayerNorm for norm_q/norm_k
+        # flattens the sharded head dim, which costs 84 all_gathers and a 6.99 GB
+        # tile-padded transpose that OOMs DRAM. See _RankPreservingQKLayerNorm.
+        # Unlike rank_preserving_attention this is independent of the SDPA
+        # composite -- it replaces the norm modules, not the attn processor, so
+        # stock CogVideoXAttnProcessor2_0 (and its fused SDPA) is untouched.
         self.rank_preserving_qk_norm = rank_preserving_qk_norm
+        # On by default and required to run: stock apply_rotary_emb's rank-5
+        # intermediates cost a 862 MB tile-padded buffer, and its slice-assignment
+        # costs 84 gathers. See _SplitHalfRopeAttnProcessor. Mutually exclusive with
+        # rank_preserving_attention -- both install an attn1 processor, and only this
+        # one keeps the fused SDPA.
         if split_half_rope and rank_preserving_attention:
             raise ValueError(
                 "split_half_rope and rank_preserving_attention both replace the "
@@ -414,71 +502,129 @@ class CogVideoXConfig:
             )
         self.split_half_rope = split_half_rope
 
+    @property
+    def any_on_tt(self) -> bool:
+        return self.transformer_on_tt or self.text_encoder_on_tt or self.vae_on_tt
+
 
 class CogVideoXPipeline:
-    """CogVideoX pipeline: DiT sharded on TT, T5 / scheduler / VAE on CPU."""
+    """CogVideoX pipeline: T5 encoder, DiT and VAE decoder sharded on TT."""
 
     def __init__(self, config: CogVideoXConfig):
         self.config = config
+        # Built lazily by _ensure_mesh() and shared by every TT component, so the
+        # encoder, the DiT and the VAE decoder all live on the same device mesh.
+        self.mesh = None
+        # Compiled (z) -> frames decoder; only built when vae_on_tt.
+        self.vae_decoder = None
+        # Components whose device buffers generate() has released; re-armed at the
+        # top of the next generate() so the pipeline stays reusable.
+        self._released = set()
 
     def setup(self):
         self.load_models()
-        if self.config.transformer_on_tt:
-            # Must be set before the first DiT forward, since that is what
+        if self.config.any_on_tt:
+            # Must be set before the first device forward, since that is what
             # triggers compilation and these options are read at compile time.
             import torch_xla
 
             compile_options = _compile_options()
             torch_xla.set_custom_compile_options(compile_options)
             logger.info(f"[SETUP] compile options: {compile_options}")
-            self.transformer = self.transformer.to(TRANSFORMER_DTYPE)
-            self.pipe.transformer = self.transformer
-            # Must precede shard_to_tt(): the processor swap changes which ops the
-            # tracer sees, and it is those ops -- not the mark_sharding specs --
-            # that decide whether the head shard survives to the score matmul.
-            if self.config.rank_preserving_attention:
-                n = _use_rank_preserving_attention(self.transformer)
-                logger.info(f"[SETUP] rank-preserving attention on {n} blocks")
-            # Same ordering requirement as the processor swap above: it must
-            # precede shard_to_tt() because it changes the ops the tracer sees,
-            # and it is those ops that decide whether the head shard survives the
-            # norm. Reuses the original Parameters, so the shard specs collected
-            # inside shard_to_tt() still match.
-            if self.config.rank_preserving_qk_norm:
-                n = _use_rank_preserving_qk_norm(self.transformer)
-                logger.info(f"[SETUP] rank-preserving qk-norm on {n} norms")
-            if self.config.split_half_rope:
-                n = _use_split_half_rope(self.transformer)
-                logger.info(f"[SETUP] split-half RoPE on {n} blocks")
-            if self.config.shard:
-                self.shard_to_tt()
-            else:
-                self.transformer = self.transformer.to(xm.xla_device())
-                self.pipe.transformer = self.transformer
-            # Compile forward, not the module, so self.transformer stays an
-            # nn.Module: self.pipe.transformer keeps working and callers can
-            # still wrap forward (e.g. the nightly per-step PCC check). Compile
-            # last so Dynamo traces the post-swap, post-shard module.
-            self.transformer.forward = torch.compile(
-                self.transformer.forward, backend="tt"
-            )
+        if self.config.text_encoder_on_tt:
+            self._setup_text_encoder()
+        if self.config.transformer_on_tt:
+            self._setup_transformer()
+        if self.config.vae_on_tt:
+            self._setup_vae()
+
+    def _setup_text_encoder(self):
+        """Cast, shard and compile the T5 v1.1-XXL encoder."""
+        self.text_encoder = self.text_encoder.to(TEXT_ENCODER_DTYPE)
+        self.text_encoder = self._shard_to_tt(
+            self.text_encoder, shard_text_encoder_specs
+        )
+        self.pipe.text_encoder = self.text_encoder
+        # Compile forward, not the module, so pipe.text_encoder stays the same
+        # nn.Module and diffusers' own ``_get_t5_prompt_embeds`` (which calls
+        # ``self.text_encoder(input_ids)``) picks the compiled forward up for free.
+        self.text_encoder.forward = torch.compile(
+            self.text_encoder.forward, backend="tt"
+        )
+        logger.info("[SETUP] T5 text encoder on TT")
+
+    def _setup_transformer(self):
+        """Cast, rewrite, shard and compile the DiT."""
+        self.transformer = self.transformer.to(TRANSFORMER_DTYPE)
+        self.pipe.transformer = self.transformer
+        # Must precede the device move: the processor swap changes which ops the
+        # tracer sees, and it is those ops -- not the mark_sharding specs --
+        # that decide whether the head shard survives to the score matmul.
+        if self.config.rank_preserving_attention:
+            n = _use_rank_preserving_attention(self.transformer)
+            logger.info(f"[SETUP] rank-preserving attention on {n} blocks")
+        # Same ordering requirement as the processor swap above: it must precede
+        # the device move because it changes the ops the tracer sees, and it is
+        # those ops that decide whether the head shard survives the norm. Reuses
+        # the original Parameters, so the shard specs collected in _shard_to_tt() still
+        # match.
+        if self.config.rank_preserving_qk_norm:
+            n = _use_rank_preserving_qk_norm(self.transformer)
+            logger.info(f"[SETUP] rank-preserving qk-norm on {n} norms")
+        if self.config.split_half_rope:
+            n = _use_split_half_rope(self.transformer)
+            logger.info(f"[SETUP] split-half RoPE on {n} blocks")
+        self.transformer = self._shard_to_tt(self.transformer, shard_transformer_specs)
+        self.pipe.transformer = self.transformer
+        # Compile forward, not the module, so self.transformer stays an
+        # nn.Module: self.pipe.transformer keeps working and callers can
+        # still wrap forward (e.g. the nightly per-step PCC check). Compile
+        # last so Dynamo traces the post-swap, post-shard module.
+        self.transformer.forward = torch.compile(self.transformer.forward, backend="tt")
+        logger.info("[SETUP] DiT transformer on TT")
+
+    def _setup_vae(self):
+        """Cast, shard and compile the VAE decoder.
+
+        The whole ``AutoencoderKLCogVideoX`` moves to device (the encoder half is
+        dead weight on the t2v path, but it is only ~0.02 B params and dropping it
+        would break ``vae.dtype``/``vae.config`` lookups the diffusers pipeline
+        still makes). Only the decoder is sharded and only the decoder is compiled:
+        ``VAEDecoderWrapper`` exposes ``vae.decode`` as a flat ``(z) -> frames``
+        forward, which is the same entry point the standalone VAE component test
+        compiles.
+        """
+        self.vae = self.vae.to(VAE_DTYPE)
+        self.vae = self._shard_to_tt(self.vae, shard_vae_specs)
+        self.pipe.vae = self.vae
+        self.vae_decoder = VAEDecoderWrapper(self.vae).eval()
+        self.vae_decoder.forward = torch.compile(self.vae_decoder.forward, backend="tt")
+        logger.info("[SETUP] VAE decoder on TT")
 
     def load_models(self):
         # The whole diffusers pipeline (T5 text encoder and its tokenizer, VAE, DiT
-        # transformer and scheduler) is loaded on CPU in fp32. Only the DiT is
-        # later cast to bf16 and moved to TT; every other component runs on CPU.
+        # transformer and scheduler) is loaded on CPU in fp32. Each of the three
+        # weight-bearing components is then cast to bf16 and moved to TT unless its
+        # `*_on_tt` flag is off; the scheduler always stays on CPU.
         from diffusers import CogVideoXPipeline as _DiffusersCogVideoXPipeline
 
         self.pipe = _DiffusersCogVideoXPipeline.from_pretrained(
             REPO_ID, torch_dtype=CPU_DTYPE
         )
+        self.text_encoder = self.pipe.text_encoder
         self.transformer = self.pipe.transformer
         self.vae = self.pipe.vae
         self.scheduler = self.pipe.scheduler
 
-    def shard_to_tt(self):
-        # Enable SPMD, build the ("batch", "model") mesh, move the DiT to the XLA
-        # device, then mark every weight in the Megatron shard spec.
+    def _ensure_mesh(self) -> Mesh:
+        """Enable SPMD and build the ("batch", "model") mesh, once per pipeline.
+
+        Idempotent, and called before the first device op of the first component
+        that is moved -- ``_enable_spmd`` must run before anything touches the XLA
+        device. Every component shares this one mesh.
+        """
+        if self.mesh is not None:
+            return self.mesh
         _enable_spmd()
         num_devices = xr.global_runtime_device_count()
         if num_devices not in MESH_SHAPES:
@@ -488,10 +634,161 @@ class CogVideoXPipeline:
             )
         mesh_shape = MESH_SHAPES[num_devices]
         self.mesh = Mesh(np.array(range(num_devices)), mesh_shape, MESH_NAMES)
-        self.transformer = self.transformer.to(xm.xla_device())
-        self.pipe.transformer = self.transformer
-        for tensor, spec in shard_transformer_specs(self.transformer).items():
-            xs.mark_sharding(tensor, self.mesh, spec)
+        return self.mesh
+
+    def _shard_to_tt(self, module: nn.Module, spec_fn) -> nn.Module:
+        """Move ``module`` to the XLA device and mark its tensor-parallel shards.
+
+        ``spec_fn`` maps the moved module to a ``{tensor: partition_spec}`` dict
+        (``shard_*_specs`` from model_utils). It is called *after* the device move
+        because ``mark_sharding`` needs the XLA tensors -- ``nn.Module.to()``
+        rewrites ``param.data`` in place, so the Parameter identities the spec
+        functions key on survive the move.
+        """
+        if not self.config.shard:
+            return module.to(xm.xla_device())
+        mesh = self._ensure_mesh()
+        module = module.to(xm.xla_device())
+        for tensor, spec in spec_fn(module).items():
+            xs.mark_sharding(tensor, mesh, spec)
+        return module
+
+    def _release_from_tt(self, module: nn.Module, label: str) -> None:
+        """Free a finished component's device buffers mid-generate().
+
+        ``generate()`` runs the three components in strictly sequential phases --
+        encode once, denoise N times, decode once -- so each is dead weight on
+        device the moment its phase ends. Keeping all three resident pins the
+        device at 99.6% DRAM (1,066,038,496 of 1,070,773,184 B per bank), and the
+        VAE decode's first ``conv2d`` dies allocating a 27,648,000 B buffer with
+        4,734,688 B free.
+
+        Dropping the Dynamo/XLA caches is part of the release, not an
+        optimization: AOTAutograd's compiled forward holds the flattened
+        parameter list, so the device buffers outlive a bare ``module.to("cpu")``.
+        That is safe only because the phases are sequential -- at each release
+        point the next component has not compiled yet, so no live executable is
+        discarded.
+        """
+        # Flush pending IR first, so tensors that must survive the release (most
+        # importantly the encoder's prompt_embeds, which every DiT step consumes)
+        # are concrete device buffers rather than IR referencing these weights.
+        xm.mark_step()
+        # Restore the uncompiled forward before clearing the caches, so nothing
+        # can route back through a graph whose weights are about to move.
+        if "forward" in module.__dict__:
+            del module.forward
+        module.to("cpu")
+        torch._dynamo.reset()
+        xr.clear_computation_cache()
+        gc.collect()
+        self._released.add(label)
+        logger.info(f"[STAGE] released {label} from TT")
+
+    def _rearm(self) -> None:
+        """Put back any component a previous generate() released.
+
+        Keeps the pipeline reusable across generate() calls: the *_setup_ methods
+        are idempotent (the DiT's module rewrites all no-op on a rewritten model),
+        so this is a re-upload, a re-mark_sharding and a recompile.
+        """
+        if not self._released:
+            return
+        released, self._released = self._released, set()
+        logger.info(f"[SETUP] re-arming released components: {sorted(released)}")
+        if "text encoder" in released:
+            self._setup_text_encoder()
+        if "DiT" in released:
+            self._setup_transformer()
+        if "VAE" in released:
+            self._setup_vae()
+
+    def _tiled_vae_decode(
+        self, z, device, dtype, tile_latent_h=34, tile_latent_w=49, overlap=8
+    ):
+        """Decode latent ``z`` in spatial tiles to fit in device DRAM.
+
+        The full-resolution VAE decode at 480x720 with 256 channels exceeds
+        per-device DRAM (~1.6 GB activation vs ~0.2 GB free after weights).
+        Splitting into 2x2 spatial tiles with linear blending keeps each
+        tile's peak activation at ~0.5 GB.
+
+        Each tile is dispatched through the compiled ``VAEDecoderWrapper``.
+        Tiles share the same shape so the compiled kernel is cached once and
+        reused. Blending happens on CPU in fp32.
+
+        Args:
+            z: latent tensor (B, C, F, H_lat, W_lat), CPU, float32.
+            device: XLA device to place tiles on before decode.
+            dtype: weight dtype (VAE_DTYPE, typically bf16).
+            tile_latent_h: tile height in latent pixels (decoded = tile * 8).
+            tile_latent_w: tile width in latent pixels.
+            overlap: overlap in latent pixels between adjacent tiles.
+        """
+        B, C, F, H, W = z.shape
+        scale = getattr(self.pipe, "vae_scale_factor_spatial", 8)  # 8 for CogVideoX
+        overlap_dec = overlap * scale
+
+        stride_h = tile_latent_h - overlap
+        stride_w = tile_latent_w - overlap
+
+        # Tile start positions -- clamp last tile so it does not exceed bounds.
+        starts_h = list(range(0, max(H - overlap, 1), stride_h))
+        starts_w = list(range(0, max(W - overlap, 1), stride_w))
+        starts_h = sorted(set(min(s, H - tile_latent_h) for s in starts_h))
+        starts_w = sorted(set(min(s, W - tile_latent_w) for s in starts_w))
+
+        logger.info(
+            f"[VAE tiled] {len(starts_h)}x{len(starts_w)} tiles, "
+            f"latent tile {tile_latent_h}x{tile_latent_w}, overlap {overlap}"
+        )
+
+        # Decode each tile on device, pull result to CPU immediately so
+        # device DRAM only holds one tile's activations at a time.
+        decoded = {}
+        for i, sh in enumerate(starts_h):
+            for j, sw in enumerate(starts_w):
+                tile = z[:, :, :, sh : sh + tile_latent_h, sw : sw + tile_latent_w]
+                tile = tile.to(dtype).to(device)
+                dec = self.vae_decoder(tile)
+                decoded[(i, j)] = dec.to("cpu").float()
+                logger.info(f"[VAE tiled] tile ({i},{j}) done")
+
+        # Blend horizontally within each row, then vertically across rows.
+        nrows, ncols = len(starts_h), len(starts_w)
+
+        def _blend_h(left, right):
+            w = overlap_dec
+            weight = torch.linspace(1, 0, w, dtype=left.dtype).view(1, 1, 1, 1, -1)
+            blended = left[:, :, :, :, -w:] * weight + right[:, :, :, :, :w] * (
+                1 - weight
+            )
+            return torch.cat(
+                [left[:, :, :, :, :-w], blended, right[:, :, :, :, w:]], dim=4
+            )
+
+        def _blend_v(top, bottom):
+            h = overlap_dec
+            weight = torch.linspace(1, 0, h, dtype=top.dtype).view(1, 1, 1, -1, 1)
+            blended = top[:, :, :, -h:, :] * weight + bottom[:, :, :, :h, :] * (
+                1 - weight
+            )
+            return torch.cat(
+                [top[:, :, :, :-h, :], blended, bottom[:, :, :, h:, :]], dim=3
+            )
+
+        rows = []
+        for i in range(nrows):
+            row = decoded[(i, 0)]
+            for j in range(1, ncols):
+                row = _blend_h(row, decoded[(i, j)])
+            rows.append(row)
+
+        result = rows[0]
+        for i in range(1, nrows):
+            result = _blend_v(result, rows[i])
+
+        return result
 
     @torch.no_grad()
     def generate(
@@ -503,10 +800,13 @@ class CogVideoXPipeline:
     ):
         """Reimplements ``CogVideoXPipeline.__call__`` (t2v) with a CPU/TT split.
 
-          - T5 text encode      -> CPU
+          - T5 text encode      -> TT (bf16, sharded)
           - DiT denoising loop   -> TT (bf16, sharded)
           - scheduler step       -> CPU
-          - VAE decode           -> CPU
+          - VAE decode           -> TT (bf16, sharded)
+
+        Each TT stage falls back to CPU fp32 when its ``*_on_tt`` config flag is
+        off; the scheduler step (and the CFG combine feeding it) is always CPU.
 
         Post-processes the VAE decode via the diffusers ``VideoProcessor`` (same
         as ``CogVideoXPipeline.__call__``): ``output_type="pil"`` returns a list of
@@ -518,11 +818,24 @@ class CogVideoXPipeline:
         from diffusers.pipelines.cogvideo.pipeline_cogvideox import retrieve_timesteps
         from diffusers.schedulers import CogVideoXDPMScheduler
 
+        self._rearm()
+
         pipe = self.pipe
         transformer = self.transformer
         scheduler = self.scheduler
-        on_tt = self.config.transformer_on_tt
+        dit_on_tt = self.config.transformer_on_tt
+        te_on_tt = self.config.text_encoder_on_tt
+        vae_on_tt = self.config.vae_on_tt
+        # Only worth releasing a component if a *later* TT phase still needs the
+        # DRAM, so a DiT-only configuration keeps its weights resident exactly as
+        # it did before the encoder and VAE moved onto device.
+        offload = self.config.offload_after_use
+        release_te = offload and te_on_tt and (dit_on_tt or vae_on_tt)
+        release_dit = offload and dit_on_tt and vae_on_tt
         cpu = torch.device("cpu")
+        # Resolved once: xm.xla_device() would initialize the runtime, so it is
+        # only touched when at least one component actually lives there.
+        tt = xm.xla_device() if self.config.any_on_tt else cpu
 
         height, width = self.config.height, self.config.width
         num_frames = self.config.num_frames
@@ -532,34 +845,62 @@ class CogVideoXPipeline:
         do_cfg = guidance_scale > 1.0
         B = 1
 
-        def _to_tt(x, dtype=None):
-            if not on_tt:
-                return x
+        def _to(x, device, dtype=None):
+            """Cast then place. Both halves are no-ops when already satisfied.
+
+            Explicit per-component placement (rather than one global "on TT?"
+            switch) because the components move independently: with the encoder on
+            TT and the DiT on CPU, ``prompt_embeds`` comes back as an XLA tensor
+            that must be pulled to host before the DiT sees it, and vice versa.
+            """
             if dtype is not None:
                 x = x.to(dtype)
-            return x.to(xm.xla_device())
+            return x.to(device)
+
+        def _to_dit(x, dtype=None):
+            """Place a DiT input, applying ``dtype`` only on the TT path.
+
+            The bf16 cast exists to fit TT DRAM, so the CPU fallback keeps fp32
+            instead -- and actively pulls floats back to fp32, since with the
+            encoder on TT ``prompt_embeds`` arrives bf16 even when the DiT is not.
+            """
+            if dit_on_tt:
+                return _to(x, tt, dtype)
+            return _to(x, cpu, CPU_DTYPE if x.is_floating_point() else None)
 
         def _to_cpu(x):
-            return x.to("cpu") if on_tt else x
+            return x.to(cpu)
 
         generator = torch.Generator(device="cpu")
         if seed is not None:
             generator.manual_seed(seed)
 
-        # ── Text encode (CPU): T5 per-token embeddings ────────────────────
-        logger.info("[STAGE] T5 text encode (CPU): start")
+        # ── Text encode: T5 per-token embeddings ──────────────────────────
+        # Tokenization always runs on the host inside encode_prompt; `device` only
+        # decides where the encoder forward runs and where the embeds land.
+        text_device = tt if te_on_tt else cpu
+        text_dtype = TEXT_ENCODER_DTYPE if te_on_tt else CPU_DTYPE
+        te_where = "TT" if te_on_tt else "CPU"
+        logger.info(f"[STAGE] T5 text encode ({te_where}): start")
         prompt_embeds, negative_prompt_embeds = pipe.encode_prompt(
             prompt=prompt,
             negative_prompt=negative_prompt,
             do_classifier_free_guidance=do_cfg,
             num_videos_per_prompt=1,
             max_sequence_length=self.config.max_sequence_length,
-            device=cpu,
+            device=text_device,
+            dtype=text_dtype,
         )
         if do_cfg:
             # Stack [uncond, cond] into a single batch of 2 (single DiT forward).
+            # Both halves come off the same device, so this concat is local.
             prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
-        logger.info("[STAGE] T5 text encode (CPU): done")
+        logger.info(f"[STAGE] T5 text encode ({te_where}): done")
+        # The encoder is finished for this generation -- it ran once per prompt,
+        # and prompt_embeds is now a materialized device buffer. Release before
+        # the DiT compiles so the compile has the DRAM headroom too.
+        if release_te:
+            self._release_from_tt(self.text_encoder, "text encoder")
 
         # ── Timesteps ──────────────────────────────────────────────────────
         timesteps, num_inference_steps = retrieve_timesteps(
@@ -593,10 +934,12 @@ class CogVideoXPipeline:
         )
 
         # ── Loop-invariant DiT inputs: cast to bf16 + move to TT once ──────
-        eh_tt = _to_tt(prompt_embeds, TRANSFORMER_DTYPE)
+        # Already on device (and already bf16) when the encoder ran on TT too, so
+        # this is a no-op on the default all-TT path rather than a round trip.
+        eh_tt = _to_dit(prompt_embeds, TRANSFORMER_DTYPE)
         if image_rotary_emb is not None:
-            cos_tt = _to_tt(image_rotary_emb[0], TRANSFORMER_DTYPE)
-            sin_tt = _to_tt(image_rotary_emb[1], TRANSFORMER_DTYPE)
+            cos_tt = _to_dit(image_rotary_emb[0], TRANSFORMER_DTYPE)
+            sin_tt = _to_dit(image_rotary_emb[1], TRANSFORMER_DTYPE)
             rot_tt = (cos_tt, sin_tt)
         else:
             rot_tt = None
@@ -623,8 +966,8 @@ class CogVideoXPipeline:
             # Discrete timestep: keep fp32 (not bf16) so the value is exact.
             timestep = t.expand(latent_input.shape[0]).to(CPU_DTYPE)
 
-            hidden_tt = _to_tt(latent_input, TRANSFORMER_DTYPE)
-            timestep_tt = _to_tt(timestep)  # fp32 on TT
+            hidden_tt = _to_dit(latent_input, TRANSFORMER_DTYPE)
+            timestep_tt = _to_dit(timestep)  # fp32 on TT
 
             noise_pred = _to_cpu(_dit(hidden_tt, eh_tt, timestep_tt, rot_tt)).float()
 
@@ -666,14 +1009,36 @@ class CogVideoXPipeline:
         logger.info("[STAGE] DiT denoising loop: done")
 
         if output_type == "latent":
+            # No VAE decode on this path, so the DiT's DRAM is not in anyone's
+            # way -- keep it resident and skip the recompile it would cost.
             return latents
 
-        # ── VAE decode (CPU) -> RGB video ──────────────────────────────────
-        logger.info("[STAGE] VAE decode (CPU): start")
-        # decode_latents permutes to (B, C, F, H, W), rescales by the VAE's
-        # scaling factor and decodes to pixels.
-        video = pipe.decode_latents(latents.to(self.vae.dtype))
-        logger.info("[STAGE] VAE decode (CPU): done")
+        # latents is a CPU tensor (the scheduler step runs on host), so the DiT is
+        # dead weight from here on. Release it before the VAE decode compiles.
+        if release_dit:
+            self._release_from_tt(self.transformer, "DiT")
+
+        # ── VAE decode -> RGB video ────────────────────────────────────────
+        vae_where = "TT" if vae_on_tt else "CPU"
+        logger.info(f"[STAGE] VAE decode ({vae_where}): start")
+        if vae_on_tt:
+            # Inlined from ``decode_latents``: permute to (B, C, F, H, W) and undo
+            # the VAE's latent scaling on CPU in fp32 (both cheap), then run the
+            # decode itself through the compiled, sharded VAEDecoderWrapper.
+            # decode_latents cannot be reused as-is because it calls the
+            # uncompiled ``self.vae.decode``.
+            z = latents.permute(0, 2, 1, 3, 4)
+            z = (1 / pipe.vae_scaling_factor_image) * z
+            # Tiled decode: split the latent spatially into 2x2 overlapping
+            # tiles so each tile's peak activation fits in device DRAM.
+            # The full 480x720 decode OOMs (~1.6 GB activation vs ~0.2 GB
+            # free); each tile at ~272x392 needs ~0.5 GB.
+            video = self._tiled_vae_decode(z, device=tt, dtype=VAE_DTYPE)
+        else:
+            # decode_latents permutes to (B, C, F, H, W), rescales by the VAE's
+            # scaling factor and decodes to pixels.
+            video = pipe.decode_latents(latents.to(self.vae.dtype))
+        logger.info(f"[STAGE] VAE decode ({vae_where}): done")
 
         # Post-process via the diffusers video processor, matching
         # ``CogVideoXPipeline.__call__``.


### PR DESCRIPTION
### Ticket
Fixes [#5841](https://github.com/tenstorrent/tt-xla/issues/5841)

### Problem description
CogVideoX-5b ran only its DiT on TT; the T5 v1.1-XXL text encoder and the VAE decoder stayed on host. Move both onto device, sharded on the same mesh as the DiT.

### What's changed

- In third_party/tt_forge_models/cog_videox/pytorch/src/pipeline.py, per-component placement flags text_encoder_on_tt and vae_on_tt join the pre-existing transformer_on_tt on CogVideoXConfig, with an any_on_tt property gating runtime/compile-option setup so each component can be flipped back to CPU independently
for bisecting. The DiT-only shard_to_tt() split into an idempotent _ensure_mesh() that enables SPMD once before the first device op and builds one ("batch", "model") mesh shared by all three components, and _shard_to_tt(module, spec_fn) which moves to XLA.

- tiling bounds the activation directly, the alternative fix — making CogVideoXUpsample3D.conv row-parallel so the 1.5 GB interpolate output could stay channel-sharded — was not needed. That change would have unpicked the block-boundary convention across the whole decoder, since the preceding resnet's row-parallel conv2 all-reduces to replicated and _shard_resnet_block in model_utils.py documents three rules depending on it. Setting vae.num_latent_frames_batch_size = 1 remains a trap: with t == 1 per chunk CogVideoXUpsample3D takes the else: squeeze(2) → 2D branch, does no temporal upsampling, and yields 13 frames instead of 49.

- Post this fix, tests/torch/models/cog_videox/test_pipeline.py passes in  with all three components on device — T5 encode 60s, 50 DiT steps in 49m56s at ~31.7 s/step, tiled VAE decode 12m04s (9m25s for the first tile including compile, ~53s each for the remaining three on the cached kernel). DiT PCC against the fp32 CPU twin is
0.999903 and 0.999874, unchanged from the DiT-only baseline


### Validation
E2E test tests/torch/models/cog_videox/test_pipeline.py::test_pipeline — PASSED (1:04:39 / 3879.28s), all three weight-bearing components on TT.

Prompt: "A panda, dressed in a small red jacket and a tiny hat, sits on a wooden stool in a serene bamboo forest. The panda's fluffy paws strum a miniature acoustic guitar, sunlight filtering through the tall bamboo, cinematic, photorealistic, highly detailed, smooth natural motion", 720×480, 49 frames (13 latent frames, DiT seq_len 17776), 50 denoising steps, guidance_scale 6.0, seed 42, 8 chips ((2, 4) mesh). Compile options {'optimization_level': '1'}. 

| Stage | Device | Time |
| --- | --- | --- |
| load diffusers pipeline (T5 + DiT + VAE + scheduler, fp32) | CPU | 54.6s (incl. 35s HF fetch of 16 files)|
| bf16 cast + shard T5 / DiT (rank-preserving qk-norm 84 norms, split-half RoPE 42 blocks) / VAE, one shared mesh | CPU->TT | ~50s |
| T5 v1.1-XXL text encode  | TT | 59.8s |
| DiT denoising loop (50 steps, CFG batched, incl. first-step compile + per-step fp32 CPU twin)  | TT (bf16, sharded) + CPU twin | 49m 55.8s |
| VAE decode (2×2 tiled) | TT (bf16, sharded) | 12m 03.8s |

Loop breakdown: first TT forward incl. compile 5m 23.8s; twin load + first fp32 CPU forward 9m 14.4s; second gated forward (device + twin) 9m 55.8s; the remaining 48 ungated steps ran 1521.75s total, 31.70 s/step.

Per-step DiT PCC vs. fp32 CPU twin: 0.999903 and 0.999874 — unchanged from the DiT-only baseline, so neither the encoder move nor the tiling perturbed numerics.

```
[SETUP] compile options: {'optimization_level': '1'}          14:26:59
[SETUP] T5 text encoder on TT                                 14:27:02
[SETUP] DiT transformer on TT                                 14:27:06
[SETUP] VAE decoder on TT                                     14:27:06
[STAGE] T5 text encode (TT): done                             14:28:06
[STAGE] released text encoder from TT                         14:28:23
[STAGE] DiT denoising loop: start (50 steps)                  14:28:23
[PCC]   loading CPU fp32 DiT twin                             14:33:47
[PCC]   dit forward 2:  pcc=0.999903                          14:43:01
[PCC]   dit forward 4:  pcc=0.999874                          14:52:57
[PCC]   step 5: past PCC_MAX_STEPS=3, releasing fp32 CPU twin 14:52:57
[STAGE] DiT denoising loop: done                              15:18:19
[STAGE] released DiT from TT                                  15:18:38
[VAE tiled] 2x2 tiles, latent tile 34x49, overlap 8           15:18:38
[VAE tiled] tile (0,0) done                                   15:28:03
[VAE tiled] tile (1,1) done                                   15:30:42
[STAGE] VAE decode (TT): done                                 15:30:42
======== 1 passed, 23 warnings in 3879.28s (1:04:39) ========
```


Final video generated from pipeline:

https://github.com/user-attachments/assets/837137ad-d611-4ae7-91e1-94a151d484ad
