### PR TITLE
[GLM Image] Shard VAE decoder on the model axis only

### DIFF
--- a/glm_image/pytorch/src/model_utils.py
+++ b/glm_image/pytorch/src/model_utils.py
@@ -606,23 +606,32 @@ def _shard_resnet_block_2d(block, specs: dict) -> None:
         # `conv2_out + shortcut_out` requires the shortcut to also be
         # replicated, so we don't shard it.
 
+      norm1 / norm2 (replicated):
+        weight (None,)
+        bias   (None,)
+        # GroupNorm params are per-channel over the block's INPUT channels.
+        # Sharding them on "batch" (a mesh axis the activation is not split
+        # on) forces a model<->batch axis swap that lowers to
+        # collective_permute; Shardy slices a replicated param locally to
+        # whatever the activation sharding turns out to be, for free.
+
     Spatial dims (kH, kW) are NEVER sharded — that would require a halo
     exchange (neighbor_pad / slice_reshard) collective which TTIR/TTNN MLIR
     does not currently expose. Channel sharding is the only viable strategy.
     """
     if hasattr(block, "norm1"):
-        specs[block.norm1.weight] = ("batch",)
+        specs[block.norm1.weight] = (None,)
         if block.norm1.bias is not None:
-            specs[block.norm1.bias] = ("batch",)
+            specs[block.norm1.bias] = (None,)
 
     specs[block.conv1.weight] = ("model", None, None, None)
     if block.conv1.bias is not None:
         specs[block.conv1.bias] = ("model",)
 
     if hasattr(block, "norm2"):
-        specs[block.norm2.weight] = ("batch",)
+        specs[block.norm2.weight] = (None,)
         if block.norm2.bias is not None:
-            specs[block.norm2.bias] = ("batch",)
+            specs[block.norm2.bias] = (None,)
 
     specs[block.conv2.weight] = (None, "model", None, None)
     if block.conv2.bias is not None:
@@ -660,8 +669,15 @@ def shard_vae_specs(vae) -> dict:
         # must match the post-all_reduce replicated state of conv2 so the
         # residual add doesn't need a re-shard.
 
-    Norm / mid-block attention specs are replicated along the "batch" axis
-    only, mirroring the conventions used elsewhere in the pipeline.
+    "model" is the ONLY weight-sharding axis here, matching the convention in
+    shard_transformer_specs. Everything that is not channel-parallel (the
+    GroupNorms, the row-parallel biases) is REPLICATED rather than
+    "batch"-sharded: the decoder activations are never split on "batch"
+    (B == 1), so a "batch"-sharded param forces a model<->batch axis-swap
+    reshard that lowers to collective_permute — which ShardyToStableHLO
+    cannot lower (tt-mlir#3370). A replicated param costs nothing: Shardy
+    slices it locally to match whatever the activation sharding turns out
+    to be.
     """
     specs = {}
 
@@ -682,13 +698,13 @@ def shard_vae_specs(vae) -> dict:
             if attn is None:
                 continue
             if hasattr(attn, "group_norm") and attn.group_norm is not None:
-                specs[attn.group_norm.weight] = ("batch",)
+                specs[attn.group_norm.weight] = (None,)
                 if attn.group_norm.bias is not None:
-                    specs[attn.group_norm.bias] = ("batch",)
+                    specs[attn.group_norm.bias] = (None,)
             for proj_name in ("to_q", "to_k", "to_v"):
                 if hasattr(attn, proj_name):
                     proj = getattr(attn, proj_name)
-                    specs[proj.weight] = ("model", "batch")
+                    specs[proj.weight] = ("model", None)
                     if proj.bias is not None:
                         specs[proj.bias] = ("model",)
             if hasattr(attn, "to_out"):
@@ -698,9 +714,11 @@ def shard_vae_specs(vae) -> dict:
                     if isinstance(out, (torch.nn.Sequential, torch.nn.ModuleList))
                     else out
                 )
-                specs[target.weight] = ("batch", "model")
+                specs[target.weight] = (None, "model")
+                # Replicated: the row-parallel output is replicated after the
+                # all_reduce, so a sharded bias would be summed N times.
                 if target.bias is not None:
-                    specs[target.bias] = ("batch",)
+                    specs[target.bias] = (None,)
 
     for up_block in getattr(decoder, "up_blocks", []) or []:
         for resnet in getattr(up_block, "resnets", []) or []:
@@ -711,9 +729,9 @@ def shard_vae_specs(vae) -> dict:
                 specs[upsampler.conv.bias] = ("model",)
 
     if hasattr(decoder, "conv_norm_out"):
-        specs[decoder.conv_norm_out.weight] = ("batch",)
+        specs[decoder.conv_norm_out.weight] = (None,)
         if decoder.conv_norm_out.bias is not None:
-            specs[decoder.conv_norm_out.bias] = ("batch",)
+            specs[decoder.conv_norm_out.bias] = (None,)
 
     if hasattr(decoder, "conv_out"):
         specs[decoder.conv_out.weight] = (None, "model", None, None)


### PR DESCRIPTION
### Ticket
Fixes [#5934](https://github.com/tenstorrent/tt-xla/issues/5934)

### Problem description
VAE decoder (test_vae_decoder_sharded, 8-device (2,4) ("batch","model") mesh) fails in three successive stages, each one only visible after the previous is cleared:

loc("reshape.900"): error: ShardyToStableHLO lowering for CollectivePermuteOp is not implemented yet

### What's changed

- Two independent fixes, one shared principle each: a tensor may only be sharded on an axis its consumer can actually match, and a fused kernel must not be decomposed when its decomposition is asymptotically worse than the kernel.

- VAE decoder is now single-axis "model" (tt-forge-models, glm_image/pytorch/src/model_utils.py). "model" becomes the only weight-sharding axis in the decoder; everything not channel-parallel is replicated rather than "batch"-sharded. The decoder runs with B == 1, so its activations are never split on "batch" — a "batch"-sharded parameter forces a model↔batch axis-swap reshard that lowers to collective_permute.

- Replication is free for these tensors: Shardy slices a replicated param locally to match whatever the activation sharding turns out to be. Concretely, in _shard_resnet_block_2d the norm1/norm2 weight+bias go ("batch",) → (None,), and in shard_vae_specs the mid-block attn.group_norm and decoder.conv_norm_out go ("batch",) → (None,), to_q/to_k/to_v.weight go ("model","batch") → ("model", None), and to_out[0].weight goes ("batch","model") → (None,"model") with its bias ("batch",) → (None,) (the row-parallel output is replicated after the all_reduce, so a sharded bias would be summed N times). All conv specs are untouched — conv_in/conv1/upsampler stay column-parallel, conv2/conv_out row-parallel, conv_shortcut replicated; they were already single-axis and correct.

- After this change, model failed with oom which was fixed by setting opt level to 1, post which it fails with pcc drop, which is fixed by a following tt-mlir PR.

### Logs
[glm_vae_decoder_before_fix_aug19.log](https://github.com/user-attachments/files/31543202/glm_vae_decoder_before_fix_aug19.log)
[glm_vae_decoder_after_fix_aug19.log](https://github.com/user-attachments/files/31543207/glm_vae_decoder_after_fix_aug19.log)




