### PR TITLE
[HunyuanVideo-1.5] Run text encoders on TT

### DIFF
--- a/hunyuan_1_5/pytorch/src/model_utils.py
+++ b/hunyuan_1_5/pytorch/src/model_utils.py
@@ -54,15 +54,21 @@ BYT5_VOCAB_SIZE = 384  # ByT5 text_encoder_2
 
 
 def load_text_encoder(dtype: torch.dtype = DTYPE):
-    """Load Qwen2.5-VL text encoder from the text_encoder subfolder."""
+    """Load Qwen2.5-VL text encoder from the text_encoder subfolder.
+
+    The pipeline only feeds input_ids/attention_mask (no pixel_values), so the
+    vision tower never runs. Return `.language_model` when the checkpoint is a
+    full VL model, to avoid uploading an unused tower replicated on every chip.
+    """
     from transformers import AutoModel
 
-    return AutoModel.from_pretrained(
+    encoder = AutoModel.from_pretrained(
         REPO_ID,
         subfolder="text_encoder",
         torch_dtype=dtype,
         device_map="cpu",
     ).eval()
+    return getattr(encoder, "language_model", encoder)
 
 
 def load_text_encoder_2(dtype: torch.dtype = DTYPE):
@@ -126,6 +132,32 @@ class VAEDecoderWrapper(torch.nn.Module):
         return self.vae.decode(z, return_dict=False)[0]
 
 
+class QwenPromptEmbedsWrapper(torch.nn.Module):
+    """Qwen2.5-VL text encoder as (input_ids, attention_mask) -> prompt_embeds.
+
+    Picking the hidden state and dropping the prompt-template prefix inside the
+    forward (mirrors the pipeline's `_get_mllm_prompt_embeds`) keeps all ~29
+    hidden states out of the graph outputs. The mask is only an input here — the
+    encoder attends over the template prefix, and the caller drops that prefix
+    from the copy it passes downstream.
+    """
+
+    def __init__(self, encoder, hidden_state_skip_layer: int, drop_idx: int):
+        super().__init__()
+        self.encoder = encoder
+        self.hidden_state_skip_layer = hidden_state_skip_layer
+        self.drop_idx = drop_idx
+
+    def forward(self, input_ids, attention_mask):
+        out = self.encoder(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+        )
+        skip = self.hidden_state_skip_layer
+        return out.hidden_states[-(skip + 1)][:, self.drop_idx :]
+
+
 class HunyuanVideo15TransformerWrapper(torch.nn.Module):
     """Simplify HunyuanVideo15Transformer3DModel forward to tensor-only inputs/outputs."""
 
@@ -172,12 +204,19 @@ def shard_text_encoder_specs(encoder) -> dict:
     """
     specs = {}
 
+    # Unwrap Qwen2_5_VLModel -> decoder; else embed_tokens/layers aren't found
+    # and every weight stays replicated on each device.
+    encoder = getattr(encoder, "language_model", encoder)
+
     if hasattr(encoder, "embed_tokens"):
         specs[encoder.embed_tokens.weight] = (None, "batch")
 
     layers = getattr(encoder, "layers", None)
-    if layers is None:
-        return specs
+    if not layers:
+        raise ValueError(
+            f"No decoder layers on {type(encoder).__name__}; refusing to run "
+            "fully replicated (expected `.layers` after unwrapping)."
+        )
 
     for layer in layers:
         sa = layer.self_attn

--- a/hunyuan_1_5/pytorch/src/pipeline.py
+++ b/hunyuan_1_5/pytorch/src/pipeline.py
@@ -2,8 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""HunyuanVideo 1.5 (480p t2v distilled) pipeline: DiT tensor-parallel on TT,
-text encoders/scheduler/VAE on CPU.
+"""HunyuanVideo 1.5 (480p t2v distilled) pipeline: DiT and both text encoders on
+TT, scheduler/VAE on CPU.
+
+The Qwen2.5-VL encoder and the DiT are tensor-parallel sharded over one shared
+mesh; ByT5 (0.22B) carries no shard spec, so SPMD replicates it. All three are
+loaded, compiled and uploaded once in `setup()` and stay resident, so repeat
+`generate()` calls reuse both weights and compiled graphs.
 
 guidance_scale=1.0 for this checkpoint -> CFG disabled -> single transformer
 forward per step (no guider object needed). use_meanflow=False -> no
@@ -33,14 +38,19 @@ from .model_utils import (
     MESH_NAMES,
     MESH_SHAPES,
     REPO_ID,
+    HunyuanVideo15TransformerWrapper,
+    QwenPromptEmbedsWrapper,
     load_text_encoder,
     load_text_encoder_2,
     load_transformer,
     load_vae,
+    shard_text_encoder_specs,
     shard_transformer_specs,
 )
 
-PROMPT = "a cat sitting on a boat"
+# The double-quoted span is what routes text through text_encoder_2 (the ByT5
+# glyph encoder); without it the pipeline feeds the DiT zero glyph embeds.
+PROMPT = 'A girl holding a paper with words "Hello, world!"'
 SEED = 42
 HEIGHT = 480
 WIDTH = 848
@@ -106,6 +116,7 @@ class HunyuanVideo15Config:
         num_frames: int = NUM_FRAMES,
         shard: bool = True,
         transformer_on_tt: bool = True,
+        text_encoders_on_tt: bool = True,
     ):
         self.num_inference_steps = num_inference_steps
         self.height = height
@@ -113,13 +124,15 @@ class HunyuanVideo15Config:
         self.num_frames = num_frames
         self.shard = shard
         self.transformer_on_tt = transformer_on_tt
+        self.text_encoders_on_tt = text_encoders_on_tt
 
 
 class HunyuanVideo15Pipeline:
-    """DiT sharded on TT; text encoders, scheduler, VAE stay on CPU."""
+    """DiT and both text encoders on TT; scheduler and VAE stay on CPU."""
 
     def __init__(self, config: HunyuanVideo15Config):
         self.config = config
+        self.mesh = None  # set when sharded; shared by every TT component
         self.mesh_shape = None  # set when sharded; read by the benchmark harness
         self._perf = None  # per-stage/per-step timings from the last generate()
 
@@ -131,16 +144,25 @@ class HunyuanVideo15Pipeline:
         self.vae_scale_factor_spatial = self.vae.config.spatial_compression_ratio
         self.num_channels_latents = self.vae.config.latent_channels
         self.scaling_factor = self.vae.config.scaling_factor
-        self.image_embed_dim = self.transformer.config.image_embed_dim
+        self.image_embed_dim = self.transformer.transformer.config.image_embed_dim
         self.video_processor = VideoProcessor(
             vae_scale_factor=self.vae_scale_factor_spatial
         )
 
+        # One mesh, shared by every TT component. SPMD has to be enabled before
+        # the first device op, so this runs ahead of any .to(xla_device()).
+        if self.config.shard and (
+            self.config.transformer_on_tt or self.config.text_encoders_on_tt
+        ):
+            self._init_mesh()
+
+        if self.config.text_encoders_on_tt:
+            self.load_text_encoders_to_tt()
+
         if self.config.transformer_on_tt:
-            if self.config.shard:
-                self.shard_to_tt()
-            else:
-                self.transformer = self.transformer.to(xm.xla_device())
+            self.transformer = self._place_on_tt(
+                self.transformer, lambda m: shard_transformer_specs(m.transformer)
+            )
             # forward, not the module, so self.transformer stays an nn.Module and
             # callers can still wrap forward (e.g. the nightly PCC check).
             self.transformer.forward = torch.compile(
@@ -149,13 +171,32 @@ class HunyuanVideo15Pipeline:
 
     def load_models(self):
         logger.info("[load_models] text_encoder (Qwen2.5-VL, ~7.07B) ...")
-        self.text_encoder = load_text_encoder(DTYPE)
+        # Wrapped even on CPU so both paths call it the same way; the wrapper
+        # holds the hidden-state pick and the template-prefix drop.
+        self.text_encoder = QwenPromptEmbedsWrapper(
+            load_text_encoder(DTYPE),
+            HIDDEN_STATE_SKIP_LAYER,
+            PROMPT_TEMPLATE_ENCODE_START_IDX,
+        ).eval()
         logger.info("[load_models] text_encoder_2 (ByT5, ~0.22B) ...")
         self.text_encoder_2 = load_text_encoder_2(DTYPE)
         logger.info("[load_models] transformer (~8.33B) ...")
-        self.transformer = load_transformer(DTYPE)
+        # Same wrapper the loader hands out, so every TT component takes
+        # positional tensors and returns a bare tensor.
+        self.transformer = HunyuanVideo15TransformerWrapper(
+            load_transformer(DTYPE)
+        ).eval()
         logger.info("[load_models] vae (~1.26B) ...")
         self.vae = load_vae(DTYPE, enable_tiling=True)
+
+    def load_text_encoders_to_tt(self):
+        """Qwen sharded, ByT5 (0.22B) replicated — then compile both forwards."""
+        self.text_encoder = self._place_on_tt(
+            self.text_encoder, lambda m: shard_text_encoder_specs(m.encoder)
+        )
+        self.text_encoder_2 = self._place_on_tt(self.text_encoder_2)
+        for module in (self.text_encoder, self.text_encoder_2):
+            module.forward = torch.compile(module.forward, backend="tt")
 
     def load_scheduler(self):
         self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
@@ -168,7 +209,8 @@ class HunyuanVideo15Pipeline:
             REPO_ID, subfolder="tokenizer_2"
         )
 
-    def shard_to_tt(self):
+    def _init_mesh(self):
+        """Enable SPMD and build the ("batch", "model") mesh all components share."""
         _enable_spmd()
         num_devices = xr.global_runtime_device_count()
         if num_devices not in MESH_SHAPES:
@@ -179,9 +221,31 @@ class HunyuanVideo15Pipeline:
             np.array(range(num_devices)), MESH_SHAPES[num_devices], MESH_NAMES
         )
         self.mesh_shape = tuple(self.mesh.mesh_shape)
-        self.transformer = self.transformer.to(xm.xla_device())
-        for tensor, spec in shard_transformer_specs(self.transformer).items():
-            xs.mark_sharding(tensor, self.mesh, spec)
+        logger.info("[setup] mesh {} over {} device(s)", self.mesh_shape, num_devices)
+
+    def _place_on_tt(self, module, shard_spec_fn=None):
+        """Move a component to the device and apply its shard spec.
+
+        `shard_spec_fn` maps the moved module to its tensor -> partition_spec
+        dict; omit it to run replicated across the mesh.
+        """
+        module = module.to(xm.xla_device())
+        if self.mesh is not None and shard_spec_fn is not None:
+            specs = shard_spec_fn(module)
+            assert (
+                specs
+            ), f"{type(module).__name__} shard spec is empty — would run replicated"
+            for tensor, spec in specs.items():
+                xs.mark_sharding(tensor, self.mesh, spec)
+        return module
+
+    def _to_encoder_device(self, x):
+        """Move a text-encoder input to TT when the encoders run there."""
+        return x.to(xm.xla_device()) if self.config.text_encoders_on_tt else x
+
+    def _from_encoder_device(self, x):
+        """Bring a text-encoder output back to host, forcing the device sync."""
+        return x.to("cpu") if self.config.text_encoders_on_tt else x
 
     def _get_mllm_prompt_embeds(self, prompt: list):
         text_inputs = self.tokenizer.apply_chat_template(
@@ -194,23 +258,34 @@ class HunyuanVideo15Pipeline:
             truncation=True,
             return_tensors="pt",
         )
-        outputs = self.text_encoder(
-            input_ids=text_inputs.input_ids,
-            attention_mask=text_inputs.attention_mask,
-            output_hidden_states=True,
-        )
-        prompt_embeds = outputs.hidden_states[-(HIDDEN_STATE_SKIP_LAYER + 1)]
+        # The encoder gets the full mask — attention runs over the template
+        # prefix; only the copy going downstream to the DiT drops it. The
+        # embeds' hidden-state pick and prefix drop live in the wrapper's
+        # forward, so they stay inside the graph.
         prompt_attention_mask = text_inputs.attention_mask
-        prompt_embeds = prompt_embeds[:, PROMPT_TEMPLATE_ENCODE_START_IDX:]
-        prompt_attention_mask = prompt_attention_mask[
-            :, PROMPT_TEMPLATE_ENCODE_START_IDX:
-        ]
-        return prompt_embeds, prompt_attention_mask
+
+        logger.info("[STAGE] text_encoder (Qwen, sharded, bf16)")
+        t0 = time.perf_counter()
+        prompt_embeds = self._from_encoder_device(
+            self.text_encoder(
+                self._to_encoder_device(text_inputs.input_ids),
+                self._to_encoder_device(prompt_attention_mask),
+            )
+        )
+        self._perf["components"]["text_encoder"] = time.perf_counter() - t0
+
+        return (
+            prompt_embeds,
+            prompt_attention_mask[:, PROMPT_TEMPLATE_ENCODE_START_IDX:],
+        )
 
     def _get_byt5_prompt_embeds(self, prompt: list):
         embeds_list, mask_list = [], []
+        elapsed = 0.0
         for glyph_text in [extract_glyph_texts(p) for p in prompt]:
             if glyph_text is None:
+                # No quoted text: the embeds are fabricated zeros, so stay on
+                # host instead of compiling a graph to produce them.
                 embeds = torch.zeros(
                     (1, TOKENIZER_2_MAX_LENGTH, self.text_encoder_2.config.d_model),
                     dtype=self.text_encoder_2.dtype,
@@ -225,25 +300,32 @@ class HunyuanVideo15Pipeline:
                     add_special_tokens=True,
                     return_tensors="pt",
                 )
-                embeds = self.text_encoder_2(
-                    input_ids=txt_tokens.input_ids,
-                    attention_mask=txt_tokens.attention_mask.float(),
-                )[0]
+                logger.info("[STAGE] text_encoder_2 (ByT5, replicated, bf16)")
+                # The encoder takes a float mask; DTYPE keeps it in the dtype the
+                # model itself runs in. The int mask flows downstream.
+                t0 = time.perf_counter()
+                embeds = self._from_encoder_device(
+                    self.text_encoder_2(
+                        self._to_encoder_device(txt_tokens.input_ids),
+                        self._to_encoder_device(txt_tokens.attention_mask.to(DTYPE)),
+                    )[0]
+                )
+                elapsed += time.perf_counter() - t0
                 mask = txt_tokens.attention_mask
             embeds_list.append(embeds)
             mask_list.append(mask)
+        self._perf["components"]["text_encoder_2"] = elapsed
         return torch.cat(embeds_list, dim=0), torch.cat(mask_list, dim=0)
 
     def _encode_prompt(self, prompt: str):
         prompt = [prompt]
         prompt_embeds, prompt_embeds_mask = self._get_mllm_prompt_embeds(prompt)
         prompt_embeds_2, prompt_embeds_mask_2 = self._get_byt5_prompt_embeds(prompt)
-        dtype = self.transformer.dtype
         return (
-            prompt_embeds.to(dtype=dtype),
-            prompt_embeds_mask.to(dtype=dtype),
-            prompt_embeds_2.to(dtype=dtype),
-            prompt_embeds_mask_2.to(dtype=dtype),
+            prompt_embeds.to(dtype=DTYPE),
+            prompt_embeds_mask.to(dtype=DTYPE),
+            prompt_embeds_2.to(dtype=DTYPE),
+            prompt_embeds_mask_2.to(dtype=DTYPE),
         )
 
     @torch.no_grad()
@@ -261,7 +343,12 @@ class HunyuanVideo15Pipeline:
 
         # Per-stage/per-step timings for the benchmark harness (components =
         # CPU stages, steps = per-DiT-forward device latency, total = wall time).
-        perf = {"components": {}, "steps": [], "step_metric_name": "transformer_step"}
+        # Bound to self up front so the encode helpers can record into it.
+        self._perf = perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "transformer_step",
+        }
         gen_start = time.perf_counter()
 
         def _to_tt(x):
@@ -275,14 +362,14 @@ class HunyuanVideo15Pipeline:
             generator.manual_seed(seed)
 
         logger.info("[generate] encoding prompt ...")
-        t0 = time.perf_counter()
+        # Each encoder records its own component time (device-synced) inside
+        # _encode_prompt.
         (
             prompt_embeds,
             prompt_embeds_mask,
             prompt_embeds_2,
             prompt_embeds_mask_2,
         ) = self._encode_prompt(prompt)
-        perf["components"]["text_encode"] = time.perf_counter() - t0
 
         latent_shape = (
             1,
@@ -292,21 +379,17 @@ class HunyuanVideo15Pipeline:
             cfg.width // self.vae_scale_factor_spatial,
         )
         latents = randn_tensor(
-            latent_shape, generator=generator, device=cpu, dtype=self.transformer.dtype
+            latent_shape, generator=generator, device=cpu, dtype=DTYPE
         )
 
         b, c, f, h, w = latents.shape
-        cond_latents_concat = torch.zeros(
-            b, c, f, h, w, dtype=self.transformer.dtype, device=cpu
-        )
-        mask_concat = torch.zeros(
-            b, 1, f, h, w, dtype=self.transformer.dtype, device=cpu
-        )
+        cond_latents_concat = torch.zeros(b, c, f, h, w, dtype=DTYPE, device=cpu)
+        mask_concat = torch.zeros(b, 1, f, h, w, dtype=DTYPE, device=cpu)
         image_embeds = torch.zeros(
             1,
             VISION_NUM_SEMANTIC_TOKENS,
             self.image_embed_dim,
-            dtype=self.transformer.dtype,
+            dtype=DTYPE,
             device=cpu,
         )
 
@@ -331,17 +414,17 @@ class HunyuanVideo15Pipeline:
                 latent_model_input.dtype
             )
 
+            # Positional, in HunyuanVideo15TransformerWrapper.forward's order.
             step_start = time.perf_counter()
             noise_pred = self.transformer(
-                hidden_states=_to_tt(latent_model_input),
-                timestep=_to_tt(timestep),
-                encoder_hidden_states=eh_tt,
-                encoder_attention_mask=mask_tt,
-                encoder_hidden_states_2=eh2_tt,
-                encoder_attention_mask_2=mask2_tt,
-                image_embeds=img_tt,
-                return_dict=False,
-            )[0]
+                _to_tt(latent_model_input),
+                _to_tt(timestep),
+                eh_tt,
+                mask_tt,
+                eh2_tt,
+                mask2_tt,
+                img_tt,
+            )
             noise_pred = _to_cpu(
                 noise_pred
             )  # forces the device sync -> real per-step latency
@@ -359,5 +442,4 @@ class HunyuanVideo15Pipeline:
         perf["components"]["vae"] = time.perf_counter() - t0
 
         perf["total"] = time.perf_counter() - gen_start
-        self._perf = perf
         return frames


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/5973

### Problem description
- HunyuanVideo 1.5 only ran the DiT on TT; the Qwen2.5-VL and ByT5 text encoders stayed on CPU.

### What's changed
- Moved Qwen (TP-sharded) and ByT5 (replicated) text encoders onto TT in `HunyuanVideo15Pipeline`, compiled and resident from `setup()`; scheduler and VAE stay on CPU. All three TT components run bf16.
- Built one mesh shared by every TT component, created before the first device op. Previously the mesh was created inside the transformer-only path.
- Added `QwenPromptEmbedsWrapper` so Qwen's TT forward emits only the prompt embeds, not all hidden states.
- Sharded Qwen even though it is only 7B: without a shard spec, SPMD replicates it onto every chip, which crowds out the DiT. `shard_text_encoder_specs` now unwraps `.language_model` and raises instead of silently returning `{}`.
- Switched the pipeline to `HunyuanVideo15TransformerWrapper` (the wrapper the loader already hands out), so every TT component takes positional tensors and returns a bare tensor — one PCC code path covers all three.
- Default prompt now carries a double-quoted span, so the ByT5 glyph path actually runs instead of short-circuiting to zeros.

### Checklist
- [x] Demo - [demo.zip](https://github.com/user-attachments/files/31175619/demo.zip)
- [x] Benchmark - [Perf benchmark run](https://github.com/tenstorrent/tt-xla/actions/runs/32122250239/job/95668789549)
- [x] PCC-gated Nightly test - [pcc_test.zip](https://github.com/user-attachments/files/31175623/pcc_test.zip)

### Generated Video

- Prompt : `A girl holding a paper with words "Hello, world!"`, 10 inference steps, 25 frames, 15 fps

https://github.com/user-attachments/assets/b56f97d2-5beb-44a6-b416-f2d2468246c2



