### PR TITLE
[HunyuanImage-2.1] Replace distilled variant with base variant

### DIFF
--- a/hunyuan_image_2_1/pytorch/loader.py
+++ b/hunyuan_image_2_1/pytorch/loader.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-HunyuanImage 2.1 (Distilled) component loader.
+HunyuanImage 2.1 component loader.
 
 Each variant corresponds to one independently loadable component:
   - TextEncoder   → Qwen2.5-VL-7B-Instruct encoder (text_encoder)   params=8.29B
   - TextEncoder2  → ByT5 encoder (text_encoder_2)                    params=0.22B
-  - Transformer   → HunyuanImage21TransformerWrapper (MMDiT)         params=17.45B
+  - Transformer   → HunyuanImage21TransformerWrapper (MMDiT)         params=17.43B
   - Vae           → VAEDecoderWrapper                                params=0.41B
 """
 
@@ -51,7 +51,7 @@ from .src.model_utils import (
     shard_transformer_specs,
 )
 
-_REPO_ID = "hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers"
+_REPO_ID = "hunyuanvideo-community/HunyuanImage-2.1-Diffusers"
 
 
 class ModelVariant(StrEnum):
@@ -152,8 +152,7 @@ class ModelLoader(ForgeModel):
 
         TEXT_ENCODER   → [input_ids (1,1034) int64, attention_mask (1,1034) int64]
         TEXT_ENCODER_2 → [input_ids (1,128) int64,  attention_mask (1,128) float32]
-        TRANSFORMER    → [hidden_states (1,64,64,64), timestep (1,), timestep_r (1,),
-                          guidance (1,),
+        TRANSFORMER    → [hidden_states (1,64,64,64), timestep (1,),
                           encoder_hidden_states (1,1000,3584),
                           encoder_attention_mask (1,1000) int64,
                           encoder_hidden_states_2 (1,128,1472),
@@ -182,10 +181,6 @@ class ModelLoader(ForgeModel):
                 1, TRANSFORMER_IN_CHANNELS, LATENT_H, LATENT_W, dtype=dtype
             )
             timestep = torch.tensor([1000.0], dtype=dtype)
-            timestep_r = torch.tensor([0.0], dtype=dtype)
-            guidance = torch.tensor(
-                [3500.0], dtype=dtype
-            )  # distilled_guidance_scale * 1000
             encoder_hidden_states = torch.randn(
                 1, TRANSFORMER_TEXT_SEQ, TEXT_EMBED_DIM, dtype=dtype
             )
@@ -201,8 +196,6 @@ class ModelLoader(ForgeModel):
             return [
                 hidden_states,
                 timestep,
-                timestep_r,
-                guidance,
                 encoder_hidden_states,
                 encoder_attention_mask,
                 encoder_hidden_states_2,

--- a/hunyuan_image_2_1/pytorch/pipeline.py
+++ b/hunyuan_image_2_1/pytorch/pipeline.py
@@ -1,24 +1,24 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-"""HunyuanImage 2.1 (Distilled) text-to-image pipeline running on Tenstorrent.
+"""HunyuanImage 2.1 text-to-image pipeline running on Tenstorrent.
 
 The Qwen2.5-VL encoder, the ByT5 glyph encoder and the MMDiT transformer run on
-TT in bf16; the scheduler and the VAE run on CPU in fp32. Qwen and the
-transformer are tensor-parallel sharded; ByT5 (0.22B) carries no shard spec, so
-SPMD replicates it across the mesh.
+TT in bf16; the scheduler, the guider combine and the VAE run on CPU in fp32.
+Qwen and the transformer are tensor-parallel sharded; ByT5 (0.22B) carries no
+shard spec, so SPMD replicates it across the mesh.
 
 Every TT model is loaded, compiled and uploaded once in ``setup()`` and stays
 resident: in bf16 the three together are ~13 GB of a chip's 32 GB. Repeat
 ``generate()`` calls reuse both the weights and the compiled graphs.
 
-The math mirrors ``HunyuanImagePipeline.__call__`` (distilled: guider disabled →
-single conditional forward per step, distilled-guidance embedding, meanflow
-``timestep_r``, ByT5 glyph stream).
+The math mirrors ``HunyuanImagePipeline.__call__``: guidance is real CFG from the
+repo's ``guider``/``ocr_guider``, so the transformer runs twice per step (cond +
+uncond) and the predictions are combined on the host.
 
 Consumed by the runnable example (``examples/pytorch/hunyuan_image_2_1.py``), the
 image-gen benchmark and the nightly PCC test. ``self._perf`` holds per-component
-times after each ``generate()``.
+times after each ``generate()``; one ``steps`` entry covers both forwards.
 """
 
 import re
@@ -31,10 +31,12 @@ import torch_xla
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from diffusers import FlowMatchEulerDiscreteScheduler
+from diffusers.guiders import AdaptiveProjectedMixGuidance
+from diffusers.guiders.adaptive_projected_guidance_mix import MomentumBuffer
+from diffusers.image_processor import VaeImageProcessor
 from diffusers.utils.torch_utils import randn_tensor
 from infra.utilities.torch_multichip_utils import enable_spmd, get_mesh
 from loguru import logger
-from PIL import Image
 from transformers import ByT5Tokenizer, Qwen2Tokenizer
 
 from .loader import ModelLoader, ModelVariant
@@ -44,7 +46,7 @@ from .src.model_utils import (
     QwenPromptEmbedsWrapper,
 )
 
-REPO_ID = "hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers"
+REPO_ID = "hunyuanvideo-community/HunyuanImage-2.1-Diffusers"
 PROMPT = (
     "A cute, cartoon-style anthropomorphic penguin plush toy with fluffy fur, "
     "standing in a painting studio, wearing a red knitted scarf and a red beret "
@@ -55,8 +57,8 @@ PROMPT = (
 # The three TT components run bf16; the VAE stays fp32 on CPU.
 TT_DTYPE = torch.bfloat16
 SEED = 649151
-NUM_INFERENCE_STEPS = 8
-DISTILLED_GUIDANCE_SCALE = 3.5
+NUM_INFERENCE_STEPS = 10  # 10 for now, will be boosted to 50 later
+NEGATIVE_PROMPT = None  # -> "", which gives a zero ByT5 glyph stream
 HEIGHT = 2048
 WIDTH = 2048
 
@@ -139,6 +141,14 @@ class HunyuanImage21Pipeline:
             self.config.repo_id, subfolder="tokenizer_2"
         )
 
+        # Both loaded: selection depends on the prompt's glyph stream.
+        self.guider = AdaptiveProjectedMixGuidance.from_pretrained(
+            self.config.repo_id, subfolder="guider"
+        )
+        self.ocr_guider = AdaptiveProjectedMixGuidance.from_pretrained(
+            self.config.repo_id, subfolder="ocr_guider"
+        )
+
     def load_models(self):
         # TT-bound models: load on CPU and compile here, then setup() uploads
         # them. We wrap forward, not the module, so each attribute stays an
@@ -176,9 +186,10 @@ class HunyuanImage21Pipeline:
                 xs.mark_sharding(tensor, self.mesh, spec)
         return module
 
-    def _encode_qwen(self, prompt):
-        """Qwen2.5-VL text encoder — TT (bf16, sharded)."""
-        logger.info("[STAGE] text_encoder (Qwen, sharded, bf16): TT")
+    def _encode_qwen(self, prompt, role="cond"):
+        """Qwen2.5-VL text encoder — TT (bf16, sharded). Called twice per
+        ``generate()``; the recorded time accumulates across both."""
+        logger.info("[STAGE] text_encoder (Qwen, sharded, bf16): TT [{}]", role)
         dev = torch_xla.device()
         drop_idx = PROMPT_TEMPLATE_ENCODE_START_IDX
         tokens = self.tokenizer(
@@ -197,8 +208,30 @@ class HunyuanImage21Pipeline:
             .cpu()
             .to(torch.float32)
         )
-        self._perf["components"]["text_encoder"] = time.perf_counter() - t0
+        self._perf["components"]["text_encoder"] = self._perf["components"].get(
+            "text_encoder", 0.0
+        ) + (time.perf_counter() - t0)
         return prompt_embeds, tokens.attention_mask[:, drop_idx:]
+
+    def _select_guider(self, prompt_embeds_2):
+        """Mirror HunyuanImagePipeline's guider selection, fallback included."""
+        if not torch.all(prompt_embeds_2 == 0) and self.ocr_guider is not None:
+            guider, which = self.ocr_guider, "ocr_guider (glyph stream non-zero)"
+        elif self.guider is not None:
+            guider, which = self.guider, "guider (glyph stream all zero)"
+        else:
+            guider, which = (
+                AdaptiveProjectedMixGuidance(enabled=False),
+                "disabled fallback (no guider in repo)",
+            )
+        logger.info(
+            "[guider] {} | num_conditions={} guidance_scale={} apg_start_step={}",
+            which,
+            guider.num_conditions,
+            guider.guidance_scale,
+            guider.adaptive_projected_guidance_start_step,
+        )
+        return guider
 
     def _encode_byt5(self, prompt):
         """ByT5 glyph encoder — TT (bf16, replicated)."""
@@ -238,7 +271,7 @@ class HunyuanImage21Pipeline:
     def generate(
         self,
         prompt: str = PROMPT,
-        distilled_guidance_scale: float = DISTILLED_GUIDANCE_SCALE,
+        negative_prompt: Optional[str] = NEGATIVE_PROMPT,
         num_inference_steps: int = NUM_INFERENCE_STEPS,
         seed: Optional[int] = SEED,
     ) -> torch.Tensor:
@@ -264,6 +297,17 @@ class HunyuanImage21Pipeline:
             prompt_embeds, prompt_embeds_mask = self._encode_qwen(prompt)
             prompt_embeds_2, prompt_embeds_mask_2 = self._encode_byt5(prompt)
 
+            # Selected off the conditional glyph stream, before the negative
+            # encode — same order as the stock pipeline.
+            guider = self._select_guider(prompt_embeds_2)
+
+            # Constant across steps, so encoded once.
+            neg_embeds = neg_mask = neg_embeds_2 = neg_mask_2 = None
+            if guider._enabled and guider.num_conditions > 1:
+                neg_prompt = negative_prompt if negative_prompt is not None else ""
+                neg_embeds, neg_mask = self._encode_qwen(neg_prompt, role="uncond")
+                neg_embeds_2, neg_mask_2 = self._encode_byt5(neg_prompt)
+
             # ──────────── Latents / timesteps / guidance (CPU) ────────────
             latents_h = int(self.config.height) // VAE_SCALE_FACTOR
             latents_w = int(self.config.width) // VAE_SCALE_FACTOR
@@ -277,12 +321,6 @@ class HunyuanImage21Pipeline:
             self.scheduler.set_timesteps(sigmas=sigmas, device="cpu")
             timesteps = self.scheduler.timesteps
             self.scheduler.set_begin_index(0)
-            guidance = (
-                torch.tensor(
-                    [distilled_guidance_scale] * batch_size, dtype=torch.float32
-                )
-                * 1000.0
-            )
 
             # ─────── Transformer denoising loop (TT, bf16, sharded) ───────
             logger.info(
@@ -298,27 +336,48 @@ class HunyuanImage21Pipeline:
             for i, t in enumerate(timesteps):
                 logger.info("[STEP] transformer step {}/{}", i + 1, num_inference_steps)
                 timestep = t.expand(batch_size).to(latents.dtype)
-                # meanflow: refiner timestep = next timestep (0 on the last step).
-                if i == len(timesteps) - 1:
-                    timestep_r = torch.tensor([0.0])
-                else:
-                    timestep_r = timesteps[i + 1]
-                timestep_r = timestep_r.expand(batch_size).to(latents.dtype)
 
-                tt_inputs = [
-                    to_dev(latents),
-                    to_dev(timestep),
-                    to_dev(timestep_r),
-                    to_dev(guidance),
-                    to_dev(prompt_embeds),
-                    to_dev(prompt_embeds_mask),
-                    to_dev(prompt_embeds_2),
-                    to_dev(prompt_embeds_mask_2),
-                ]
+                guider.set_state(
+                    step=i, num_inference_steps=num_inference_steps, timestep=t
+                )
+                # Fresh APG momentum buffer per generate(); diffusers does this
+                # inside prepare_inputs(), which this pipeline does not call.
+                if i == 0 and guider.adaptive_projected_guidance_momentum is not None:
+                    guider.momentum_buffer = MomentumBuffer(
+                        guider.adaptive_projected_guidance_momentum
+                    )
+
+                def _denoise(embeds, mask, embeds_2, mask_2):
+                    # .cpu() is the sync point: forces the graph to run.
+                    return (
+                        self.transformer(
+                            to_dev(latents),
+                            to_dev(timestep),
+                            to_dev(embeds),
+                            to_dev(mask),
+                            to_dev(embeds_2),
+                            to_dev(mask_2),
+                        )
+                        .cpu()
+                        .to(torch.float32)
+                    )
+
+                # Identical shapes, so both forwards share one compiled graph.
                 t0 = time.perf_counter()
-                # .cpu() is the sync point: it forces the graph to run and only
-                # returns once the result is on host, so the timer ends there.
-                noise_pred = self.transformer(*tt_inputs).cpu().to(torch.float32)
+                pred_cond = _denoise(
+                    prompt_embeds,
+                    prompt_embeds_mask,
+                    prompt_embeds_2,
+                    prompt_embeds_mask_2,
+                )
+                if guider.num_conditions > 1:
+                    pred_uncond = _denoise(
+                        neg_embeds, neg_mask, neg_embeds_2, neg_mask_2
+                    )
+                else:
+                    pred_uncond = None
+                noise_pred = guider.forward(pred_cond, pred_uncond).pred
+                # One entry per step, covering both forwards.
                 self._perf["steps"].append(time.perf_counter() - t0)
 
                 latents = self.scheduler.step(
@@ -339,12 +398,9 @@ class HunyuanImage21Pipeline:
 
 
 def save_image(image: torch.Tensor, filepath: str = "output.png"):
-    """Rescale ([-1,1]→[0,255]), reshape and save the pipeline output as PNG."""
-    image = (
-        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
-    )
-    image_np = image.cpu().squeeze().numpy()
-    assert image_np.ndim == 3, "Image must be 3D"
-    if image_np.shape[0] == 3:
-        image_np = image_np.transpose(1, 2, 0)
-    Image.fromarray(image_np).save(filepath)
+    """Save the pipeline output (range [-1, 1], BCHW) as a PNG.
+
+    Uses the same ``VaeImageProcessor`` path as ``HunyuanImagePipeline``.
+    """
+    processor = VaeImageProcessor(vae_scale_factor=VAE_SCALE_FACTOR)
+    processor.postprocess(image, output_type="pil")[0].save(filepath)

--- a/hunyuan_image_2_1/pytorch/src/model_utils.py
+++ b/hunyuan_image_2_1/pytorch/src/model_utils.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 """
-Component loaders and wrappers for HunyuanImage 2.1 (Distilled).
+Component loaders and wrappers for HunyuanImage 2.1.
 
-Model: hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers
+Model: hunyuanvideo-community/HunyuanImage-2.1-Diffusers
 Components:
   - text_encoder:   Qwen2.5-VL-7B-Instruct encoder (8.29B)
   - text_encoder_2: ByT5 encoder                   (0.22B)
-  - transformer:    HunyuanImageTransformer2DModel (MMDiT) (17.45B)
+  - transformer:    HunyuanImageTransformer2DModel (MMDiT) (17.43B)
   - vae:            AutoencoderKLHunyuanImage      (0.41B)
 """
 
@@ -18,7 +18,7 @@ import torch
 # Model identity
 # ---------------------------------------------------------------------------
 
-REPO_ID = "hunyuanvideo-community/HunyuanImage-2.1-Distilled-Diffusers"
+REPO_ID = "hunyuanvideo-community/HunyuanImage-2.1-Diffusers"
 DTYPE = torch.float32
 
 # ---------------------------------------------------------------------------
@@ -151,7 +151,12 @@ class QwenPromptEmbedsWrapper(torch.nn.Module):
 
 
 class HunyuanImage21TransformerWrapper(torch.nn.Module):
-    """Simplify HunyuanImageTransformer2DModel forward to tensor-only inputs/outputs."""
+    """Simplify HunyuanImageTransformer2DModel forward to tensor-only inputs/outputs.
+
+    ``guidance_embeds=False`` and ``use_meanflow=False``, so ``guidance`` and
+    ``timestep_r`` are always None — passing a ``timestep_r`` tensor would fault
+    on ``time_proj_r is None``. Guidance comes from CFG instead.
+    """
 
     def __init__(self, transformer):
         super().__init__()
@@ -161,8 +166,6 @@ class HunyuanImage21TransformerWrapper(torch.nn.Module):
         self,
         hidden_states,
         timestep,
-        timestep_r,
-        guidance,
         encoder_hidden_states,
         encoder_attention_mask,
         encoder_hidden_states_2,
@@ -171,8 +174,8 @@ class HunyuanImage21TransformerWrapper(torch.nn.Module):
         return self.transformer(
             hidden_states=hidden_states,
             timestep=timestep,
-            timestep_r=timestep_r,
-            guidance=guidance,
+            timestep_r=None,
+            guidance=None,
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
             encoder_hidden_states_2=encoder_hidden_states_2,


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/5985

### Problem description

- The requirement is to support [HunyuanImage-2.1](https://huggingface.co/docs/diffusers/api/pipelines/hunyuanimage21). It ships three variants which share the same MMDiT architecture and differ in how guidance is applied:

| Variant | num_inference_steps | guidance |
| --- | --- | --- |
| HunyuanImage-2.1 | 50 | real CFG + APG, from the repo's `guider` / `ocr_guider` |
| HunyuanImage-2.1-Distilled | 8 | `distilled_guidance_scale=3.5`, embedded in the forward |
| HunyuanImage-2.1-Refiner | 4 | separate second-stage pipeline |

- The Distilled variant was added initially, as it reaches comparable output quality in far fewer steps. The current required variant is the base model, so the component loader and the e2e pipeline should both target it: guidance is no longer embedded in the transformer, so the denoising loop needs restructuring — two forwards per step with a host-side combine — not just a new checkpoint.

### What's changed

Cross-verified the architecture and the shapes/dtypes of every input to each nn component across the base and Distilled variants. Every component input shape and dtype is identical, and the `text_encoder`, `text_encoder_2` and `vae` weights are byte-identical between the two repos([shape_arch_check.zip](https://github.com/user-attachments/files/31273183/shape_arch_check.zip)). All the differences are on the transformer:

* `guidance_embeds` `true` → `false` — the base checkpoint has no distilled-guidance embedder, so `guidance` is dropped.
* `use_meanflow` `true` → `false` — no meanflow refiner timestep, so `timestep_r` is dropped. Passing a tensor here faults on `time_proj_r is None`.
* Guidance is real CFG — the transformer runs twice per step (conditional + unconditional) as two separate calls, and the predictions are combined on the host by the repo's guider. Batch size stays 1.
* Transformer params 17.453B → 17.426B; the 27,539,456 difference is exactly the two `TimestepEmbedding(256 → 3584)` blocks (`guidance_embedder`, `timestep_embedder_r`) the base checkpoint does not ship.
* Scheduler `shift` `4.0` → `5.0`.

Updated the loader accordingly: repo id, docstrings, transformer wrapper signature (8 → 6 tensor inputs) and `load_inputs`. The pipeline now loads `guider`/`ocr_guider`, encodes the negative prompt once per `generate()`, and runs the two-forward CFG loop with the combine on the host.

After this change, the e2e nightly PCC test fails with a PCC drop in transformer — tracked separately in [tt-xla#5984](https://github.com/tenstorrent/tt-xla/issues/5984).

### Checklist
- [x] Cpu parity check - [cpu_parity.zip](https://github.com/user-attachments/files/31272893/cpu_parity.zip)
- [x] PCC gated nightly test - [PCC_check.log.zip](https://github.com/user-attachments/files/31272909/aug20_hunyuan_image_2_1_pipeline_base_pcc_check_1.log.zip)
- [x] Benchmark - https://github.com/tenstorrent/tt-xla/actions/runs/32376506316
