### PR TITLE
[Krea Realtime Video] Vendor prompt_clean instead of importing it from a non-existent cached module path

### DIFF
--- a/krea_realtime_video/pytorch/pipeline.py
+++ b/krea_realtime_video/pytorch/pipeline.py
@@ -42,6 +42,7 @@ from .src.model_utils import (
     load_text_encoder,
     load_transformer,
     load_vae,
+    prompt_clean,
     shard_transformer_specs,
 )
 from .src.modified_model import apply_krea_static_patches
@@ -125,10 +126,7 @@ class KreaRealtimePipeline:
             WAN_REPO_ID, subfolder="tokenizer"
         )
         self.video_processor = VideoProcessor(vae_scale_factor=VAE_SCALE_FACTOR)
-        enc_mod = importlib.import_module(
-            type(self.transformer).__module__.rsplit(".", 1)[0] + ".encoders"
-        )
-        self._prompt_clean = enc_mod.prompt_clean
+        self._prompt_clean = prompt_clean
 
         self._num_heads = self.transformer.config.num_heads
         self._head_dim = self.transformer.config.dim // self._num_heads

--- a/krea_realtime_video/pytorch/src/model_utils.py
+++ b/krea_realtime_video/pytorch/src/model_utils.py
@@ -11,6 +11,10 @@ Components:
   - vae:          AutoencoderKLWan (3D causal VAE)
 """
 
+import html
+import re
+
+import ftfy
 import torch
 
 # ---------------------------------------------------------------------------
@@ -48,6 +52,32 @@ KV_CACHE_SIZE = LOCAL_ATTN_SIZE * FRAME_SEQ_LENGTH  # 9360
 
 # UMT5 vocabulary size (Embedding(256384, 4096) from model architecture)
 UMT5_VOCAB_SIZE = 256384
+
+# ---------------------------------------------------------------------------
+# Prompt text cleaning
+# ---------------------------------------------------------------------------
+#
+# Vendored from krea/krea-realtime-video's encoders.py. The upstream pipeline
+# code resolves this via importlib against the diffusers dynamic-module cache
+# path for the *transformer* (trust_remote_code) subfolder, but encoders.py
+# lives at the repo root, one level above that subfolder, so diffusers never
+# mirrors it there and the importlib lookup always fails. Vendoring the
+# (6-line) helper directly avoids guessing a cached-module path that does not
+# exist.
+
+
+def basic_clean(text):
+    text = ftfy.fix_text(text)
+    return html.unescape(html.unescape(text)).strip()
+
+
+def whitespace_clean(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def prompt_clean(text):
+    return whitespace_clean(basic_clean(text))
+
 
 # ---------------------------------------------------------------------------
 # Component loaders


### PR DESCRIPTION
## Problem

`KreaRealtimePipeline.setup()` resolves `prompt_clean` via:

```python
enc_mod = importlib.import_module(
    type(self.transformer).__module__.rsplit(".", 1)[0] + ".encoders"
)
self._prompt_clean = enc_mod.prompt_clean
```

`type(self.transformer).__module__` resolves to diffusers' dynamic-module cache
path for the `transformer/` subfolder (loaded via `trust_remote_code=True`,
`subfolder="transformer"`). `encoders.py` lives at the **repo root** of
`krea/krea-realtime-video`, one level above `transformer/` — diffusers' subfolder-scoped
dynamic-module cache never mirrors root-level files when only a subfolder is
requested, so this `importlib.import_module` call fails deterministically, every
run, with:

```
ModuleNotFoundError: No module named 'diffusers_modules.local.krea--krea-realtime-video.<hash>.encoders'
```

This is 100% reproducible — verified by fetching the HF repo tree directly and
confirming the `transformer/` subfolder only contains `__init__.py`,
`attention.py`, `causal_model.py`, `config.json`, weights, and `model.py`, with
no `encoders.py`.

## Fix

`prompt_clean` (and its two helpers) is a trivial ~6-line text-cleaning function
(`ftfy.fix_text` + `html.unescape` + whitespace collapse). Vendor it directly
into `krea_realtime_video/pytorch/src/model_utils.py` and import it normally,
removing the fragile `importlib` path-guessing entirely.

## CI verification

Dispatched `manual-test-single.yml` on `tenstorrent/tt-xla` `main`
(reusing pre-built artifacts, `forge_models_override` pointed at this branch's head
`e0ad2aabc80057febeedce47473d6e1115416039`) against
`tests/examples/test_examples.py::test_script_examples[pytorch/krea_realtime_video.py]`
on `qb2-blackhole`: https://github.com/tenstorrent/tt-xla/actions/runs/33360960593

That OOM is a separate DRAM-capacity problem (tracked in tt-xla's bisection notes as
`device-dram-oom`), not something this PR's fix is meant to address. This PR is correct
and necessary but not sufficient on its own to get this test to a full PASS.

## Test plan

- [x] `python -m py_compile` on both changed files
- [x] Standalone unit check of `prompt_clean("  hello   world\n\n  ") == "hello world"`
- [x] tt-xla CI: confirmed the `ModuleNotFoundError` no longer occurs (see CI verification above); a separate DRAM-OOM issue remains before this test can fully pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)