### PR TITLE
[XTTS-v2] Read the reference clip from the HF LibriSpeech dummy set

### DIFF
--- a/xtts_v2/pytorch/loader.py
+++ b/xtts_v2/pytorch/loader.py
@@ -71,9 +71,16 @@ class ModelLoader(ForgeModel):
         "it I'm not going to be silent."
     )
     DEFAULT_LANGUAGE = "en"
-    # Real public reference clip (LibriSpeech, the Whisper loader's asset), since
-    # the model card ships only a placeholder speaker wav.
-    REFERENCE_AUDIO = "test_files/pytorch/whisper/1272-128104-0000.pt"
+    # Real public reference clip, since the model card ships only a placeholder
+    # speaker wav: LibriSpeech utterance 1272-128104-0000, read straight from the
+    # HF dummy set. The same clip also exists as a cached asset
+    # (test_files/pytorch/whisper/1272-128104-0000.pt, the Whisper loader's), but
+    # that one is only reachable where the large-file cache is, which excludes the
+    # bare-metal perf runners. Both sources decode to identical float32 samples.
+    REFERENCE_AUDIO_REPO = "hf-internal-testing/librispeech_asr_dummy"
+    REFERENCE_AUDIO_CONFIG = "clean"
+    REFERENCE_AUDIO_SPLIT = "validation"
+    REFERENCE_AUDIO_INDEX = 0
     # Seconds of reference audio used for the conditioning latents (model-card
     # ``gpt_cond_len=3``).
     GPT_COND_LEN = 3
@@ -132,6 +139,32 @@ class ModelLoader(ForgeModel):
     # Xtts.inference). Each block is memoized so a variant only pays for   #
     # the tensors it needs; the whole chain is deterministic.             #
     # ------------------------------------------------------------------ #
+    @classmethod
+    def load_reference_audio(cls):
+        """The reference clip as float32 samples plus its own sample rate.
+
+        Decoding is done here rather than through ``datasets``' own Audio
+        decoding, which routes via torchcodec and so needs ffmpeg shared
+        libraries that the test images do not carry.
+        """
+        import io
+
+        import soundfile
+        from datasets import Audio, load_dataset
+
+        dataset = load_dataset(
+            cls.REFERENCE_AUDIO_REPO,
+            cls.REFERENCE_AUDIO_CONFIG,
+            split=cls.REFERENCE_AUDIO_SPLIT,
+        ).cast_column("audio", Audio(decode=False))
+        clip = dataset[cls.REFERENCE_AUDIO_INDEX]["audio"]
+        encoded = clip["bytes"]
+        if not encoded:
+            with open(clip["path"], "rb") as handle:
+                encoded = handle.read()
+        array, sample_rate = soundfile.read(io.BytesIO(encoded), dtype="float32")
+        return array, int(sample_rate)
+
     def _reference_audio_22k(self):
         """Load the real reference clip and resample to XTTS's 22.05 kHz rate."""
         if "audio22" in self._cache:
@@ -140,13 +173,8 @@ class ModelLoader(ForgeModel):
         import numpy as np
         import torchaudio
 
-        from ...tools.utils import get_file
-
-        sample = torch.load(get_file(self.REFERENCE_AUDIO), weights_only=False)
-        sr = int(sample["audio"].get("sampling_rate", 16000))  # asset's own rate
-        audio = torch.tensor(
-            np.asarray(sample["audio"]["array"], dtype="float32")
-        ).unsqueeze(0)
+        array, sr = self.load_reference_audio()
+        audio = torch.tensor(np.asarray(array, dtype="float32")).unsqueeze(0)
         if sr != self.XTTS_SR:
             audio = torchaudio.functional.resample(audio, sr, self.XTTS_SR)
         self._cache["audio22"] = audio

--- a/xtts_v2/pytorch/pipeline.py
+++ b/xtts_v2/pytorch/pipeline.py
@@ -41,7 +41,6 @@ OUTPUT_SAMPLE_RATE = 24000
 # Audio sample rates (Hz).
 XTTS_SAMPLE_RATE = 22050  # XTTS native rate for conditioning / cloning mels
 SPEAKER_ENCODER_SR = 16000  # speaker-encoder input rate
-DEFAULT_REFERENCE_SR = 16000  # fallback rate of the packaged reference clip
 
 # wav_to_mel_cloning front-end params (reference Xtts.get_gpt_cond_latents).
 MEL_N_FFT = 2048
@@ -183,15 +182,8 @@ class XTTSPipeline:
             audio = audio.mean(0, keepdim=True)  # mono
         else:
             # Same public LibriSpeech reference the component loader uses.
-            from ...tools.utils import get_file
-
-            sample = torch.load(
-                get_file(self._loader.REFERENCE_AUDIO), weights_only=False
-            )
-            sr = int(sample["audio"].get("sampling_rate", DEFAULT_REFERENCE_SR))
-            audio = torch.tensor(
-                np.asarray(sample["audio"]["array"], dtype="float32")
-            ).unsqueeze(0)
+            array, sr = self._loader.load_reference_audio()
+            audio = torch.tensor(np.asarray(array, dtype="float32")).unsqueeze(0)
         if sr != XTTS_SAMPLE_RATE:
             audio = torchaudio.functional.resample(audio, sr, XTTS_SAMPLE_RATE)
         return audio

--- a/xtts_v2/pytorch/requirements.txt
+++ b/xtts_v2/pytorch/requirements.txt
@@ -1,3 +1,5 @@
 coqui-tts
+datasets
+soundfile
 --extra-index-url https://download.pytorch.org/whl/cpu
 torchaudio==2.11.0+cpu


### PR DESCRIPTION
## Ticket
- https://github.com/tenstorrent/tt-xla/issues/5216

## Problem Description
- The XTTS-v2 loader and pipeline took their reference speaker clip from `test_files/pytorch/whisper/1272-128104-0000.pt` via `get_file()`, which resolves a fixture from one of two places: the S3-synced docker cache (`DOCKER_CACHE_ROOT`) or the IRD large-file cache (`IRD_LF_CACHE`).
- **Neither is usable on the bare-metal perf runners**, so the xtts_v2 perf benchmark cannot run there at all:
  - `shared-runners=false` (the nightly's config): `DOCKER_CACHE_ROOT=/mnt/dockercache` is set, but that pool's cache carries no `test_files/` tree — `FileNotFoundError` ([run 32323066818](https://github.com/tenstorrent/tt-xla/actions/runs/32323066818)). Probed directly from p150-perf: `ls: cannot access '/mnt/dockercache/models/tt-ci-models-private/test_files/pytorch/whisper/': No such file or directory`.
  - `shared-runners=true`: `call-perf-test.yml` never sets `IRD_LF_CACHE` — `ValueError` ([run 32320607057](https://github.com/tenstorrent/tt-xla/actions/runs/32320607057)).
- Pointing the perf legs at the IRD cache is not an available fix: `vars.IRD_LF_CACHE` is `http://large-file-cache.large-file-cache.svc.cluster.local`, a cluster-internal service name, and the perf runners sit outside the kubernetes cluster. Probed from p150-perf ([run 32326295221](https://github.com/tenstorrent/tt-xla/actions/runs/32326295221)): `DNS RESOLUTION FAILED`, `http_code=000`, wget exit 1024.
- The clip itself is public and needs no private asset: it is LibriSpeech utterance `1272-128104-0000`, i.e. row 0 of `hf-internal-testing/librispeech_asr_dummy` — the cached `.pt` is that dataset row pickled (`file`, `audio{path,array,sampling_rate}`, `text`, `speaker_id`, `chapter_id`, `id`).

## What's Changed
- **`xtts_v2/pytorch/loader.py`**: replaced the `REFERENCE_AUDIO` asset path with dataset coordinates (`REFERENCE_AUDIO_REPO` / `_CONFIG` / `_SPLIT` / `_INDEX`) and added a `load_reference_audio()` classmethod returning `(float32 samples, sample_rate)`. `_reference_audio_22k()` now consumes it; the resample and every memoized derivation below it are untouched.
- Decoding goes through `soundfile` on the raw flac bytes (`Audio(decode=False)`) rather than `datasets`' own Audio decoding, which routes via `torchcodec` and needs ffmpeg shared libraries (`libavutil.so.56`) that the test images do not carry.
- **`xtts_v2/pytorch/pipeline.py`**: the non-`speaker_wav` branch calls the same `load_reference_audio()`, so loader and pipeline keep sharing one source. Drops the now-unused `DEFAULT_REFERENCE_SR`.
- **`xtts_v2/pytorch/requirements.txt`**: `datasets`, `soundfile`.
- This follows what the repo already does for audio inputs — `seamless_m4t_v2/pytorch/loader.py:138-141`, `wav2vec2/audio_classification/jax/loader.py:145`, `whisper/audio_classification/jax/loader.py:166` — where the seamless loader notes the dataset is preferred precisely because it "does not depend on arbitrary host reachability".

## Validation Results
No baseline moves, because the two sources are the same bytes. Verified on a Blackhole p150.

| Check | Result |
|---|---|
| Decoded samples, HF vs cached asset | ✅ bit-identical — 93680 float32 @ 16 kHz, `max abs diff 0.0`, transcript and `id` match |
| 22.05 kHz resampled tensor (what every downstream stage consumes) | ✅ bit-identical — `(1, 129103)`, `max abs diff 0.0` |
| `test_tts.py::test_xtts_v2` benchmark, on device | ✅ PASSED — RTF 1.079x, 127 audio tokens, 0 compilations in the measured pass, deviation `0.000e+00` |
| Warmup compile split preserved (`WARMUP_PASSES = 2` is load-bearing) | ✅ 26 graphs on warmup 1, 32 cumulative on warmup 2, 32 → 32 in the measured pass |
| `black --check`, `py_compile` | ✅ clean |

Benchmark, post-change:

```
Warmup pass 1/2: 2049.090s  (127 audio tokens, cumulative compiles=26)
Warmup pass 2/2:    5.984s  (127 audio tokens, cumulative compiles=32)
Steady-state pass:  5.456s
| Compilations during the steady-state pass: 0 (32 -> 32)
| Max |measured - warmup| sample deviation: 0.000e+00
| Audio tokens: 127 (5.89s @ 24000 Hz)
|   real-time factor: 1.079x
PASSED
```


## Checklist
- [x] New/existing tests provide coverage for changes (xtts_v2 benchmark + the PCC-gated e2e and single-device inference variants in tt-xla)
- [x] Reference input proven byte-identical to the previous source, so no PCC or RTF baseline needs re-recording
- [x] Loader and pipeline share a single reference-clip source

## Related
- tt-xla https://github.com/tenstorrent/tt-xla/pull/5905 adds the xtts_v2 benchmark and its nightly matrix entry. It should merge only after this PR is merged and the `tt_forge_models` submodule is uplifted in tt-xla, otherwise the nightly's `n150-perf` / `p150-perf` xtts_v2 legs fail on the missing fixture.


## Logs
- [xtts_v2_hf_clip_benchmark_trimmed.log](https://github.com/user-attachments/files/31259920/xtts_v2_hf_clip_benchmark_trimmed.log)

