### PR TITLE
[Mochi-1] Run the T5-XXL text encoder on TT

### DIFF
--- a/mochi/pytorch/loader.py
+++ b/mochi/pytorch/loader.py
@@ -40,6 +40,7 @@ from .src.utils import (
     load_vae_decoder_inputs,
     load_transformer_inputs,
     load_text_encoder_inputs,
+    shard_text_encoder_specs,
     shard_transformer_specs,
     shard_vae_decoder_specs,
 )
@@ -191,12 +192,8 @@ class ModelLoader(ForgeModel):
     def get_mesh_config(self, num_devices: int):
         """Return ((batch, model) mesh shape, mesh names) for the active component.
 
-        transformer and vae use the supported shapes in MESH_SHAPES.
-        text_encoder runs on a single chip.
+        Every component is sharded, so all of them use MESH_SHAPES.
         """
-        if self._subfolder == "text_encoder":
-            return (1, 1), MESH_NAMES
-
         if num_devices not in MESH_SHAPES:
             raise ValueError(
                 f"Unsupported device count: {num_devices}. "
@@ -208,14 +205,16 @@ class ModelLoader(ForgeModel):
         """Return tensor -> partition_spec dict for the active component.
 
         Expects whatever the test passes to run_graph_test:
-          transformer → MochiTransformer3DModel
-          vae         → MochiDecoder3D (vae.decoder)
-          text_encoder → None (single-chip, no sharding)
+          transformer  → MochiTransformer3DModel
+          vae          → MochiDecoder3D (vae.decoder)
+          text_encoder → T5EncoderModel
         """
         if self._subfolder == "transformer":
             return shard_transformer_specs(model)
         if self._subfolder == "vae":
             return shard_vae_decoder_specs(model)
+        if self._subfolder == "text_encoder":
+            return shard_text_encoder_specs(model)
         return None
 
     def unpack_forward_output(self, output: Any) -> torch.Tensor:

--- a/mochi/pytorch/src/pipeline.py
+++ b/mochi/pytorch/src/pipeline.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Mochi-1 preview pipeline: DiT tensor-parallel on TT, T5-XXL text encoder,
-scheduler and VAE on CPU.
+"""Mochi-1 preview pipeline: DiT (bf16) and T5-XXL text encoder (fp32) both
+tensor-parallel on TT, scheduler and VAE on CPU.
 
 Mirrors ``MochiPipeline.__call__``. guidance_scale=4.5 for this checkpoint ->
 CFG is enabled, so the DiT sees a batch-2 ``cat([uncond, cond])`` input on
@@ -37,6 +37,7 @@ from .utils import (
     load_text_encoder,
     load_transformer,
     load_vae,
+    shard_text_encoder_specs,
     shard_transformer_specs,
 )
 
@@ -54,6 +55,11 @@ FPS = 15
 GUIDANCE_SCALE = 4.5
 MAX_SEQUENCE_LENGTH = 256
 DTYPE = torch.bfloat16
+# The encoder runs fp32: in bf16 its pad rows accumulate error down the 24 blocks
+# (PCC ~0.81 on the empty negative prompt, ~0.96 on a populated one; fp32 lifts
+# that to ~0.95). Tensor-parallel sharding pays for the 2x weight memory.
+# Details: https://github.com/tenstorrent/tt-xla/issues/5995
+TEXT_ENCODER_DTYPE = torch.float32
 
 # MochiPipeline.__init__ / __call__ constants (not derivable from the configs).
 VAE_SPATIAL_SCALE_FACTOR = 8
@@ -105,6 +111,7 @@ class Mochi1Config:
         guidance_scale: float = GUIDANCE_SCALE,
         shard: bool = True,
         transformer_on_tt: bool = True,
+        text_encoder_on_tt: bool = True,
     ):
         self.num_inference_steps = num_inference_steps
         self.height = height
@@ -113,13 +120,16 @@ class Mochi1Config:
         self.guidance_scale = guidance_scale
         self.shard = shard
         self.transformer_on_tt = transformer_on_tt
+        self.text_encoder_on_tt = text_encoder_on_tt
 
 
 class Mochi1Pipeline:
-    """DiT sharded on TT; text encoder, scheduler and VAE stay on CPU."""
+    """DiT (bf16) and T5-XXL text encoder (fp32) sharded on TT; scheduler and
+    VAE stay on CPU."""
 
     def __init__(self, config: Mochi1Config):
         self.config = config
+        self.mesh = None  # set when sharded; shared by every TT component
         self.mesh_shape = None  # set when sharded; read by the benchmark harness
         self._perf = None  # per-stage/per-step timings from the last generate()
 
@@ -138,20 +148,35 @@ class Mochi1Pipeline:
         # attention.py.
         patch_static_attn_processor()
 
+        # One mesh, shared by every TT component. SPMD has to be enabled before
+        # the first device op, so this runs ahead of any .to(xla_device()).
+        if self.config.shard and (
+            self.config.transformer_on_tt or self.config.text_encoder_on_tt
+        ):
+            self._init_mesh()
+
+        # forward, not the module, so each component stays an nn.Module and
+        # callers can still wrap forward (e.g. the nightly PCC check).
+        if self.config.text_encoder_on_tt:
+            # Tensor-parallel so fp32 weights (~19 GB) fit across the mesh.
+            self.text_encoder = self._place_on_tt(
+                self.text_encoder, shard_text_encoder_specs
+            )
+            self.text_encoder.forward = torch.compile(
+                self.text_encoder.forward, backend="tt"
+            )
+
         if self.config.transformer_on_tt:
-            if self.config.shard:
-                self.shard_to_tt()
-            else:
-                self.transformer = self.transformer.to(xm.xla_device())
-            # forward, not the module, so self.transformer stays an nn.Module and
-            # callers can still wrap forward (e.g. the nightly PCC check).
+            self.transformer = self._place_on_tt(
+                self.transformer, shard_transformer_specs
+            )
             self.transformer.forward = torch.compile(
                 self.transformer.forward, backend="tt"
             )
 
     def load_models(self):
-        logger.info("[load_models] text_encoder (T5-XXL, ~4.76B) ...")
-        self.text_encoder = load_text_encoder(REPO_ID, DTYPE)
+        logger.info("[load_models] text_encoder (T5-XXL, ~4.76B, fp32) ...")
+        self.text_encoder = load_text_encoder(REPO_ID, TEXT_ENCODER_DTYPE)
         logger.info("[load_models] transformer (MochiTransformer3DModel, ~10.03B) ...")
         self.transformer = load_transformer(REPO_ID, DTYPE)
         logger.info("[load_models] vae (AutoencoderKLMochi, ~0.46B) ...")
@@ -165,7 +190,8 @@ class Mochi1Pipeline:
     def load_tokenizer(self):
         self.tokenizer = T5Tokenizer.from_pretrained(REPO_ID, subfolder="tokenizer")
 
-    def shard_to_tt(self):
+    def _init_mesh(self):
+        """Enable SPMD and build the (batch, model) mesh all components share."""
         _enable_spmd()
         num_devices = xr.global_runtime_device_count()
         if num_devices not in MESH_SHAPES:
@@ -177,9 +203,26 @@ class Mochi1Pipeline:
             np.array(range(num_devices)), MESH_SHAPES[num_devices], MESH_NAMES
         )
         self.mesh_shape = tuple(self.mesh.mesh_shape)
-        self.transformer = self.transformer.to(xm.xla_device())
-        for tensor, spec in shard_transformer_specs(self.transformer).items():
-            xs.mark_sharding(tensor, self.mesh, spec)
+        logger.info("[setup] mesh {} over {} device(s)", self.mesh_shape, num_devices)
+
+    def _place_on_tt(self, module, shard_spec_fn=None):
+        """Move a component to the device and apply its shard spec; omit
+        ``shard_spec_fn`` to run replicated across the mesh."""
+        module = module.to(xm.xla_device())
+        if self.mesh is not None and shard_spec_fn is not None:
+            specs = shard_spec_fn(module)
+            assert (
+                specs
+            ), f"{type(module).__name__} shard spec is empty — would run replicated"
+            for tensor, spec in specs.items():
+                xs.mark_sharding(tensor, self.mesh, spec)
+        return module
+
+    def _to_encoder_device(self, x):
+        return x.to(xm.xla_device()) if self.config.text_encoder_on_tt else x
+
+    def _from_encoder_device(self, x):
+        return x.to("cpu") if self.config.text_encoder_on_tt else x
 
     def _get_t5_prompt_embeds(self, prompt: list):
         """Mirrors MochiPipeline._get_t5_prompt_embeds (num_videos_per_prompt==1
@@ -194,10 +237,17 @@ class Mochi1Pipeline:
         )
         # T5 gets a bool mask, not the int mask.
         prompt_attention_mask = text_inputs.attention_mask.bool()
-        prompt_embeds = self.text_encoder(
-            text_inputs.input_ids, attention_mask=prompt_attention_mask
-        )[0]
-        return prompt_embeds.to(dtype=self.text_encoder.dtype), prompt_attention_mask
+
+        logger.info("[STAGE] text_encoder (T5-XXL, sharded, fp32)")
+        # out[0] is last_hidden_state, the only output, so no wrapper is needed.
+        # .to("cpu") is the sync point on TT.
+        prompt_embeds = self._from_encoder_device(
+            self.text_encoder(
+                self._to_encoder_device(text_inputs.input_ids),
+                self._to_encoder_device(prompt_attention_mask),
+            )[0]
+        )
+        return prompt_embeds.to(dtype=DTYPE), prompt_attention_mask
 
     def _encode_prompt(self, prompt: str, negative_prompt: Optional[str]):
         """Mirrors encode_prompt with CFG enabled (force_zeros_for_empty_prompt is
@@ -252,7 +302,7 @@ class Mochi1Pipeline:
             negative_prompt_embeds,
             negative_prompt_attention_mask,
         ) = self._encode_prompt(prompt, negative_prompt)
-        perf["components"]["text_encode"] = time.perf_counter() - t0
+        perf["components"]["text_encoder"] = time.perf_counter() - t0
 
         # Latents are sampled in fp32, then cast to the DiT dtype.
         latent_shape = (

--- a/mochi/pytorch/src/utils.py
+++ b/mochi/pytorch/src/utils.py
@@ -409,6 +409,55 @@ def shard_transformer_specs(transformer) -> dict:
     return specs
 
 
+def shard_text_encoder_specs(encoder) -> dict:
+    """Build tensor -> partition_spec dict for the T5 v1.1-XXL text encoder.
+
+    Megatron column->row per block, on the "model" axis only — same rule as
+    shard_transformer_specs. T5 projections are bias-free, so only weights are
+    sharded; embeddings, norms and the relative-attention bias stay replicated.
+
+    Column-parallel (q, k, v, wi_0, wi_1): ("model", None)
+    Row-parallel    (o, wo):               (None, "model")
+
+    Accepts either the T5EncoderModel or its inner T5Stack.
+    """
+    specs: dict = {}
+
+    if hasattr(encoder, "shared"):
+        specs[encoder.shared.weight] = (None, None)
+
+    stack = getattr(encoder, "encoder", encoder)
+    if hasattr(stack, "embed_tokens"):
+        specs[stack.embed_tokens.weight] = (None, None)
+
+    for block in stack.block:
+        sa_layer = block.layer[0]
+        sa = sa_layer.SelfAttention
+        specs[sa.q.weight] = ("model", None)
+        specs[sa.k.weight] = ("model", None)
+        specs[sa.v.weight] = ("model", None)
+        specs[sa.o.weight] = (None, "model")
+        # Only block 0 carries it; [num_buckets, heads] stays replicated.
+        if getattr(sa, "relative_attention_bias", None) is not None:
+            specs[sa.relative_attention_bias.weight] = (None, None)
+        specs[sa_layer.layer_norm.weight] = (None,)
+
+        ff_layer = block.layer[-1]
+        dense = ff_layer.DenseReluDense
+        # T5 v1.1 is gated (wi_0/wi_1); v1.0 has a single wi.
+        if hasattr(dense, "wi_0"):
+            specs[dense.wi_0.weight] = ("model", None)
+            specs[dense.wi_1.weight] = ("model", None)
+        else:
+            specs[dense.wi.weight] = ("model", None)
+        specs[dense.wo.weight] = (None, "model")
+        specs[ff_layer.layer_norm.weight] = (None,)
+
+    specs[stack.final_layer_norm.weight] = (None,)
+
+    return specs
+
+
 def shard_vae_decoder_specs(decoder) -> dict:
     """Build tensor -> partition_spec dict for MochiDecoder3D.
 


### PR DESCRIPTION
### Ticket
- https://github.com/tenstorrent/tt-xla/issues/5994
- fixes https://github.com/tenstorrent/tt-xla/issues/5995

### Problem description
- Initial bring-up enabled only the DiT on TT; the T5-XXL text encoder stayed on CPU. It can now run on TT too.

### What's changed
- Moved the T5-XXL text encoder onto TT in `Mochi1Pipeline`, tensor-parallel sharded; scheduler and VAE stay on CPU.
- Ran the encoder in **fp32** (`TEXT_ENCODER_DTYPE`) while the DiT stays bf16. In bf16 the encoder's pad rows accumulate error across its 24 blocks — PCC 0.81 on the empty negative prompt vs 0.96 on a populated one; fp32 lifts both forwards to ~0.95 (0.9494 / 0.9518). Chisel shows every op passing in isolation, so this is accumulation, not a broken op — see the ticket([#5995](https://github.com/tenstorrent/tt-xla/issues/5995)).
- Sharded the encoder so the 2x fp32 weight memory (~19 GB) splits across the mesh instead of SPMD replicating it onto every chip. Added `shard_text_encoder_specs`: Megatron column→row per T5 block (q/k/v/wi_0/wi_1 column, o/wo row) on the `"model"` axis only; embeddings, norms and the relative-attention bias stay replicated.
- Split `shard_to_tt()` into `_init_mesh()` + `_place_on_tt()`, so a single mesh is created once and shared by both TT components.
- Called the encoder positionally as `(input_ids, attention_mask)`, with the embeds returning to host and casting to the DiT dtype at the boundary. No output wrapper needed — `out[0]` is the encoder's only output.
- Added `text_encoder_on_tt` to `Mochi1Config` (mirrors `transformer_on_tt`), so the encoder can be kept on CPU without touching the pipeline.
- Wired `text_encoder` into the loader's `get_mesh_config` / `load_shard_spec`.
- Renamed the perf component key `text_encode` → `text_encoder` to match the other videogen pipelines.

### Checklist

- [x] Demo - [demo.zip](https://github.com/user-attachments/files/31361034/demo.zip)
- [x] PCC-gated Nightly test - [PCC_check.zip](https://github.com/user-attachments/files/31361038/after_fix.zip)
