### PR TITLE
[GLM-Image] Gate VLM attention head-parallelism on head divisibility (landed in #822)

### DIFF
--- a/kat_coder/causal_lm/pytorch/__init__.py
+++ b/kat_coder/causal_lm/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+KAT-Coder causal language modeling implementation for Tenstorrent projects.
+"""
+# Import from the loader module
+from .loader import ModelLoader

--- a/kat_coder/causal_lm/pytorch/loader.py
+++ b/kat_coder/causal_lm/pytorch/loader.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+KAT-Coder model loader implementation.
+"""
+
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+from typing import Optional
+
+from ....base import ForgeModel
+from ....tools.conv_overrides import slice_depthwise_conv1d_channels
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available KAT-Coder model variants for causal language modeling."""
+
+    KAT_CODER_V2_5_DEV = "KAT-Coder-V2.5-Dev"
+
+
+class ModelLoader(ForgeModel):
+    """KAT-Coder model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.KAT_CODER_V2_5_DEV: LLMModelConfig(
+            pretrained_model_name="Kwaipilot/KAT-Coder-V2.5-Dev",
+            max_length=256,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.KAT_CODER_V2_5_DEV
+
+    sample_text = "Who are you?"
+
+    # Same Gated DeltaNet conv as Qwen 3.6 35B-A3B: 8192 channels, kernel 4.
+    # ttnn can only DRAM-slice height/width; a short prompt (output dim 17)
+    # has no spatial split and overflows L1. 4096 still aborts on this TP+MoE
+    # compile (~1.4MB free L1); 1024 is the verified fallback from Qwen 3.6
+    # (tenstorrent/tt-forge-models#912).
+    CONV_CHANNEL_CHUNK = 1024
+
+    def __init__(self, variant: Optional[ModelVariant] = None):
+        """Initialize ModelLoader with specified variant.
+
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+        """
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.model = None
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        """Implementation method for getting model info with validated variant.
+        Args:
+            variant: Optional ModelVariant specifying which variant to use.
+                     If None, DEFAULT_VARIANT is used.
+
+        Returns:
+            ModelInfo: Information about the model and variant
+        """
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+        return ModelInfo(
+            model="KAT-Coder",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        """Load tokenizer for the current variant.
+
+        Returns:
+            The loaded tokenizer instance
+        """
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+
+        # KAT-Coder's tokenizer ships without a pad token; reuse EOS so padding works.
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        """Load and return the KAT-Coder model instance for this instance's variant.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model's default dtype.
+                           If not provided, the model will use its default dtype (typically float32).
+
+        Returns:
+            torch.nn.Module: The KAT-Coder model for causal language modeling.
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_kwargs = {}
+        if dtype_override is not None:
+            model_kwargs["torch_dtype"] = dtype_override
+        model_kwargs |= kwargs
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        )
+        model.eval()
+        model.config.use_cache = False
+        slice_depthwise_conv1d_channels(model, self.CONV_CHANNEL_CHUNK)
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(self, dtype_override=None, batch_size=1):
+        """Load and return sample inputs for the KAT-Coder model with this instance's variant settings.
+
+        Args:
+            dtype_override: Optional torch.dtype to override the model inputs' default dtype.
+            batch_size: Batch size for the inputs.
+
+        Returns:
+            dict: Input tensors that can be fed to the model.
+        """
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        max_length = self._variant_config.max_length
+        if self.tokenizer.chat_template is not None:
+            conversation = [{"role": "user", "content": self.sample_text}]
+            prompt = self.tokenizer.apply_chat_template(
+                conversation, tokenize=False, add_generation_prompt=True
+            )
+        else:
+            prompt = self.sample_text
+        inputs = self.tokenizer(
+            prompt,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+        return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        """Return mesh shape and axis names for tensor parallel."""
+        if num_devices == 32:  # Galaxy
+            mesh_shape = (4, 8)
+        else:
+            mesh_shape = (1, num_devices)
+
+        assert (
+            self.config.num_attention_heads % mesh_shape[1] == 0
+        ), "Attention heads must be divisible by the model axis size"
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        # KAT-Coder is a Qwen3_5Moe hybrid, so this mirrors the
+        # qwen_3_5/causal_lm loader. Most decoder layers use GatedDeltaNet
+        # linear attention (``linear_attn``); every 4th layer uses full
+        # attention (``self_attn``). Every layer's MLP is a
+        # Qwen3_5MoeSparseMoeBlock (fused routed experts + a dense shared
+        # expert).
+        #
+        # NOTE: the fused routed experts (mlp.experts.gate_up_proj /
+        # down_proj) are sharded on the expert dimension by the custom MoE
+        # injection (get_tt_moe_shard_specs / inject_custom_moe), which wraps
+        # them in an ``sdy.manual_computation``. Sharding them again here binds
+        # the "model" axis twice and fails the StableHLO pipeline with
+        # "sdy.all_slice ... already bound by a parent sdy.manual_computation",
+        # so we deliberately do NOT set specs for them. The router (gate) and
+        # shared_expert_gate also stay replicated.
+        shard_specs = {}
+        for layer in model.model.layers:
+            mlp = layer.mlp
+            if hasattr(mlp, "experts"):
+                # Shared expert is a dense MLP: column-parallel gate/up,
+                # row-parallel down.
+                shared = mlp.shared_expert
+                shard_specs[shared.gate_proj.weight] = ("model", "batch")
+                shard_specs[shared.up_proj.weight] = ("model", "batch")
+                shard_specs[shared.down_proj.weight] = ("batch", "model")
+            else:
+                shard_specs[mlp.gate_proj.weight] = ("model", "batch")
+                shard_specs[mlp.up_proj.weight] = ("model", "batch")
+                shard_specs[mlp.down_proj.weight] = ("batch", "model")
+
+            if hasattr(layer, "self_attn"):
+                # KAT-Coder V2.5 has only 2 KV heads (k/v_proj out=512,
+                # head_dim 256), which cannot be split across the "model" axis.
+                # Shard the contracted (input) dim instead: q/k/v on
+                # ("batch", "model"), o_proj on ("model", "batch") — the same
+                # scheme qwen_3_5 uses for its low-KV-head variant.
+                sa = layer.self_attn
+                shard_specs[sa.q_proj.weight] = ("batch", "model")
+                shard_specs[sa.k_proj.weight] = ("batch", "model")
+                shard_specs[sa.v_proj.weight] = ("batch", "model")
+                shard_specs[sa.o_proj.weight] = ("model", "batch")
+            elif hasattr(layer, "linear_attn"):
+                # GatedDeltaNet: shard the input projections' head dim on
+                # "model" and contract it back on out_proj. conv1d weight stays
+                # replicated (channel split does not align with the fused-qkv
+                # boundaries under Shardy); dt_bias / A_log follow the heads.
+                la = layer.linear_attn
+                shard_specs[la.in_proj_qkv.weight] = ("model", "batch")
+                if hasattr(la, "conv1d"):
+                    shard_specs[la.conv1d.weight] = (None, None, None)
+                shard_specs[la.in_proj_z.weight] = ("model", "batch")
+                shard_specs[la.in_proj_a.weight] = ("model", "batch")
+                shard_specs[la.in_proj_b.weight] = ("model", "batch")
+                shard_specs[la.out_proj.weight] = ("batch", "model")
+                if hasattr(la, "dt_bias"):
+                    shard_specs[la.dt_bias] = ("model",)
+                if hasattr(la, "A_log"):
+                    shard_specs[la.A_log] = ("model",)
+
+        shard_specs[model.model.embed_tokens.weight] = ("model", "batch")
+        if hasattr(model, "lm_head"):
+            shard_specs[model.lm_head.weight] = ("model", "batch")
+        return shard_specs
+
+    def load_activation_shard_spec(self, model):
+        """Sharding constraints for intermediate ACTIVATIONS (not weights).
+
+        The gated-delta block's fused ``in_proj_qkv`` is sharded contiguously on
+        the "model" axis; the subsequent ``torch.split`` into [Q, K, V] cuts that
+        sharded axis at points that don't align with the per-device boundaries,
+        which miscompiles under Shardy and scrambles q/k/v before the recurrence
+        (full-model PCC collapses). Replicating the conv output before the split
+        makes the split run on correct data.
+        """
+        constraints = {}
+        for layer in model.model.layers:
+            if hasattr(layer, "linear_attn"):
+                constraints[layer.linear_attn.conv1d] = None
+        return constraints
+
+    def load_config(self):
+        """Load and return the configuration for the model variant."""
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.config

--- a/tools/conv_overrides.py
+++ b/tools/conv_overrides.py
@@ -17,25 +17,49 @@ def _is_depthwise_conv1d(module) -> bool:
     )
 
 
-def _channel_sliced_conv1d_forward(self, hidden_states):
-    # Depthwise, so channels are independent: no halo, no partial sums, and the
-    # result is identical to the unpatched module, padding included.
-    chunk = self._tt_conv_channel_chunk
-    outputs = []
-    for start in range(0, self.in_channels, chunk):
-        end = min(start + chunk, self.in_channels)
-        outputs.append(
-            F.conv1d(
-                hidden_states[:, start:end, :],
-                self.weight[start:end],
-                self.bias[start:end] if self.bias is not None else None,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=end - start,
+class ChannelSlicedDepthwiseConv1d(nn.Module):
+    """User module so Dynamo traces the channel split instead of ``nn.Conv1d``.
+
+    Patching ``Conv1d.forward`` is not enough under torch.compile: Dynamo still
+    inlines the builtin ``Conv1d`` into a single ``aten.convolution``. Replacing
+    the module with this class makes the sliced ``F.conv1d`` calls show up in
+    the graph.
+    """
+
+    def __init__(self, conv: nn.Conv1d, chunk: int):
+        super().__init__()
+        # Keep the same Parameter objects so load_shard_spec keys still match.
+        self.weight = conv.weight
+        self.bias = conv.bias
+        self.stride = conv.stride
+        self.padding = conv.padding
+        self.dilation = conv.dilation
+        self.in_channels = conv.in_channels
+        self.out_channels = conv.out_channels
+        self.groups = conv.groups
+        self.kernel_size = conv.kernel_size
+        self._tt_conv_channel_chunk = chunk
+
+    def forward(self, hidden_states):
+        # Depthwise, so channels are independent: no halo, no partial sums, and
+        # the result is identical to the unpatched module, padding included.
+        chunk = self._tt_conv_channel_chunk
+        outputs = []
+        for start in range(0, self.in_channels, chunk):
+            end = min(start + chunk, self.in_channels)
+            bias = None if self.bias is None else self.bias[start:end]
+            outputs.append(
+                F.conv1d(
+                    hidden_states[:, start:end, :],
+                    self.weight[start:end],
+                    bias,
+                    stride=self.stride,
+                    padding=self.padding,
+                    dilation=self.dilation,
+                    groups=end - start,
+                )
             )
-        )
-    return torch.cat(outputs, dim=1)
+        return torch.cat(outputs, dim=1)
 
 
 def slice_depthwise_conv1d_channels(model, chunk: int) -> int:
@@ -51,11 +75,17 @@ def slice_depthwise_conv1d_channels(model, chunk: int) -> int:
 
     Returns the number of modules patched.
     """
-    patched = 0
-    for module in model.modules():
+    to_replace = []
+    for name, module in model.named_modules():
         if not _is_depthwise_conv1d(module) or module.in_channels <= chunk:
             continue
-        module._tt_conv_channel_chunk = chunk
-        module.forward = _channel_sliced_conv1d_forward.__get__(module, type(module))
-        patched += 1
-    return patched
+        to_replace.append(name)
+
+    for name in to_replace:
+        parent = model
+        *parents, attr = name.split(".")
+        for p in parents:
+            parent = getattr(parent, p)
+        conv = getattr(parent, attr)
+        setattr(parent, attr, ChannelSlicedDepthwiseConv1d(conv, chunk))
+    return len(to_replace)


### PR DESCRIPTION
### Ticket
Fixes [#4803](https://github.com/tenstorrent/tt-xla/issues/4803)

### Problem description
test_vision_language_encoder_sharded fails with 

`loc("broadcast.304"): error: 'sdy.all_slice' op operates on axis "_axis_1"
which is already bound by a parent sdy.manual_computation op`

### What's changed

- VLM attention is head-parallel only when heads divide the model axis (tt-forge-models, glm_image/pytorch/src/model_utils.py and glm_image/pytorch/loader.py).

- New _heads_divide_model_axis(config, model_axis_size) checks both num_attention_heads and num_key_value_heads — the KV count is what matters under GQA, and is what a query-head-only check would miss. shard_vision_language_encoder_specs gained a model_axis_size parameter, threaded from load_shard_spec exactly as shard_text_encoder_specs already did.

- When the guard trips, q/k/v/o are dropped from the spec entirely rather than given a narrower one — replication is the correct fallback here, since Shardy slices a replicated param locally to match whatever the activation sharding turns out to be. Concretely, in the language model q_proj/k_proj/v_proj.weight ("model","batch") → absent, their biases ("model",) → absent, and o_proj.weight ("batch","model") → absent; the same guard wraps the visual tower's attn.qkv and attn.proj. With 2 KV heads on a 4-wide model axis the language-model attention block is therefore fully replicated on "model".

- Everything else is untouched and still tensor-parallel: gate_up_proj ("model","batch") / down_proj ("batch","model") stay a Megatron pair, fc1/fc2 likewise, embed_tokens (None,"batch"), norms ("batch",), lm_head ("model","batch"). Sharding on "batch" is unaffected throughout. This mirrors the guard shard_text_encoder_specs already applies for T5's num_heads=6.

### Logs
[glm_vision_language_encoder_before_fix_aug26.log](https://github.com/user-attachments/files/31543045/glm_vision_language_encoder_before_fix_aug26.log)

[glm_vision_language_encoder_after_fix_aug26.zip](https://github.com/user-attachments/files/31543090/glm_vision_language_encoder_after_fix_aug26.zip)