### PR TITLE
[EXAONE 4.5] Pin transformers>=5.8.0 for native exaone4_5 support

### DIFF
--- a/exaone_4_5/pytorch/loader.py
+++ b/exaone_4_5/pytorch/loader.py
@@ -6,8 +6,16 @@ EXAONE 4.5 model loader implementation.
 """
 
 import torch
-from transformers import AutoTokenizer, AutoModelForMultimodalLM, AutoConfig
 from typing import Optional
+
+# NOTE: `transformers` is intentionally NOT imported at module top level.
+# EXAONE 4.5 gained native support in transformers >= 5.8.0 (see requirements.txt;
+# model_type "exaone4_5"). The Hub checkpoint has no auto_map, so
+# trust_remote_code cannot load it on older installs. The test runner upgrades
+# transformers at test time and purges it from sys.modules. A top-level import
+# would bind the Auto* classes to whatever transformers was loaded during pytest
+# collection, leaving stale class objects whose in-memory mappings omit
+# exaone4_5. So the Auto* classes are imported lazily in the methods.
 
 from ...base import ForgeModel
 from ...config import (
@@ -80,6 +88,9 @@ class ModelLoader(ForgeModel):
         Returns:
             The loaded tokenizer instance
         """
+        # Lazy import so it binds to the pinned transformers (see module note).
+        from transformers import AutoTokenizer
+
         self.tokenizer = AutoTokenizer.from_pretrained(
             self._variant_config.pretrained_model_name
         )
@@ -100,12 +111,15 @@ class ModelLoader(ForgeModel):
         Returns:
             torch.nn.Module: The EXAONE 4.5 model for causal language modeling.
         """
+        # Lazy import so it binds to the pinned transformers (see module note).
+        from transformers import AutoModelForMultimodalLM
+
         pretrained_model_name = self._variant_config.pretrained_model_name
 
         if self.tokenizer is None:
             self._load_tokenizer()
 
-        model_kwargs = {"trust_remote_code": True}
+        model_kwargs = {}
         if dtype_override is not None:
             model_kwargs["torch_dtype"] = dtype_override
         model_kwargs |= kwargs
@@ -174,6 +188,9 @@ class ModelLoader(ForgeModel):
 
     def load_config(self):
         """Load and return the configuration for the model variant."""
+        # Lazy import so it binds to the pinned transformers (see module note).
+        from transformers import AutoConfig
+
         self.config = AutoConfig.from_pretrained(
             self._variant_config.pretrained_model_name
         )

--- a/exaone_4_5/pytorch/requirements.txt
+++ b/exaone_4_5/pytorch/requirements.txt
@@ -1,0 +1,4 @@
+# Native EXAONE 4.5 (model_type "exaone4_5") landed in transformers 5.8.0.
+# The Hub checkpoint has no auto_map, so trust_remote_code cannot load it on older
+# installs (tt-xla defaults to 5.5.1).
+transformers>=5.8.0


### PR DESCRIPTION
### Ticket
- Failing tt-xla CI: https://github.com/tenstorrent/tt-xla/actions/runs/32686252171/job/97311934269
- Test: `tests/runner/test_models.py::test_all_models_torch[exaone_4_5/pytorch-EXAONE_4_5_33B-tensor_parallel-inference]`

### Problem description
tt-xla's default env is `transformers==5.5.1`. EXAONE 4.5 (`model_type: exaone4_5`) only has native support in `transformers>=5.8.0` ([HF docs](https://huggingface.co/docs/transformers/v5.8.0/model_doc/exaone4_5), [PR #45471](https://github.com/huggingface/transformers/pull/45471)).

`AutoModelForMultimodalLM.from_pretrained` / `AutoConfig.from_pretrained` therefore raise:

```
ValueError: The checkpoint you are trying to load has model type `exaone4_5` but Transformers does not recognize this architecture.
```

`trust_remote_code=True` does not help: [`LGAI-EXAONE/EXAONE-4.5-33B`](https://huggingface.co/LGAI-EXAONE/EXAONE-4.5-33B) has no `auto_map`, so there is no Hub modeling code to load.

### What's changed
- Added `exaone_4_5/pytorch/requirements.txt` pinning `transformers>=5.8.0`, so the tt-xla per-model requirements manager upgrades Transformers for this test only.
- Lazy-import `AutoTokenizer` / `AutoModelForMultimodalLM` / `AutoConfig` in `loader.py` (same pattern as HyperCLOVA X). A top-level import would keep the 5.5.1 Auto classes from pytest collection after the pin is installed.
- Dropped `trust_remote_code=True`; it cannot load this checkpoint without remote code.

logs:
ci link: https://github.com/tenstorrent/tt-xla/actions/runs/32732040834

### Checklist
- [ ] New/Existing tests provide coverage for changes

Made with [Cursor](https://cursor.com)