### PR TITLE
Model Bringup Qwen_3_8-27B

### DIFF
--- a/qwen_3_8/causal_lm/pytorch/__init__.py
+++ b/qwen_3_8/causal_lm/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.8 causal language modeling PyTorch model implementation for Tenstorrent projects.
+"""
+
+from .loader import ModelLoader, ModelVariant

--- a/qwen_3_8/causal_lm/pytorch/loader.py
+++ b/qwen_3_8/causal_lm/pytorch/loader.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.8 model loader implementation for causal language modeling.
+"""
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Qwen 3.8 dense model variants for causal language modeling."""
+
+    QWEN_3_8_27B = "27B"
+
+
+class ModelLoader(ForgeModel):
+    """Qwen 3.8 model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.QWEN_3_8_27B: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3.8-27B",
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.QWEN_3_8_27B
+
+    sample_text = "Give me a short introduction to large language model."
+
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.num_layers = num_layers
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="Qwen 3.8",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_kwargs = {}
+
+        if self.num_layers is not None:
+            # Qwen 3.8 keeps the decoder depth in the nested text_config; setting
+            # it on the outer config is ignored (the model still builds all 64
+            # layers). Set text_config and keep layer_types consistent so the
+            # hybrid linear/full pattern still includes a full_attention layer.
+            config = AutoConfig.from_pretrained(pretrained_model_name)
+            text_cfg = getattr(config, "text_config", config)
+            text_cfg.num_hidden_layers = self.num_layers
+            if getattr(text_cfg, "layer_types", None) is not None:
+                text_cfg.layer_types = text_cfg.layer_types[: self.num_layers]
+            model_kwargs["config"] = config
+
+        model_kwargs |= kwargs
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        ).eval()
+
+        # Force use_cache=False so the forward output is logits only. With the
+        # checkpoint default (use_cache=True) it also carries a DynamicCache,
+        # which the runner's pytree comparator can't diff leaf-wise against the
+        # CPU golden. Set after load rather than via from_pretrained kwargs so
+        # it wins regardless of what the caller passed in **kwargs.
+        model.config.use_cache = False
+
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(
+        self, dtype_override=None, prompt: Optional[str] = None, batch_size=1
+    ):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        max_length = self._variant_config.max_length
+
+        messages = [{"role": "user", "content": prompt or self.sample_text}]
+        text = self.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        prompts = [text]
+
+        inputs = self.tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+
+        return inputs
+
+    def load_config(self):
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.config
+
+    def get_mesh_config(self, num_devices: int):
+        mesh_shape = (1, num_devices)
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+
+        for layer in model.model.layers:
+            # Dense layer (27B): plain gate/up/down MLP. Column-parallel
+            # gate/up, row-parallel down.
+            mlp = layer.mlp
+            shard_specs[mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[mlp.down_proj.weight] = ("batch", "model")
+
+            if hasattr(layer, "self_attn"):
+                sa = layer.self_attn
+                shard_specs[sa.q_proj.weight] = ("batch", "model")
+                shard_specs[sa.k_proj.weight] = ("batch", "model")
+                shard_specs[sa.v_proj.weight] = ("batch", "model")
+                shard_specs[sa.o_proj.weight] = ("model", "batch")
+
+            elif hasattr(layer, "linear_attn"):
+                la = layer.linear_attn
+                shard_specs[la.in_proj_qkv.weight] = ("model", "batch")
+                if hasattr(la, "conv1d"):
+                    shard_specs[la.conv1d.weight] = (None, None, None)
+                shard_specs[la.in_proj_z.weight] = ("model", "batch")
+                shard_specs[la.in_proj_a.weight] = ("model", "batch")
+                shard_specs[la.in_proj_b.weight] = ("model", "batch")
+                shard_specs[la.out_proj.weight] = ("batch", "model")
+                if hasattr(la, "dt_bias"):
+                    shard_specs[la.dt_bias] = ("model",)
+                if hasattr(la, "A_log"):
+                    shard_specs[la.A_log] = ("model",)
+
+        shard_specs[model.model.embed_tokens.weight] = ("model", "batch")
+        if hasattr(model, "lm_head"):
+            shard_specs[model.lm_head.weight] = ("model", "batch")
+
+        return shard_specs
+
+    def load_activation_shard_spec(self, model):
+        """Sharding constraints for intermediate ACTIVATIONS (not weights).
+
+        The gated-delta block's fused ``in_proj_qkv`` is sharded contiguously on
+        the "model" axis; the subsequent ``torch.split`` into [Q, K, V] cuts that
+        sharded axis at points that don't align with the per-device boundaries,
+        which miscompiles under Shardy and scrambles q/k/v before the recurrence
+        (full-model PCC collapses). Replicating the conv output before the split
+        makes the split run on correct data.
+        """
+        constraints = {}
+        for layer in model.model.layers:
+            if layer.layer_type == "linear_attention":
+                constraints[layer.linear_attn.conv1d] = None
+        return constraints

--- a/qwen_3_8/multimodal/pytorch/__init__.py
+++ b/qwen_3_8/multimodal/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.8 multimodal PyTorch model implementation for Tenstorrent projects.
+"""
+
+from .loader import ModelLoader, ModelVariant

--- a/qwen_3_8/multimodal/pytorch/loader.py
+++ b/qwen_3_8/multimodal/pytorch/loader.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.8 vision-language (image + text -> text) model loader.
+
+Loads the Qwen 3.8 VLM (vision encoder + hybrid Gated DeltaNet / full-attention
+text decoder) via AutoModelForImageTextToText for image-conditioned generation.
+
+Qwen 3.8 reuses the Qwen 3.5 architecture verbatim: the checkpoint ships
+``model_type: "qwen3_5"`` and ``Qwen3_5ForConditionalGeneration``, so the stock
+transformers ``qwen3_5`` implementation loads it and the Qwen 3.5 shard map
+applies unchanged. The 27B vision tower is depth 27, hidden 1152, patch 16,
+projecting to the 5120-wide text decoder.
+"""
+from transformers import AutoModelForImageTextToText, AutoProcessor, AutoConfig
+from typing import Optional
+
+from ....base import ForgeModel
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....tools.utils import cast_input_to_type
+
+
+class ModelVariant(StrEnum):
+    """Available Qwen 3.8 multimodal model variants."""
+
+    QWEN_3_8_27B = "Qwen/Qwen3.8-27B"
+
+
+class ModelLoader(ForgeModel):
+    """Qwen 3.8 VLM loader (image + text → text) for n300, llmbox, and galaxy."""
+
+    _VARIANTS = {
+        ModelVariant.QWEN_3_8_27B: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.QWEN_3_8_27B),
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.QWEN_3_8_27B
+
+    sample_text = "What animal is on the candy?"
+    sample_image_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/p-blog/candy.JPG"
+
+    min_pixels = 56 * 56
+    max_pixels = 14 * 28 * 1280
+
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
+        """
+        Args:
+            variant: Which Qwen 3.5 variant to load.
+            num_layers: If set, truncate the text decoder to this many layers.
+        """
+        super().__init__(variant)
+        self.processor = None
+        self.config = None
+        self.num_layers = num_layers
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="Qwen 3.8",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.MM_CONDITIONAL_GENERATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_processor(self, dtype_override=None):
+        kwargs = {
+            "min_pixels": self.min_pixels,
+            "max_pixels": self.max_pixels,
+        }
+        if dtype_override is not None:
+            kwargs["torch_dtype"] = dtype_override
+        self.processor = AutoProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name, **kwargs
+        )
+        return self.processor
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        """Load the full Qwen 3.8 VLM (vision encoder + hybrid text decoder).
+
+        AutoModelForImageTextToText resolves to Qwen3_5ForConditionalGeneration
+        for the dense 27B (the checkpoint declares the qwen3_5 architecture).
+
+        Args:
+            dtype_override: torch.dtype forwarded to the processor. The model
+                itself loads in the checkpoint dtype (bfloat16 per config).
+
+        Returns:
+            torch.nn.Module in eval mode with use_cache=False.
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.processor is None:
+            self._load_processor(dtype_override)
+
+        model_kwargs = {}
+
+        if self.num_layers is not None:
+            # Qwen 3.8 keeps the decoder depth in the nested text_config; setting
+            # it on the outer VLM config is ignored (the model still builds all 64
+            # layers). Set text_config and keep layer_types consistent so the
+            # hybrid linear/full pattern still includes a full_attention layer.
+            config = AutoConfig.from_pretrained(pretrained_model_name)
+            text_cfg = getattr(config, "text_config", config)
+            text_cfg.num_hidden_layers = self.num_layers
+            if getattr(text_cfg, "layer_types", None) is not None:
+                text_cfg.layer_types = text_cfg.layer_types[: self.num_layers]
+            model_kwargs["config"] = config
+
+        model_kwargs |= kwargs
+
+        model = AutoModelForImageTextToText.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        ).eval()
+
+        # Force use_cache=False so the forward output is logits only. With the
+        # checkpoint default (use_cache=True) it also carries a DynamicCache,
+        # which the runner's pytree comparator can't diff leaf-wise against the
+        # CPU golden. Set it on both the outer VLM config and the nested
+        # text_config (the language_model reads text_config), after load so it
+        # wins regardless of what the caller passed in **kwargs.
+        model.config.use_cache = False
+        if getattr(model.config, "text_config", None) is not None:
+            model.config.text_config.use_cache = False
+
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(
+        self,
+        dtype_override=None,
+        batch_size=1,
+        prompt: Optional[str] = None,
+        image_url: Optional[str] = None,
+    ):
+        """Build a multimodal (image + text) input dict via the Qwen 3.8 processor.
+
+        Args:
+            dtype_override: If given, cast pixel_values to this dtype.
+            batch_size: Only batch_size=1 supported; pixel_values shapes are image-specific.
+            prompt: Override the default sample text prompt.
+            image_url: Override the default sample image URL.
+
+        Returns:
+            dict with input_ids, attention_mask, pixel_values, image_grid_thw.
+        """
+        if self.processor is None:
+            self._load_processor(dtype_override)
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "url": image_url or self.sample_image_url},
+                    {"type": "text", "text": prompt or self.sample_text},
+                ],
+            }
+        ]
+
+        inputs = self.processor.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+
+        if dtype_override is not None and "pixel_values" in inputs:
+            inputs["pixel_values"] = cast_input_to_type(
+                inputs["pixel_values"], dtype_override
+            )
+
+        return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        mesh_shape = (1, num_devices)
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        """Tensor-parallel shard specifications for the full VLM."""
+        shard_specs = {}
+
+        for block in model.model.visual.blocks:
+            # Megatron-style: fused qkv is column-parallel (shard output / heads),
+            # proj is row-parallel (shard input / heads -> all-reduce after).
+            shard_specs[block.attn.qkv.weight] = ("model", "batch")
+            if block.attn.qkv.bias is not None:
+                shard_specs[block.attn.qkv.bias] = ("model",)
+            shard_specs[block.attn.proj.weight] = ("batch", "model")
+
+            shard_specs[block.mlp.linear_fc1.weight] = ("model", None)
+            if block.mlp.linear_fc1.bias is not None:
+                shard_specs[block.mlp.linear_fc1.bias] = ("model",)
+            shard_specs[block.mlp.linear_fc2.weight] = (None, "model")
+
+        merger = model.model.visual.merger
+        shard_specs[merger.linear_fc1.weight] = ("model", "batch")
+        if merger.linear_fc1.bias is not None:
+            shard_specs[merger.linear_fc1.bias] = ("model",)
+        shard_specs[merger.linear_fc2.weight] = ("batch", "model")
+
+        for layer in model.model.language_model.layers:
+            # Dense layer (27B): plain gate/up/down MLP. Column-parallel
+            # gate/up, row-parallel down.
+            mlp = layer.mlp
+            shard_specs[mlp.gate_proj.weight] = ("model", "batch")
+            shard_specs[mlp.up_proj.weight] = ("model", "batch")
+            shard_specs[mlp.down_proj.weight] = ("batch", "model")
+
+            if layer.layer_type == "full_attention":
+                shard_specs[layer.self_attn.q_proj.weight] = ("batch", "model")
+                shard_specs[layer.self_attn.k_proj.weight] = ("batch", "model")
+                shard_specs[layer.self_attn.v_proj.weight] = ("batch", "model")
+                shard_specs[layer.self_attn.o_proj.weight] = ("model", "batch")
+
+            elif layer.layer_type == "linear_attention":
+                shard_specs[layer.linear_attn.in_proj_qkv.weight] = ("model", "batch")
+                shard_specs[layer.linear_attn.in_proj_z.weight] = ("model", "batch")
+                shard_specs[layer.linear_attn.in_proj_b.weight] = ("model", "batch")
+                shard_specs[layer.linear_attn.in_proj_a.weight] = ("model", "batch")
+                shard_specs[layer.linear_attn.out_proj.weight] = ("batch", "model")
+
+                shard_specs[layer.linear_attn.conv1d.weight] = (None, None, None)
+                shard_specs[layer.linear_attn.dt_bias] = ("model",)
+                shard_specs[layer.linear_attn.A_log] = ("model",)
+
+        shard_specs[model.lm_head.weight] = ("model", "batch")
+
+        return shard_specs
+
+    def load_activation_shard_spec(self, model):
+        """Sharding constraints for intermediate ACTIVATIONS.
+
+        The gated-delta block's fused ``in_proj_qkv`` is sharded contiguously on
+        the "model" axis; the subsequent ``torch.split`` into [Q, K, V] cuts that
+        sharded axis at points that don't align with the per-device boundaries,
+        which miscompiles under Shardy and scrambles q/k/v before the recurrence
+        (full-model PCC collapses). Replicating the conv output before the split
+        makes the split run on correct data.
+        """
+        constraints = {}
+        for layer in model.model.language_model.layers:
+            if layer.layer_type == "linear_attention":
+                constraints[layer.linear_attn.conv1d] = None
+        return constraints
+
+    def load_config(self):
+        """Return the top-level Qwen3_5Config (VLM; Qwen 3.8 reuses this class).
+
+        Sub-configs: config.text_config, config.vision_config
+        """
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.config


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5962)

### Problem description
Model bringup for Qwen_3_8-27B

### What's changed
Added loader file for Qwen_3_8-27B causal_lm and multimodal
Model is passing with 0.99 pcc for causal_lm and 0.87 pcc for multimodal

### Logs
[qwen_3_8_27B_mm.log](https://github.com/user-attachments/files/31547673/qwen_3_8_27B_mm.log)
[qwen3_8_27B.log](https://github.com/user-attachments/files/31547679/qwen3_8_27B.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
