### PR TITLE
[pyramid_flow] Add the end-to-end text-to-video pipeline

### DIFF
--- a/pyramid_flow/pytorch/pipeline.py
+++ b/pyramid_flow/pytorch/pipeline.py
@@ -1,0 +1,466 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end Pyramid Flow (miniFLUX) text-to-video pipeline for Tenstorrent.
+
+Pyramid Flow has no diffusers integration, so upstream's runner class
+(``pyramid_dit.PyramidDiTForVideoGeneration``) is CUDA-only and drags in the
+training path. This module is the inference half of it, rebuilt on top of the
+components the loader already exposes, with each heavy net independently
+switchable onto the Tenstorrent backend:
+
+===========================  ========  ======================================
+Component                    Params    Device
+===========================  ========  ======================================
+``PyramidFluxTransformer``   1.97B     TT when ``transformer_on_tt``
+CLIP text encoder (pooled)   0.12B     TT when ``text_encoder_on_tt``
+``CausalVideoVAE`` decode    225.77M   TT when ``vae_on_tt``
+T5-XXL (``text_encoder_2``)  4.76B     host, always
+pyramid flow-matching        --        host, always
+===========================  ========  ======================================
+
+Two of those are host-side on purpose, not by omission. T5-XXL compiles and
+executes on device but lands at PCC 0.8598 against CPU, so it is not exposed as
+a runnable component and running it on device here would poison the conditioning
+of every step. The scheduler is control flow over small tensors - stage sigmas
+and an Euler update - not a net worth compiling.
+
+Scope: one temporal unit (``temp=1``, a single frame). The multi-frame path
+needs the chunked VAE decode, whose Python loop carries causal-conv state across
+temporal windows and does not trace; ``generate`` raises for ``temp > 1`` rather
+than silently running something the VAE cannot decode on device.
+
+The sampler is ported from upstream's ``generate`` / ``generate_one_unit``. It
+keeps upstream's numerics, including the ``sample_block_noise`` fix: upstream
+draws through ``MultivariateNormal`` over a 2x2 block whose covariance is
+singular at the default ``gamma = 1/3``, which makes ``torch.linalg.cholesky``
+raise on torch >= 2.2. Sampling through the symmetric square root is exact for
+the degenerate case and vectorised.
+"""
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Sequence, Union
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+
+from .src.schedulers import PyramidFlowMatchEulerDiscreteScheduler
+from .src.utils import (
+    load_clip_tokenizer,
+    load_t5_text_encoder,
+    load_t5_tokenizer,
+    load_text_encoder,
+    load_transformer,
+    load_vae_decoder,
+)
+
+# Upstream appends this to every prompt; keeping it means a prompt produces the
+# same frame here as it does upstream.
+_PROMPT_SUFFIX = ", hyper quality, Ultra HD, 8K"
+_DEFAULT_NEGATIVE_PROMPT = (
+    "cartoon style, worst quality, low quality, blurry, absolute black, "
+    "absolute white, low res, extra limbs, extra digits, misplaced objects, "
+    "mutated anatomy, monochrome, horror"
+)
+# miniFLUX (``pyramid_flux``) latent statistics. The mmdit variant uses
+# different ones; this pipeline is miniFLUX-only.
+_VAE_SHIFT_FACTOR = -0.04
+_VAE_SCALE_FACTOR = 1 / 1.8726
+# CausalVideoVAE downsamples 8x spatially.
+_DOWNSAMPLE = 8
+# T5 branch length upstream uses for miniFLUX.
+_T5_MAX_SEQUENCE_LENGTH = 128
+
+
+def _to_device(value: Any, device: torch.device) -> Any:
+    """Move a tensor, or an arbitrarily nested list/tuple of them, to ``device``."""
+    if isinstance(value, torch.Tensor):
+        return value.to(device)
+    if isinstance(value, (list, tuple)):
+        return type(value)(_to_device(v, device) for v in value)
+    return value
+
+
+def _to_cpu(value: Any, dtype: Optional[torch.dtype] = None) -> Any:
+    """Bring a tensor, or a nested list/tuple of them, back to host."""
+    if isinstance(value, torch.Tensor):
+        out = value.to("cpu")
+        return out.to(dtype) if dtype is not None else out
+    if isinstance(value, (list, tuple)):
+        return type(value)(_to_cpu(v, dtype) for v in value)
+    return value
+
+
+class _OnDevice(torch.nn.Module):
+    """Run one net on the Tenstorrent device, host tensors in and out.
+
+    The rest of the pipeline - latent creation, the RNG stream, the scheduler -
+    stays on host, so every device net is entered and left with host tensors.
+    That keeps a device run's numerics comparable to an all-host run of the same
+    seed instead of quietly moving the RNG onto another device.
+    """
+
+    def __init__(self, module: torch.nn.Module):
+        super().__init__()
+        import torch_xla.core.xla_model as xm
+
+        self.device = xm.xla_device()
+        self.module = module.to(self.device)
+        self.compiled = torch.compile(self.module, backend="tt")
+
+    def forward(self, *args, **kwargs):
+        args = _to_device(args, self.device)
+        kwargs = {k: _to_device(v, self.device) for k, v in kwargs.items()}
+        return _to_cpu(self.compiled(*args, **kwargs))
+
+
+@dataclass
+class PyramidFlowConfig:
+    """Configuration for an end-to-end Pyramid Flow run."""
+
+    # ``diffusion_transformer_384p`` renders 640x384, ``..._768p`` 1280x768.
+    variant: str = "diffusion_transformer_384p"
+    dtype: torch.dtype = torch.bfloat16
+    text_encoder_on_tt: bool = False
+    transformer_on_tt: bool = False
+    vae_on_tt: bool = False
+    # Pyramid stages and the schedule that splits sigma space between them.
+    stages: Sequence[int] = (1, 2, 4)
+    stage_range: Sequence[float] = (0.0, 1 / 3, 2 / 3, 1.0)
+    scheduler_gamma: float = 1 / 3
+    timestep_shift: float = 1.0
+
+    height: int = field(default=None)
+    width: int = field(default=None)
+
+    def __post_init__(self):
+        if self.height is None or self.width is None:
+            is_768p = "768p" in self.variant
+            self.height = 768 if is_768p else 384
+            self.width = 1280 if is_768p else 640
+
+
+class PyramidFlowPipeline:
+    """Text-to-video pipeline for Pyramid Flow miniFLUX.
+
+    Callers construct it with a :class:`PyramidFlowConfig`, call ``setup`` once
+    and drive it through ``generate``.
+    """
+
+    def __init__(self, config: Optional[PyramidFlowConfig] = None):
+        self.config = config or PyramidFlowConfig()
+        self.dtype = self.config.dtype
+        self.stages = list(self.config.stages)
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    def setup(self):
+        self.load_models()
+        self.load_tokenizers()
+        self.load_scheduler()
+
+    def load_models(self):
+        self.dit = load_transformer(self.dtype, subfolder=self.config.variant)
+        self.dit_config = self.dit.config
+        if self.config.transformer_on_tt:
+            self.dit = _OnDevice(self.dit)
+
+        # CLIP contributes the DiT's `pooled_projections`.
+        self.clip = load_text_encoder(self.dtype)
+        if self.config.text_encoder_on_tt:
+            self.clip = _OnDevice(self.clip)
+
+        # T5-XXL contributes `encoder_hidden_states`. Host-only - see the module
+        # docstring for why.
+        self.t5 = load_t5_text_encoder(self.dtype)
+
+        self.vae = load_vae_decoder(self.dtype)
+        if self.config.vae_on_tt:
+            self.vae = _OnDevice(self.vae)
+
+    def load_tokenizers(self):
+        self.clip_tokenizer = load_clip_tokenizer()
+        self.t5_tokenizer = load_t5_tokenizer()
+
+    def load_scheduler(self):
+        self.scheduler = PyramidFlowMatchEulerDiscreteScheduler(
+            shift=self.config.timestep_shift,
+            stages=len(self.stages),
+            stage_range=list(self.config.stage_range),
+            gamma=self.config.scheduler_gamma,
+        )
+
+    # ------------------------------------------------------------------
+    # Prompt encoding
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def encode_prompt(self, prompt: str):
+        """Return ``(prompt_embeds, prompt_attention_mask, pooled_prompt_embeds)``.
+
+        Mirrors upstream's ``FluxTextEncoderWithMask``: the sequence embedding
+        comes from T5 at 128 tokens, the pooled vector from CLIP's
+        ``pooler_output`` at the tokenizer's own max length.
+        """
+        clip_inputs = self.clip_tokenizer(
+            [prompt],
+            padding="max_length",
+            max_length=self.clip_tokenizer.model_max_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+        pooled_prompt_embeds = self.clip(clip_inputs.input_ids)
+        pooled_prompt_embeds = pooled_prompt_embeds.to(self.dtype)
+
+        t5_inputs = self.t5_tokenizer(
+            [prompt],
+            padding="max_length",
+            max_length=_T5_MAX_SEQUENCE_LENGTH,
+            truncation=True,
+            return_tensors="pt",
+        )
+        prompt_attention_mask = t5_inputs.attention_mask
+        prompt_embeds = self.t5(
+            t5_inputs.input_ids,
+            attention_mask=prompt_attention_mask,
+            output_hidden_states=False,
+        )[0].to(self.dtype)
+
+        return prompt_embeds, prompt_attention_mask, pooled_prompt_embeds
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+
+    def prepare_latents(self, batch_size, num_channels_latents, temp, generator):
+        shape = (
+            batch_size,
+            num_channels_latents,
+            int(temp),
+            int(self.config.height) // _DOWNSAMPLE,
+            int(self.config.width) // _DOWNSAMPLE,
+        )
+        # Draw in fp32 and cast: `torch.randn` consumes its generator
+        # differently per dtype, so a seeded bf16 draw is unrelated to the fp32
+        # draw from the same seed. Casting keeps a seed reproducible across the
+        # dtypes the pipeline can run in.
+        latents = torch.randn(shape, generator=generator, dtype=torch.float32)
+        return latents.to(self.dtype)
+
+    def sample_block_noise(self, bs, ch, temp, height, width, generator=None):
+        """Correlated noise over each 2x2 latent block, at the stage boundary.
+
+        Upstream builds a ``MultivariateNormal`` with covariance
+        ``S = (1 + gamma) I - gamma J`` over the flattened 2x2 block. Its
+        eigenvalues are ``1 - 3*gamma`` along the all-ones direction and
+        ``1 + gamma`` on the orthogonal complement, so at the default
+        ``gamma = 1/3`` the covariance is singular and the Cholesky factor
+        ``MultivariateNormal`` needs does not exist - ``torch.linalg.cholesky``
+        raises on torch >= 2.2. Sampling through the symmetric square root is
+        exact in the degenerate case, and vectorised: upstream drew one 4-vector
+        per block, which is tens of thousands of Python-level ``sample()`` calls
+        per stage transition.
+        """
+        gamma = self.scheduler.config.gamma
+        block_number = bs * ch * temp * (height // 2) * (width // 2)
+        z = torch.randn(block_number, 4, generator=generator)
+        mean = z.mean(dim=-1, keepdim=True)
+        noise = math.sqrt(max(1.0 - 3.0 * gamma, 0.0)) * mean + math.sqrt(
+            1.0 + gamma
+        ) * (z - mean)
+        return rearrange(
+            noise,
+            "(b c t h w) (p q) -> b c t (h p) (w q)",
+            b=bs,
+            c=ch,
+            t=temp,
+            h=height // 2,
+            w=width // 2,
+            p=2,
+            q=2,
+        )
+
+    @torch.no_grad()
+    def generate_one_unit(
+        self,
+        latents,
+        prompt_embeds,
+        prompt_attention_mask,
+        pooled_prompt_embeds,
+        num_inference_steps,
+        height,
+        width,
+        temp,
+        guidance_scale,
+        generator=None,
+    ):
+        """Denoise one temporal unit through every pyramid stage.
+
+        Ported from upstream ``generate_one_unit`` for the first unit, where the
+        past-condition list is empty at every stage - that is the whole of a
+        ``temp=1`` run.
+        """
+        intermed_latents = []
+
+        for i_s in range(len(self.stages)):
+            self.scheduler.set_timesteps(num_inference_steps[i_s], i_s)
+            timesteps = self.scheduler.timesteps
+
+            if i_s > 0:
+                # Enter the next stage at twice the resolution, then re-noise so
+                # the upsample does not leave a 2x2 block artifact.
+                height *= 2
+                width *= 2
+                latents = rearrange(latents, "b c t h w -> (b t) c h w")
+                latents = F.interpolate(latents, size=(height, width), mode="nearest")
+                latents = rearrange(latents, "(b t) c h w -> b c t h w", t=temp)
+
+                ori_sigma = 1 - self.scheduler.ori_start_sigmas[i_s]
+                gamma = self.scheduler.config.gamma
+                alpha = 1 / (math.sqrt(1 + (1 / gamma)) * (1 - ori_sigma) + ori_sigma)
+                beta = alpha * (1 - ori_sigma) / math.sqrt(gamma)
+
+                bs, ch, temp, height, width = latents.shape
+                noise = self.sample_block_noise(
+                    bs, ch, temp, height, width, generator=generator
+                )
+                latents = alpha * latents + beta * noise.to(self.dtype)
+
+            for t in timesteps:
+                # Classifier-free guidance: the negative and positive prompts
+                # are batched together, so one forward covers both.
+                latent_model_input = torch.cat([latents] * 2)
+                timestep = t.expand(latent_model_input.shape[0]).to(
+                    latent_model_input.dtype
+                )
+
+                noise_pred = self.dit(
+                    sample=[[latent_model_input]],
+                    timestep_ratio=timestep,
+                    encoder_hidden_states=prompt_embeds,
+                    encoder_attention_mask=prompt_attention_mask,
+                    pooled_projections=pooled_prompt_embeds,
+                )[0]
+
+                noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                noise_pred = noise_pred_uncond + guidance_scale * (
+                    noise_pred_text - noise_pred_uncond
+                )
+
+                latents = self.scheduler.step(
+                    model_output=noise_pred,
+                    timestep=timestep,
+                    sample=latents,
+                    generator=generator,
+                ).prev_sample
+
+            intermed_latents.append(latents)
+
+        return intermed_latents
+
+    @torch.no_grad()
+    def generate(
+        self,
+        prompt: str,
+        negative_prompt: Optional[str] = None,
+        temp: int = 1,
+        num_inference_steps: Union[int, List[int]] = 8,
+        guidance_scale: float = 7.0,
+        seed: Optional[int] = None,
+        output_type: str = "pil",
+    ):
+        """Generate frames from a text prompt.
+
+        Returns a list of PIL images, or the raw latent when
+        ``output_type="latent"``.
+        """
+        if temp != 1:
+            raise NotImplementedError(
+                "temp > 1 needs the chunked VAE decode, whose Python loop carries "
+                "causal-conv state across temporal windows and does not trace. "
+                "This pipeline covers the single-frame path."
+            )
+
+        if isinstance(num_inference_steps, int):
+            num_inference_steps = [num_inference_steps] * len(self.stages)
+        if negative_prompt is None:
+            negative_prompt = _DEFAULT_NEGATIVE_PROMPT
+
+        generator = None
+        if seed is not None:
+            generator = torch.Generator().manual_seed(seed)
+
+        pos = self.encode_prompt(prompt + _PROMPT_SUFFIX)
+        neg = self.encode_prompt(negative_prompt)
+        # [negative, positive] along the batch dimension, matching the order the
+        # guidance chunk() above unpacks.
+        prompt_embeds = torch.cat([neg[0], pos[0]], dim=0)
+        prompt_attention_mask = torch.cat([neg[1], pos[1]], dim=0)
+        pooled_prompt_embeds = torch.cat([neg[2], pos[2]], dim=0)
+
+        # miniFLUX's DiT reports 64 in_channels over a hard-coded 2x2 internal
+        # patch, so the latent carries 16.
+        num_channels_latents = self.dit_config.in_channels // 4
+        latents = self.prepare_latents(1, num_channels_latents, temp, generator)
+
+        temp, height, width = latents.shape[-3], latents.shape[-2], latents.shape[-1]
+
+        # The pyramid starts at the coarsest stage, so walk the initial noise
+        # down to it. The x2 keeps the noise scale after each bilinear halving.
+        latents = rearrange(latents, "b c t h w -> (b t) c h w")
+        for _ in range(len(self.stages) - 1):
+            height //= 2
+            width //= 2
+            latents = F.interpolate(latents, size=(height, width), mode="bilinear") * 2
+        latents = rearrange(latents, "(b t) c h w -> b c t h w", t=temp)
+
+        intermed_latents = self.generate_one_unit(
+            latents[:, :, :1],
+            prompt_embeds,
+            prompt_attention_mask,
+            pooled_prompt_embeds,
+            num_inference_steps,
+            height,
+            width,
+            1,
+            guidance_scale,
+            generator,
+        )
+        generated_latents = intermed_latents[-1]
+
+        if output_type == "latent":
+            return generated_latents
+        return self.decode_latent(generated_latents)
+
+    # ------------------------------------------------------------------
+    # Decode
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def decode_latent(self, latents: torch.Tensor):
+        """Decode a single-frame latent to PIL frames.
+
+        Upstream's ``decode_latent`` un-normalises with the image statistics
+        when ``latents.shape[2] == 1`` and calls the chunked decode; at one frame
+        that chunked call degenerates to the single-shot decode this wrapper
+        makes (measured bit-exact), so the two agree here.
+        """
+        from PIL import Image
+
+        latents = (latents / _VAE_SCALE_FACTOR) + _VAE_SHIFT_FACTOR
+        image = self.vae(latents.to(self.dtype))
+        image = image.float().mul(127.5).add(127.5).clamp(0, 255).byte()
+        image = rearrange(image, "b c t h w -> (b t) h w c").cpu().numpy()
+        return [Image.fromarray(frame) for frame in image]
+
+
+def save_video(frames, output_path: str, fps: int = 24):
+    """Write PIL frames to ``output_path`` as an mp4."""
+    from diffusers.utils import export_to_video
+
+    export_to_video(frames, output_path, fps=fps)
+    return output_path

--- a/pyramid_flow/pytorch/src/schedulers/__init__.py
+++ b/pyramid_flow/pytorch/src/schedulers/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .scheduling_flow_matching import PyramidFlowMatchEulerDiscreteScheduler
+
+__all__ = ["PyramidFlowMatchEulerDiscreteScheduler"]

--- a/pyramid_flow/pytorch/src/schedulers/scheduling_flow_matching.py
+++ b/pyramid_flow/pytorch/src/schedulers/scheduling_flow_matching.py
@@ -1,0 +1,335 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Vendored from upstream Pyramid Flow
+# (https://github.com/jy0205/Pyramid-Flow,
+#  diffusion_schedulers/scheduling_flow_matching.py) because the model has no
+# diffusers integration, on the same terms as `src/flux_modules/` and
+# `src/video_vae/`: upstream code, an SPDX header, and the repo's black
+# formatting. Only the scheduler is taken; the cosine-DDPM scheduler next to it
+# upstream is unused by the miniFLUX inference path.
+#
+# The pyramid flow-matching schedule is what makes the sampler pyramid-shaped:
+# `set_timesteps(steps, stage_index)` returns the sigmas for one pyramid stage,
+# and `step` is a plain Euler update within that stage. It stays on CPU - it is
+# control flow over small tensors, not a net.
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union, List
+import math
+import numpy as np
+import torch
+
+from diffusers.configuration_utils import ConfigMixin, register_to_config
+from diffusers.utils import BaseOutput, logging
+from diffusers.utils.torch_utils import randn_tensor
+from diffusers.schedulers.scheduling_utils import SchedulerMixin
+
+
+@dataclass
+class FlowMatchEulerDiscreteSchedulerOutput(BaseOutput):
+    """
+    Output class for the scheduler's `step` function output.
+
+    Args:
+        prev_sample (`torch.FloatTensor` of shape `(batch_size, num_channels, height, width)` for images):
+            Computed sample `(x_{t-1})` of previous timestep. `prev_sample` should be used as next model input in the
+            denoising loop.
+    """
+
+    prev_sample: torch.FloatTensor
+
+
+class PyramidFlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin):
+    """
+    Euler scheduler.
+
+    This model inherits from [`SchedulerMixin`] and [`ConfigMixin`]. Check the superclass documentation for the generic
+    methods the library implements for all schedulers such as loading and saving.
+
+    Args:
+        num_train_timesteps (`int`, defaults to 1000):
+            The number of diffusion steps to train the model.
+        timestep_spacing (`str`, defaults to `"linspace"`):
+            The way the timesteps should be scaled. Refer to Table 2 of the [Common Diffusion Noise Schedules and
+            Sample Steps are Flawed](https://huggingface.co/papers/2305.08891) for more information.
+        shift (`float`, defaults to 1.0):
+            The shift value for the timestep schedule.
+    """
+
+    _compatibles = []
+    order = 1
+
+    @register_to_config
+    def __init__(
+        self,
+        num_train_timesteps: int = 1000,
+        shift: float = 1.0,  # Following Stable diffusion 3,
+        stages: int = 3,
+        stage_range: List = [0, 1 / 3, 2 / 3, 1],
+        gamma: float = 1 / 3,
+    ):
+
+        self.timestep_ratios = {}  # The timestep ratio for each stage
+        self.timesteps_per_stage = {}  # The  detailed timesteps per stage
+        self.sigmas_per_stage = {}
+        self.start_sigmas = {}
+        self.end_sigmas = {}
+        self.ori_start_sigmas = {}
+
+        # self.init_sigmas()
+        self.init_sigmas_for_each_stage()
+        self.sigma_min = self.sigmas[-1].item()
+        self.sigma_max = self.sigmas[0].item()
+        self.gamma = gamma
+
+    def init_sigmas(self):
+        """
+        initialize the global timesteps and sigmas
+        """
+        num_train_timesteps = self.config.num_train_timesteps
+        shift = self.config.shift
+
+        timesteps = np.linspace(
+            1, num_train_timesteps, num_train_timesteps, dtype=np.float32
+        )[::-1].copy()
+        timesteps = torch.from_numpy(timesteps).to(dtype=torch.float32)
+
+        sigmas = timesteps / num_train_timesteps
+        sigmas = shift * sigmas / (1 + (shift - 1) * sigmas)
+
+        self.timesteps = sigmas * num_train_timesteps
+
+        self._step_index = None
+        self._begin_index = None
+
+        self.sigmas = sigmas.to("cpu")  # to avoid too much CPU/GPU communication
+
+    def init_sigmas_for_each_stage(self):
+        """
+        Init the timesteps for each stage
+        """
+        self.init_sigmas()
+
+        stage_distance = []
+        stages = self.config.stages
+        training_steps = self.config.num_train_timesteps
+        stage_range = self.config.stage_range
+
+        # Init the start and end point of each stage
+        for i_s in range(stages):
+            # To decide the start and ends point
+            start_indice = int(stage_range[i_s] * training_steps)
+            start_indice = max(start_indice, 0)
+            end_indice = int(stage_range[i_s + 1] * training_steps)
+            end_indice = min(end_indice, training_steps)
+            start_sigma = self.sigmas[start_indice].item()
+            end_sigma = (
+                self.sigmas[end_indice].item() if end_indice < training_steps else 0.0
+            )
+            self.ori_start_sigmas[i_s] = start_sigma
+
+            if i_s != 0:
+                ori_sigma = 1 - start_sigma
+                gamma = self.config.gamma
+                corrected_sigma = (
+                    1 / (math.sqrt(1 + (1 / gamma)) * (1 - ori_sigma) + ori_sigma)
+                ) * ori_sigma
+                # corrected_sigma = 1 / (2 - ori_sigma) * ori_sigma
+                start_sigma = 1 - corrected_sigma
+
+            stage_distance.append(start_sigma - end_sigma)
+            self.start_sigmas[i_s] = start_sigma
+            self.end_sigmas[i_s] = end_sigma
+
+        # Determine the ratio of each stage according to flow length
+        tot_distance = sum(stage_distance)
+        for i_s in range(stages):
+            if i_s == 0:
+                start_ratio = 0.0
+            else:
+                start_ratio = sum(stage_distance[:i_s]) / tot_distance
+            if i_s == stages - 1:
+                end_ratio = 1.0
+            else:
+                end_ratio = sum(stage_distance[: i_s + 1]) / tot_distance
+
+            self.timestep_ratios[i_s] = (start_ratio, end_ratio)
+
+        # Determine the timesteps and sigmas for each stage
+        for i_s in range(stages):
+            timestep_ratio = self.timestep_ratios[i_s]
+            timestep_max = self.timesteps[int(timestep_ratio[0] * training_steps)]
+            timestep_min = self.timesteps[
+                min(int(timestep_ratio[1] * training_steps), training_steps - 1)
+            ]
+            timesteps = np.linspace(
+                timestep_max,
+                timestep_min,
+                training_steps + 1,
+            )
+            self.timesteps_per_stage[i_s] = (
+                timesteps[:-1]
+                if isinstance(timesteps, torch.Tensor)
+                else torch.from_numpy(timesteps[:-1])
+            )
+            stage_sigmas = np.linspace(
+                1,
+                0,
+                training_steps + 1,
+            )
+            self.sigmas_per_stage[i_s] = torch.from_numpy(stage_sigmas[:-1])
+
+    @property
+    def step_index(self):
+        """
+        The index counter for current timestep. It will increase 1 after each scheduler step.
+        """
+        return self._step_index
+
+    @property
+    def begin_index(self):
+        """
+        The index for the first timestep. It should be set from pipeline with `set_begin_index` method.
+        """
+        return self._begin_index
+
+    # Copied from diffusers.schedulers.scheduling_dpmsolver_multistep.DPMSolverMultistepScheduler.set_begin_index
+    def set_begin_index(self, begin_index: int = 0):
+        """
+        Sets the begin index for the scheduler. This function should be run from pipeline before the inference.
+
+        Args:
+            begin_index (`int`):
+                The begin index for the scheduler.
+        """
+        self._begin_index = begin_index
+
+    def _sigma_to_t(self, sigma):
+        return sigma * self.config.num_train_timesteps
+
+    def set_timesteps(
+        self,
+        num_inference_steps: int,
+        stage_index: int,
+        device: Union[str, torch.device] = None,
+    ):
+        """
+        Setting the timesteps and sigmas for each stage
+        """
+        self.num_inference_steps = num_inference_steps
+        training_steps = self.config.num_train_timesteps
+        self.init_sigmas()
+
+        stage_timesteps = self.timesteps_per_stage[stage_index]
+        timestep_max = stage_timesteps[0].item()
+        timestep_min = stage_timesteps[-1].item()
+
+        timesteps = np.linspace(
+            timestep_max,
+            timestep_min,
+            num_inference_steps,
+        )
+        self.timesteps = torch.from_numpy(timesteps).to(device=device)
+
+        stage_sigmas = self.sigmas_per_stage[stage_index]
+        sigma_max = stage_sigmas[0].item()
+        sigma_min = stage_sigmas[-1].item()
+
+        ratios = np.linspace(sigma_max, sigma_min, num_inference_steps)
+        sigmas = torch.from_numpy(ratios).to(device=device)
+        self.sigmas = torch.cat([sigmas, torch.zeros(1, device=sigmas.device)])
+
+        self._step_index = None
+
+    def index_for_timestep(self, timestep, schedule_timesteps=None):
+        if schedule_timesteps is None:
+            schedule_timesteps = self.timesteps
+
+        indices = (schedule_timesteps == timestep).nonzero()
+
+        # The sigma index that is taken for the **very** first `step`
+        # is always the second index (or the last index if there is only 1)
+        # This way we can ensure we don't accidentally skip a sigma in
+        # case we start in the middle of the denoising schedule (e.g. for image-to-image)
+        pos = 1 if len(indices) > 1 else 0
+
+        return indices[pos].item()
+
+    def _init_step_index(self, timestep):
+        if self.begin_index is None:
+            if isinstance(timestep, torch.Tensor):
+                timestep = timestep.to(self.timesteps.device)
+            self._step_index = self.index_for_timestep(timestep)
+        else:
+            self._step_index = self._begin_index
+
+    def step(
+        self,
+        model_output: torch.FloatTensor,
+        timestep: Union[float, torch.FloatTensor],
+        sample: torch.FloatTensor,
+        generator: Optional[torch.Generator] = None,
+        return_dict: bool = True,
+    ) -> Union[FlowMatchEulerDiscreteSchedulerOutput, Tuple]:
+        """
+        Predict the sample from the previous timestep by reversing the SDE. This function propagates the diffusion
+        process from the learned model outputs (most often the predicted noise).
+
+        Args:
+            model_output (`torch.FloatTensor`):
+                The direct output from learned diffusion model.
+            timestep (`float`):
+                The current discrete timestep in the diffusion chain.
+            sample (`torch.FloatTensor`):
+                A current instance of a sample created by the diffusion process.
+            generator (`torch.Generator`, *optional*):
+                A random number generator.
+            return_dict (`bool`):
+                Whether or not to return a [`~schedulers.scheduling_euler_discrete.EulerDiscreteSchedulerOutput`] or
+                tuple.
+
+        Returns:
+            [`~schedulers.scheduling_euler_discrete.EulerDiscreteSchedulerOutput`] or `tuple`:
+                If return_dict is `True`, [`~schedulers.scheduling_euler_discrete.EulerDiscreteSchedulerOutput`] is
+                returned, otherwise a tuple is returned where the first element is the sample tensor.
+        """
+
+        if (
+            isinstance(timestep, int)
+            or isinstance(timestep, torch.IntTensor)
+            or isinstance(timestep, torch.LongTensor)
+        ):
+            raise ValueError(
+                (
+                    "Passing integer indices (e.g. from `enumerate(timesteps)`) as timesteps to"
+                    " `EulerDiscreteScheduler.step()` is not supported. Make sure to pass"
+                    " one of the `scheduler.timesteps` as a timestep."
+                ),
+            )
+
+        if self.step_index is None:
+            self._step_index = 0
+
+        # Upcast to avoid precision issues when computing prev_sample
+        sample = sample.to(torch.float32)
+
+        sigma = self.sigmas[self.step_index]
+        sigma_next = self.sigmas[self.step_index + 1]
+
+        prev_sample = sample + (sigma_next - sigma) * model_output
+
+        # Cast sample back to model compatible dtype
+        prev_sample = prev_sample.to(model_output.dtype)
+
+        # upon completion increase step index by one
+        self._step_index += 1
+
+        if not return_dict:
+            return (prev_sample,)
+
+        return FlowMatchEulerDiscreteSchedulerOutput(prev_sample=prev_sample)
+
+    def __len__(self):
+        return self.config.num_train_timesteps

--- a/pyramid_flow/pytorch/src/utils.py
+++ b/pyramid_flow/pytorch/src/utils.py
@@ -4,12 +4,11 @@
 
 """Utility functions for Pyramid Flow model loading."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import torch
 
 from .flux_modules import PyramidFluxTransformer
-
 
 # HuggingFace repo carrying the real Pyramid Flow miniFLUX weights (ungated).
 _HF_REPO = "rain1011/pyramid-flow-miniflux"
@@ -21,6 +20,12 @@ _DIT_SUBFOLDER = "diffusion_transformer_768p"
 # exposed here - see `load_text_encoder` for why.
 _CLIP_SUBFOLDER = "text_encoder"
 _CLIP_TOKENIZER_SUBFOLDER = "tokenizer"
+# The T5-XXL half (`text_encoder_2` / `tokenizer_2`). It produces the DiT's
+# `encoder_hidden_states`, so the end-to-end pipeline cannot skip it - but it is
+# not exposed as a runnable component (PCC 0.86 on device), so the pipeline runs
+# it on host. See `load_t5_text_encoder`.
+_T5_SUBFOLDER = "text_encoder_2"
+_T5_TOKENIZER_SUBFOLDER = "tokenizer_2"
 # The CausalVideoVAE that decodes miniFLUX latents back to pixels.
 _VAE_SUBFOLDER = "causal_video_vae"
 
@@ -108,7 +113,9 @@ _SMOKE_BATCH = 1
 # ============================================================================
 
 
-def load_transformer(dtype: torch.dtype) -> PyramidFluxTransformer:
+def load_transformer(
+    dtype: torch.dtype, subfolder: Optional[str] = None
+) -> PyramidFluxTransformer:
     """
     Load the real Pyramid Flow miniFLUX DiT with pretrained weights.
 
@@ -120,7 +127,7 @@ def load_transformer(dtype: torch.dtype) -> PyramidFluxTransformer:
     try:
         model = PyramidFluxTransformer.from_pretrained(
             _HF_REPO,
-            subfolder=_DIT_SUBFOLDER,
+            subfolder=subfolder or _DIT_SUBFOLDER,
             torch_dtype=dtype,
         )
     except Exception:
@@ -168,6 +175,43 @@ def load_text_encoder(dtype: torch.dtype) -> ClipTextEncoderWrapper:
     except Exception:
         model = CLIPTextModel(CLIPTextConfig(**CLIP_CONFIG)).to(dtype=dtype)
     return ClipTextEncoderWrapper(model.eval()).eval()
+
+
+def load_t5_text_encoder(dtype: torch.dtype):
+    """
+    Load the T5-XXL half of the miniFLUX text stack (`text_encoder_2`, 4.76B).
+
+    Unlike the other loaders here this one is not backing a runnable component:
+    T5-XXL compiles and executes on device but lands at PCC 0.8598 against CPU,
+    so it is not exposed as a `ModelVariant` and the end-to-end pipeline runs it
+    on host. It is loaded here anyway because the DiT's `encoder_hidden_states`
+    come from it - there is no pipeline without it.
+
+    No random-init fallback: an untrained T5 would produce embeddings that make
+    an end-to-end run meaningless, so a download failure should fail loudly.
+    """
+    from transformers import T5EncoderModel
+
+    model = T5EncoderModel.from_pretrained(
+        _HF_REPO,
+        subfolder=_T5_SUBFOLDER,
+        torch_dtype=dtype,
+    )
+    return model.eval()
+
+
+def load_clip_tokenizer():
+    """Load the CLIP tokenizer (77 tokens, pooled-embedding branch)."""
+    from transformers import CLIPTokenizer
+
+    return CLIPTokenizer.from_pretrained(_HF_REPO, subfolder=_CLIP_TOKENIZER_SUBFOLDER)
+
+
+def load_t5_tokenizer():
+    """Load the T5 tokenizer (the DiT's `encoder_hidden_states` branch)."""
+    from transformers import T5TokenizerFast
+
+    return T5TokenizerFast.from_pretrained(_HF_REPO, subfolder=_T5_TOKENIZER_SUBFOLDER)
 
 
 class CausalVaeDecoderWrapper(torch.nn.Module):


### PR DESCRIPTION
### Ticket

Companion to tenstorrent/tt-xla#6012 (the nightly CI wiring). Stacked on #900 (`CausalVideoVAE` decode on TT), which it needs for `vae_on_tt`. Part of tt-xla#4447.

Jira: TEN-1066.

### Problem description

Pyramid Flow's components are all brought up individually - the 1.97B `PyramidFluxTransformer` DiT and the CLIP text encoder in #841, the `CausalVideoVAE` decode in #900 - but there is nothing that runs them together. Every test drives one net on synthetic inputs, so no end-to-end run of the model exists in this repo and none can exist in tt-xla: the thing that would drive them, upstream's `PyramidDiTForVideoGeneration`, is CUDA-only, carries the training path, and lives in a repo we do not vendor.

The consequence is not just a missing benchmark number. The host-device handoffs between the three nets - the dtype at each boundary, the sampler's per-stage reshape and re-noise, the latent the VAE is handed - are exactly where an end-to-end run fails while every component test still passes, and nothing exercises them.

### What's changed

`pyramid_flow/pytorch/pipeline.py` - the inference half of upstream's runner, rebuilt on the loader's own components, with each heavy net independently switchable onto the device:

| Component | Params | Device |
|---|---:|---|
| `PyramidFluxTransformer` DiT | 1.97B | TT when `transformer_on_tt` |
| CLIP text encoder (pooled) | 0.12B | TT when `text_encoder_on_tt` |
| `CausalVideoVAE` decode | 225.77M | TT when `vae_on_tt` |
| T5-XXL (`text_encoder_2`) | 4.76B | host, always |
| pyramid flow-matching sampler | - | host, always |

Two are host-side on purpose. T5-XXL produces the DiT's `encoder_hidden_states`, so the pipeline cannot skip it - but it reaches only PCC 0.8598 on device, so running it there would poison the conditioning of every step; it stays on host and stays unexposed as a component. The scheduler is control flow over small tensors, not a net.

`src/schedulers/scheduling_flow_matching.py` - the pyramid flow-matching scheduler, vendored on the same terms as `src/flux_modules/` and `src/video_vae/`: upstream code, SPDX header, black formatting, and only the one scheduler (upstream's cosine-DDPM scheduler is unused on this path). It carries one fix: upstream's `sample_block_noise` draws through `MultivariateNormal` over a 2x2 block whose covariance `(1 + gamma) I - gamma J` is **singular** at the default `gamma = 1/3`, so the Cholesky factor it needs does not exist and `torch.linalg.cholesky` raises on torch >= 2.2. Sampling through the symmetric square root is exact in the degenerate case and vectorised - upstream drew one 4-vector per block, tens of thousands of Python-level `sample()` calls per stage transition.

`src/utils.py` - additive: a host-only T5-XXL loader (no random-init fallback, unlike the other loaders here: an untrained T5 makes an end-to-end run meaningless, so a download failure should fail loudly), the two tokenizer helpers, and a `subfolder` argument on `load_transformer` so the pipeline can load the 384p DiT. Existing behaviour is unchanged when the argument is omitted.

The device wrapper keeps host tensors on both sides of every compiled net, so latent creation, the RNG stream and the scheduler stay on host and a device run stays comparable to an all-host run of the same seed.

### Verification

Single Wormhole **n150**, `ARCH_NAME=wormhole_b0`, bf16, `diffusion_transformer_384p`, `temp=1`, 4 steps per pyramid stage (12 DiT forwards), seed 12345, upstream's default negative prompt. The same driver runs both legs; only the `*_on_tt` flags differ, so the pair isolates where the nets ran.

**End to end, host golden vs DiT + VAE on TT.** Latents dumped from both legs and compared exactly rather than by eye:

| Tensor | PCC | MAE | max abs diff | golden max abs |
|---|---:|---:|---:|---:|
| final latent `(1, 16, 1, 48, 80)` | **0.983202** | 0.168899 | 2.843750 | 5.093750 |

Read that as what it is: **accumulated** drift over 12 bf16 DiT forwards and a bf16 decode, not one net's error. It is not a component PCC and is not claimed against the 0.99 component gate - the gated numbers are the per-component ones (#900's decode is 0.999956). It is consistent with the 0.9258 single-chip latent PCC measured earlier on this model through upstream's own script at higher step counts. Both frames render the same scene and composition; the device frame is lower in contrast and fine detail.

**Wall clock**, same run:

| Leg | setup | sample (12 steps) | decode | total |
|---|---:|---:|---:|---:|
| all host | 4.2 s | 24.7 s | 6.0 s | 30.7 s |
| DiT + VAE on TT | 5.1 s | 402.1 s | 108.8 s | 511.0 s |

Device is slower here and it is worth being precise about why, because it is a follow-up rather than a mystery. The run compiles **13 graphs**: three during sampling, at 31 s / 133 s / 220 s - exactly one per pyramid stage, which is the minimum, since the latent shape changes at every stage - and **ten** inside the single VAE decode. The decode of a 48x80 latent to 640x384 therefore breaks into ten subgraphs, where the 32x32 -> 256x256 decode #900 measures is one. Sampling is then ~33 s per DiT step with no recompilation, so the remaining cost is execution plus per-execution buffer traffic (1171 `BufferFromHostBuffer` calls across the run), not tracing.

**Port sanity.** A host-only run at 1 step per stage produced a recognisable frame rather than noise, which is the cheapest check that the ported pyramid schedule - stage sigmas, the nearest-neighbour upsample between stages, and the block re-noise - is assembled correctly.

### Out of scope

- **One temporal unit (`temp=1`, a single frame).** `generate` raises for `temp > 1` rather than silently running a path the device VAE cannot decode: the multi-frame decode walks temporal windows in a Python loop carrying causal-conv state, which does not trace. This is the same `T=1` boundary #900 validated the decode at.
- Single device. The tensor-parallel DiT path is separate work.
- No new `ModelVariant`: this adds a pipeline, not a component. The runner ids are unchanged.

### Checklist

- [x] New/Existing tests provide coverage for changes
