### PR TITLE
[imagegen] One pipeline per model for demo/PCC/benchmark; staged models report staging and warm repeats

### DIFF
--- a/diffusiongemma/pytorch/pipeline.py
+++ b/diffusiongemma/pytorch/pipeline.py
@@ -319,6 +319,10 @@ class DiffusionGemmaPipeline:
     encoder/decoder on TT and returns the decoded text.
     """
 
+    # Staged: each component is evicted before the next is placed, so a repeat call
+    # rebuilds. Cold and warm both come from the single call, before eviction.
+    benchmark_staged_residency = True
+
     def __init__(self, config: DiffusionGemmaConfig = None):
         self.config = config or DiffusionGemmaConfig()
         self.loader = None

--- a/diffusiongemma/pytorch/pipeline.py
+++ b/diffusiongemma/pytorch/pipeline.py
@@ -21,6 +21,7 @@ import gc
 import math
 import os
 import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import numpy as np
@@ -329,6 +330,18 @@ class DiffusionGemmaPipeline:
         self.cpu_model = None
         self.mesh = None
         self.xla = None
+        # Host<->device weight movement and graph teardown. Untimed it would land
+        # in cpu_overhead_s, which is what made set 2 incomparable in the first
+        # place; benchmarks read this as _perf["staging"].
+        self.staging_s = 0.0
+
+    @contextmanager
+    def _staging(self):
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.staging_s += time.perf_counter() - t0
 
     def setup(self):
         enable_spmd()
@@ -376,11 +389,12 @@ class DiffusionGemmaPipeline:
 
         def encoder_forward(**kw):
             # Free the previous block's decoder (if any) so only one model is resident.
-            if stage["dec_tt"] is not None:
-                stage["dec_tt"] = stage["dec_model"] = None
-                free_tt_graphs()
-            enc_model = self._load_sharded(ModelVariant.ENCODER)
-            enc_tt = torch.compile(TTEncoder(enc_model), backend="tt")
+            with self._staging():
+                if stage["dec_tt"] is not None:
+                    stage["dec_tt"] = stage["dec_model"] = None
+                    free_tt_graphs()
+                enc_model = self._load_sharded(ModelVariant.ENCODER)
+                enc_tt = torch.compile(TTEncoder(enc_model), backend="tt")
             pkv = DynamicCache()
             enc_args = (
                 to_device(kw["input_ids"], xla),
@@ -409,9 +423,10 @@ class DiffusionGemmaPipeline:
                 del warm_lhs
 
             # Cache to host + FREE the encoder; the decoder loads lazily in decoder_forward.
-            tt_pkv["host"] = cache_to_device(pkv, "cpu")
-            del enc_tt, enc_model, pkv
-            free_tt_graphs()
+            with self._staging():
+                tt_pkv["host"] = cache_to_device(pkv, "cpu")
+                del enc_tt, enc_model, pkv
+                free_tt_graphs()
             return SimpleNamespace(
                 last_hidden_state=lhs_host, past_key_values=tt_pkv["host"]
             )
@@ -420,11 +435,16 @@ class DiffusionGemmaPipeline:
             # First decode step: encoder is freed, so load the decoder now (vocab-shard
             # lm_head/embed so decoder + logits fit) and restore the KV cache from host.
             if stage["dec_tt"] is None:
-                dec_model = self._load_sharded(ModelVariant.DIFFUSIONGEMMA_26B_A4B_IT)
-                xs.mark_sharding(dec_model.lm_head.weight, self.mesh, ("model", None))
-                stage["dec_model"] = dec_model
-                stage["dec_tt"] = torch.compile(TTDecoder(dec_model), backend="tt")
-                tt_pkv["pkv"] = cache_to_device(tt_pkv["host"], xla)
+                with self._staging():
+                    dec_model = self._load_sharded(
+                        ModelVariant.DIFFUSIONGEMMA_26B_A4B_IT
+                    )
+                    xs.mark_sharding(
+                        dec_model.lm_head.weight, self.mesh, ("model", None)
+                    )
+                    stage["dec_model"] = dec_model
+                    stage["dec_tt"] = torch.compile(TTDecoder(dec_model), backend="tt")
+                    tt_pkv["pkv"] = cache_to_device(tt_pkv["host"], xla)
                 stage["step"] = 0
             # Consistent self-conditioning (zeros + mask=False on step 1) -> one TT graph.
             bs, canvas = kw["decoder_input_ids"].shape

--- a/diffusiongemma/pytorch/pipeline.py
+++ b/diffusiongemma/pytorch/pipeline.py
@@ -316,7 +316,7 @@ class DiffusionGemmaConfig:
         self.max_new_tokens = max_new_tokens
         self.seed = seed
         # EXTRA in-residency prefills, to get a warm encoder number before the
-        # encoder is freed. 0 = inert. Same meaning as flux2/qwen_image.
+        # encoder is freed. 0 = inert.
         self.warm_iters = warm_iters
 
 
@@ -354,8 +354,8 @@ class DiffusionGemmaPipeline:
             "total": None,
             "cold": {},
             "warm": {},
-            # Host<->device weight movement and graph teardown. Untimed it would
-            # land in cpu_overhead_s, which is what made set 2 incomparable.
+            # Host<->device weight movement and graph teardown; untimed it would
+            # land in cpu_overhead_s, which is meant to be host bookkeeping.
             "staging": 0.0,
             # Seconds burned in discarded in-residency warm repeats.
             "synthetic": 0.0,

--- a/diffusiongemma/pytorch/pipeline.py
+++ b/diffusiongemma/pytorch/pipeline.py
@@ -307,9 +307,17 @@ def manual_generate(
 
 
 class DiffusionGemmaConfig:
-    def __init__(self, max_new_tokens: int = MAX_NEW_TOKENS, seed: int = SEED):
+    def __init__(
+        self,
+        max_new_tokens: int = MAX_NEW_TOKENS,
+        seed: int = SEED,
+        warm_iters: int = 0,
+    ):
         self.max_new_tokens = max_new_tokens
         self.seed = seed
+        # EXTRA in-residency prefills, to get a warm encoder number before the
+        # encoder is freed. 0 = inert. Same meaning as flux2/qwen_image.
+        self.warm_iters = warm_iters
 
 
 class DiffusionGemmaPipeline:
@@ -318,6 +326,10 @@ class DiffusionGemmaPipeline:
     ``setup()`` enables SPMD, re-registers tt_moe (against the caller's swapped-in transformers),
     loads the host driver model, and builds the device mesh. ``generate()`` runs the staged
     encoder/decoder on TT and returns the decoded text.
+
+    One pipeline serves the demo, the PCC-gated e2e test and the benchmark. The e2e test
+    subclasses it and overrides ``_check``; the benchmark reads ``_perf``. Neither
+    reimplements the staged residency, so neither can drift from what ships.
     """
 
     # Staged: each component is evicted before the next is placed, so a repeat call
@@ -330,10 +342,24 @@ class DiffusionGemmaPipeline:
         self.cpu_model = None
         self.mesh = None
         self.xla = None
-        # Host<->device weight movement and graph teardown. Untimed it would land
-        # in cpu_overhead_s, which is what made set 2 incomparable in the first
-        # place; benchmarks read this as _perf["staging"].
-        self.staging_s = 0.0
+        self.last_new_tokens = 0
+        self._reset_perf()
+
+    def _reset_perf(self):
+        """The schema tests/benchmark/utils.staged_perf_measurements() consumes."""
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "decode_step",
+            "total": None,
+            "cold": {},
+            "warm": {},
+            # Host<->device weight movement and graph teardown. Untimed it would
+            # land in cpu_overhead_s, which is what made set 2 incomparable.
+            "staging": 0.0,
+            # Seconds burned in discarded in-residency warm repeats.
+            "synthetic": 0.0,
+        }
 
     @contextmanager
     def _staging(self):
@@ -341,7 +367,12 @@ class DiffusionGemmaPipeline:
         try:
             yield
         finally:
-            self.staging_s += time.perf_counter() - t0
+            self._perf["staging"] += time.perf_counter() - t0
+
+    def _check(self, name, tt_out, golden_fn):
+        """PCC seam. A no-op here; the nightly e2e test overrides it and calls
+        ``golden_fn()`` for the CPU twin's output. Kept lazy so the shipped
+        pipeline never pays for a CPU forward of a 26B model."""
 
     def setup(self):
         enable_spmd()
@@ -369,15 +400,16 @@ class DiffusionGemmaPipeline:
             xs.mark_sharding(tensor, self.mesh, spec)
         return model
 
-    def _staged_forwards(self, vocab_size, encoder_iters=1, encoder_times=None):
+    def _staged_forwards(self, vocab_size):
         """Build the drive-with-TT encoder/decoder forwards; one component resident at a time.
 
-        ``encoder_iters`` > 1 repeats the prefill inside the residency, timing each into
-        ``encoder_times``: this forward frees the encoder, so repeating it would rebuild.
+        Timers exclude the ``_staging()`` windows, so a stage's seconds are counted once:
+        weight movement in ``_perf["staging"]``, compute in ``components``/``steps``.
         """
         from transformers import DynamicCache  # 5.12.0, after the caller's swap
 
         xla = self.xla
+        perf = self._perf
         tt_pkv = {
             "host": None,
             "pkv": None,
@@ -402,25 +434,31 @@ class DiffusionGemmaPipeline:
                 to_device(kw["position_ids"], xla),
             )
             mm_tokens = to_device(kw.get("mm_token_type_ids"), xla)
-            # Iter 1 is the real prefill and carries the build; .to("cpu") forces the sync
+            # COLD: the real prefill, carrying the build. .to("cpu") forces the sync
             # (XLA is async, so a bare timer would measure tracing).
-            iter_start = time.perf_counter()
+            t0 = time.perf_counter()
             lhs = enc_tt(*enc_args, pkv, mm_tokens)
             xm.mark_step()
             lhs_host = lhs.to("cpu")
-            if encoder_times is not None:
-                encoder_times.append(time.perf_counter() - iter_start)
+            cold = time.perf_counter() - t0
+            perf["components"]["encoder"] = cold
+            perf["cold"]["encoder"] = cold
 
-            # Warm iters reuse the resident graph. Fresh DynamicCache each (prefill mutates
+            self._check("encoder", lhs_host, lambda: self.cpu_model.model.encoder(**kw))
+
+            # WARM: reuse the resident graph. Fresh DynamicCache each (prefill mutates
             # it); outputs discarded, so generation is unchanged.
-            for extra in range(1, max(1, encoder_iters)):
-                iter_start = time.perf_counter()
+            warm = []
+            for _ in range(max(0, self.config.warm_iters)):
+                t0 = time.perf_counter()
                 warm_lhs = enc_tt(*enc_args, DynamicCache(), mm_tokens)
                 xm.mark_step()
                 warm_lhs.to("cpu")
-                if encoder_times is not None:
-                    encoder_times.append(time.perf_counter() - iter_start)
+                warm.append(time.perf_counter() - t0)
                 del warm_lhs
+            if warm:
+                perf["warm"]["encoder"] = sum(warm) / len(warm)
+                perf["synthetic"] += sum(warm)
 
             # Cache to host + FREE the encoder; the decoder loads lazily in decoder_forward.
             with self._staging():
@@ -445,7 +483,8 @@ class DiffusionGemmaPipeline:
                     stage["dec_model"] = dec_model
                     stage["dec_tt"] = torch.compile(TTDecoder(dec_model), backend="tt")
                     tt_pkv["pkv"] = cache_to_device(tt_pkv["host"], xla)
-                stage["step"] = 0
+            # Timed from here: the load above is staging, not step time.
+            t0 = time.perf_counter()
             # Consistent self-conditioning (zeros + mask=False on step 1) -> one TT graph.
             bs, canvas = kw["decoder_input_ids"].shape
             if kw.get("self_conditioning_logits") is None:
@@ -455,7 +494,6 @@ class DiffusionGemmaPipeline:
                 scm = torch.zeros(bs, dtype=torch.bool)
             else:
                 scm = torch.ones(bs, dtype=torch.bool)
-            stage["step"] = stage.get("step", 0) + 1
             logits = stage["dec_tt"](
                 to_device(kw["decoder_input_ids"], xla),
                 to_device(kw["decoder_position_ids"], xla),
@@ -465,6 +503,12 @@ class DiffusionGemmaPipeline:
                 tt_pkv["pkv"],
             )
             out = logits.to("cpu")  # forces sync
+            perf["steps"].append(time.perf_counter() - t0)
+
+            # dict merge, not **kw + kwarg: _denoising_step owns kw and may already
+            # carry self_conditioning_mask, which would be a duplicate-kwarg TypeError.
+            golden_kw = {**kw, "self_conditioning_mask": scm}
+            self._check("decoder", out, lambda: self.cpu_model.forward(**golden_kw))
             return SimpleNamespace(logits=out)  # drive with the TT output
 
         return encoder_forward, decoder_forward
@@ -475,6 +519,7 @@ class DiffusionGemmaPipeline:
         """Generate text with both encoder and decoder on TT (staged); return decoded output."""
         max_new_tokens = max_new_tokens or self.config.max_new_tokens
         seed = self.config.seed if seed is None else seed
+        self._reset_perf()
 
         inputs = self.loader.load_inputs(dtype_override=torch.bfloat16, prompt=prompt)
         # generate()'s extra inputs (e.g. mm_token_type_ids), minus decoder_input_ids.
@@ -487,6 +532,9 @@ class DiffusionGemmaPipeline:
         encoder_forward, decoder_forward = self._staged_forwards(vocab_size)
 
         torch.manual_seed(seed)
+        # _perf["total"] covers exactly the staged run, so it reconciles against
+        # the component/step/staging/synthetic terms; input prep and decode sit outside.
+        t0 = time.perf_counter()
         output = manual_generate(
             self.cpu_model,
             input_ids=inputs["input_ids"],
@@ -496,4 +544,6 @@ class DiffusionGemmaPipeline:
             decoder_forward=decoder_forward,
             **extra_kwargs,
         )
+        self._perf["total"] = time.perf_counter() - t0
+        self.last_new_tokens = int(output.shape[-1] - inputs["input_ids"].shape[-1])
         return self.loader.processor.decode(output[0], skip_special_tokens=True)

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -230,6 +230,12 @@ class FluxTTPipeline:
     # generate() therefore rebuilds, so the harness must skip its outer warmup.
     benchmark_staged_residency = True
 
+    # Substitution seams for the plain-callable wrappers. generate()
+    # instantiates these attributes rather than the classes directly, so the
+    # PCC e2e can swap in checking subclasses without copying generate().
+    DENOISER_CLS = _DeviceDenoiser
+    VAE_CLS = _DeviceVAEDecoder
+
     def setup(self):
         # Enables SPMD + shardy annotations; required so the StableHLO handed to
         # tt-mlir carries the @Sharding custom calls the presharded args need.
@@ -264,6 +270,11 @@ class FluxTTPipeline:
         compiled graph, so a later call rebuilds rather than reusing it.
         """
         wrapper = wrapper_cls(module).eval()
+        # Hook while the wrapper is still on HOST. The PCC e2e computes its golden
+        # here so the check costs no second copy of the encoder -- placing first
+        # and loading a twin later would double this component's peak, which
+        # matters because the staging exists to keep peak at max(component).
+        self._pre_place(name, wrapper, input_ids)
         module = module.to(dev)
         compiled = self._intercept(name, torch.compile(wrapper, backend="tt"))
         t0 = time.perf_counter()
@@ -288,6 +299,13 @@ class FluxTTPipeline:
         module = module.to("cpu")
         del compiled, wrapper
         return module, out, dt
+
+    def _pre_place(self, name, wrapper, input_ids):
+        """Hook called with the wrapper still on host, before device placement.
+
+        No-op by default. See _encode for why the PCC path needs it.
+        """
+        return None
 
     def _intercept(self, name, compiled):
         """Hook applied to each component's COMPILED callable. Identity by default.
@@ -355,10 +373,10 @@ class FluxTTPipeline:
             "[STAGE] transformer (sharded) + vae: start ({} steps)",
             num_inference_steps,
         )
-        self.pipe.transformer = _DeviceDenoiser(
+        self.pipe.transformer = self.DENOISER_CLS(
             self._raw_transformer, self.mesh, self._perf
         )
-        vae_wrapper = _DeviceVAEDecoder(
+        vae_wrapper = self.VAE_CLS(
             self._raw_vae, self._perf, warm_iters=self.config.warm_iters
         )
         self.pipe.vae = vae_wrapper

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -219,6 +219,27 @@ class FluxConfig:
         self.compile_options = compile_options or {}
 
 
+def _pin_execution_device_to_cpu(pipe) -> None:
+    """Force ``pipe._execution_device`` to CPU, idempotently.
+
+    Swaps in a per-instance subclass overriding the property, so the stock
+    pipeline keeps allocating its host-side tensors on CPU exactly as it did
+    when the encoders were evicted. Cheap and reversible; no diffusers patch.
+    """
+    if getattr(type(pipe), "_tt_cpu_exec_device", False):
+        return
+    base = type(pipe)
+    pinned = type(
+        f"{base.__name__}CpuExecDevice",
+        (base,),
+        {
+            "_execution_device": property(lambda self: torch.device("cpu")),
+            "_tt_cpu_exec_device": True,
+        },
+    )
+    pipe.__class__ = pinned
+
+
 class FluxTTPipeline:
     """FluxPipeline with every module on TT, transformer tensor-parallel sharded.
 
@@ -401,6 +422,22 @@ class FluxTTPipeline:
             self._raw_vae, self._perf, warm_iters=self.config.warm_iters
         )
         self.pipe.vae = vae_wrapper
+
+        # Pin the pipeline's execution device to CPU.
+        #
+        # diffusers derives _execution_device from DiffusionPipeline.device, which
+        # returns the device of the FIRST non-CPU nn.Module component
+        # (pipeline_utils.py:614). The shipped path moved both text encoders back
+        # to CPU, and _DeviceDenoiser/_DeviceVAEDecoder are plain classes rather
+        # than nn.Modules, so nothing was left on device and it reported CPU.
+        # Keeping the encoders resident makes it report the XLA device instead,
+        # and FluxPipeline.__call__ uses it to allocate latents, timesteps,
+        # guidance and image ids -- silently moving all of them onto the device
+        # and changing the numerics (measured: the VAE decode output shifted by
+        # up to 1.562e-02, and the PCC e2e's CPU twin died on an XLA tensor).
+        # Residency is a memory decision; it must not change where the host-side
+        # bookkeeping tensors live.
+        _pin_execution_device_to_cpu(self.pipe)
 
         generator = torch.Generator().manual_seed(seed) if seed is not None else None
         self.pipe(

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -31,7 +31,6 @@ from typing import Optional
 
 import torch
 import torch_xla
-import torch_xla.debug.metrics as met
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from diffusers import FluxPipeline
@@ -57,42 +56,6 @@ from .src.model_utils import (
 )
 
 NUM_INFERENCE_STEPS = 50
-
-
-def _compile_counters():
-    """``(compile_seconds, graphs_compiled)`` accumulated process-wide so far."""
-    data = met.metric_data("CompileTime")
-    if not data:
-        return 0.0, 0
-    return (data[1] / 1e9 if len(data) > 1 else 0.0), data[0]
-
-
-def _graphs_compiled():
-    return _compile_counters()[1]
-
-
-class _StageCounters:
-    """Compile time and graph count of one staged residency, as a delta.
-
-    Makes the warm numbers falsifiable: a warm iteration must add zero graphs.
-    """
-
-    def __init__(self, sink, name):
-        self._sink, self._name = sink, name
-
-    def __enter__(self):
-        self._t0 = time.perf_counter()
-        self._before = _compile_counters()
-        return self
-
-    def __exit__(self, *exc):
-        after = _compile_counters()
-        self._sink[self._name] = {
-            "wall_s": time.perf_counter() - self._t0,
-            "compile_s": after[0] - self._before[0],
-            "graphs_compiled": after[1] - self._before[1],
-        }
-        return False
 
 
 class _DeviceDenoiser:
@@ -135,9 +98,6 @@ class _DeviceDenoiser:
         else:
             result = out.cpu()
         self._perf["steps"].append(time.perf_counter() - t0)
-        # Per-step graph count, so warm steps are selected rather than assumed:
-        # a step that compiled anything is not warm.
-        self._perf.setdefault("step_graphs", []).append(_graphs_compiled())
         return result
 
 
@@ -365,12 +325,10 @@ class FluxTTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
-            # Staged-residency additions; components[] keeps its existing meaning
-            # (the functional total) so the published <name>_s does not move.
+            # components[] keeps its existing meaning (the functional total),
+            # so the published <name>_s does not move.
             "cold": {},
             "warm": {},
-            "counters": {},
-            "step_graphs": [],
         }
         t_total_start = time.perf_counter()
 
@@ -441,24 +399,15 @@ class FluxTTPipeline:
         logger.info("[STAGE] transformer + vae: done")
 
         # ---- transformer step cold/warm ---------------------------------
-        # Warm steps are SELECTED by graph count, not assumed at index 1: a step
-        # that compiled anything is not warm.
+        # The transformer stays resident, so only the first step of the first
+        # call carries a build; every later step is warm.
         steps = self._perf["steps"]
-        sg = self._perf.get("step_graphs") or []
-        if steps and len(sg) == len(steps):
+        if steps:
             self._perf["cold"]["transformer_step"] = steps[0]
-            warm_steps = [
-                t for i, t in enumerate(steps) if i > 0 and sg[i] == sg[i - 1]
-            ]
-            if warm_steps:
-                self._perf["warm"]["transformer_step"] = sum(warm_steps) / len(
-                    warm_steps
+            if len(steps) > 1:
+                self._perf["warm"]["transformer_step"] = sum(steps[1:]) / (
+                    len(steps) - 1
                 )
-            self._perf["counters"]["transformer_warm_steps"] = {
-                "warm_steps": len(warm_steps),
-                "total_steps": len(steps),
-                "graphs_compiled": sg[-1] - sg[0],
-            }
 
         self._perf["total"] = time.perf_counter() - t_total_start
         # Raw VAE pixels in [-1, 1], shape (1, 3, H, W).

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -252,7 +252,9 @@ class FluxTTPipeline:
     # (.to("cpu") + del compiled), transformer and VAE by reassignment next call --
     # and eviction discards the compiled graph with the weights. A second
     # generate() therefore rebuilds, so the harness must skip its outer warmup.
-    benchmark_staged_residency = True
+    # Text encoders stay resident (see FluxConfig.evict_encoders), so a second
+    # generate() is genuinely warm and the harness runs warmup + steady.
+    benchmark_staged_residency = False
 
     # Substitution seams for the plain-callable wrappers. generate()
     # instantiates these attributes rather than the classes directly, so the

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -199,6 +199,7 @@ class FluxConfig:
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
         warm_iters: int = 0,
+        evict_encoders: bool = False,
     ):
         self.repo_id = REPO_ID
         self.height = height
@@ -208,6 +209,12 @@ class FluxConfig:
         # is then byte-identical to pre-instrumentation behaviour, so the demo
         # and PCC paths are unaffected. Only the benchmark sets it.
         self.warm_iters = warm_iters
+        # Keep the text encoders on device between calls. They are replicated,
+        # so T5 costs 9.12 GiB on every chip -- but all four components together
+        # are only 15.05 GiB of 31.83 (51%), and evicting cost a full rebuild
+        # every call: measured T5 84.63s evicting vs 0.24s resident (353x), call
+        # wall 105.49s -> 15.94s. Set True to restore the old evicting path.
+        self.evict_encoders = evict_encoders
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
 
@@ -223,6 +230,9 @@ class FluxTTPipeline:
     def __init__(self, config: FluxConfig):
         self.config = config
         self._perf = {}
+        # name -> (compiled, wrapper, module). Holding all three keeps both the
+        # compiled graph and its weights alive; dropping either forces a rebuild.
+        self._encoder_cache = {}
 
     # Every component is evicted inside generate() -- text encoders explicitly
     # (.to("cpu") + del compiled), transformer and VAE by reassignment next call --
@@ -260,23 +270,31 @@ class FluxTTPipeline:
         self._raw_vae = self.pipe.vae
 
     def _encode(self, wrapper_cls, module, input_ids, dev, name=None):
-        """Place a replicated text encoder on device, encode, evict.
+        """Place a replicated text encoder on device, encode, and KEEP it there.
 
-        Returns ``(cpu_module, embeds, elapsed_seconds)``.
+        Returns ``(module, embeds, elapsed_seconds)``.
 
-        Unlike Z-Image's encoder this runs ONE forward per residency, so a warm
-        number needs a synthetic repeat: the encoder is evicted at the end of
-        this call (``.to("cpu")`` + ``del compiled``), and eviction discards the
-        compiled graph, so a later call rebuilds rather than reusing it.
+        The encoder and its compiled graph are cached on first use, so a second
+        generate() reuses both instead of rebuilding. Previously this evicted
+        (``.to("cpu")`` + ``del compiled``), which discarded the graph with the
+        weights and made every later call pay a full rebuild -- measured T5
+        84.63s evicting vs 0.24s resident. Set ``evict_encoders`` to restore
+        the old behaviour on a part where the memory matters.
         """
-        wrapper = wrapper_cls(module).eval()
-        # Hook while the wrapper is still on HOST. The PCC e2e computes its golden
-        # here so the check costs no second copy of the encoder -- placing first
-        # and loading a twin later would double this component's peak, which
-        # matters because the staging exists to keep peak at max(component).
-        self._pre_place(name, wrapper, input_ids)
-        module = module.to(dev)
-        compiled = self._intercept(name, torch.compile(wrapper, backend="tt"))
+        cached = self._encoder_cache.get(name) if name else None
+        if cached is not None:
+            compiled, wrapper, module = cached
+        else:
+            wrapper = wrapper_cls(module).eval()
+            # Hook while the wrapper is still on HOST. The PCC e2e computes its
+            # golden here so the check costs no second copy of the encoder --
+            # placing first and loading a twin later would double this
+            # component's peak.
+            self._pre_place(name, wrapper, input_ids)
+            module = module.to(dev)
+            compiled = self._intercept(name, torch.compile(wrapper, backend="tt"))
+            if name and not self.config.evict_encoders:
+                self._encoder_cache[name] = (compiled, wrapper, module)
         t0 = time.perf_counter()
         with torch.no_grad():
             out = compiled(input_ids.to(dev))
@@ -296,8 +314,11 @@ class FluxTTPipeline:
                 del extra
             if warm:
                 self._perf.setdefault("warm", {})[name] = sum(warm) / len(warm)
-        module = module.to("cpu")
-        del compiled, wrapper
+        if self.config.evict_encoders:
+            # Old path: eviction discards the compiled graph along with the
+            # weights, so the next call rebuilds both.
+            module = module.to("cpu")
+            del compiled, wrapper
         return module, out, dt
 
     def _pre_place(self, name, wrapper, input_ids):

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -31,6 +31,7 @@ from typing import Optional
 
 import torch
 import torch_xla
+import torch_xla.debug.metrics as met
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from diffusers import FluxPipeline
@@ -56,6 +57,42 @@ from .src.model_utils import (
 )
 
 NUM_INFERENCE_STEPS = 50
+
+
+def _compile_counters():
+    """``(compile_seconds, graphs_compiled)`` accumulated process-wide so far."""
+    data = met.metric_data("CompileTime")
+    if not data:
+        return 0.0, 0
+    return (data[1] / 1e9 if len(data) > 1 else 0.0), data[0]
+
+
+def _graphs_compiled():
+    return _compile_counters()[1]
+
+
+class _StageCounters:
+    """Compile time and graph count of one staged residency, as a delta.
+
+    Makes the warm numbers falsifiable: a warm iteration must add zero graphs.
+    """
+
+    def __init__(self, sink, name):
+        self._sink, self._name = sink, name
+
+    def __enter__(self):
+        self._t0 = time.perf_counter()
+        self._before = _compile_counters()
+        return self
+
+    def __exit__(self, *exc):
+        after = _compile_counters()
+        self._sink[self._name] = {
+            "wall_s": time.perf_counter() - self._t0,
+            "compile_s": after[0] - self._before[0],
+            "graphs_compiled": after[1] - self._before[1],
+        }
+        return False
 
 
 class _DeviceDenoiser:
@@ -98,6 +135,9 @@ class _DeviceDenoiser:
         else:
             result = out.cpu()
         self._perf["steps"].append(time.perf_counter() - t0)
+        # Per-step graph count, so warm steps are selected rather than assumed:
+        # a step that compiled anything is not warm.
+        self._perf.setdefault("step_graphs", []).append(_graphs_compiled())
         return result
 
 
@@ -109,10 +149,11 @@ class _DeviceVAEDecoder:
     pipeline's PIL postprocess.
     """
 
-    def __init__(self, vae, perf):
+    def __init__(self, vae, perf, warm_iters=0):
         # No mesh: the VAE runs replicated, so it needs no shard annotations.
         self._dev = torch_xla.device()
         self._perf = perf
+        self._warm_iters = warm_iters
         self.config = vae.config
         self.dtype = next(vae.parameters()).dtype
         self._vae = vae
@@ -132,7 +173,21 @@ class _DeviceVAEDecoder:
         # host — the compiled lambda always returns a tensor, so no guard needed.
         out = self._compiled(latents.to(self._dev))
         image = out.cpu()
-        self._perf["components"]["vae"] = time.perf_counter() - t0
+        vae_cold = time.perf_counter() - t0
+        # components[] keeps its existing meaning: the functional decode only.
+        self._perf["components"]["vae"] = vae_cold
+        self._perf.setdefault("cold", {})["vae"] = vae_cold
+        # WARM: the VAE has no natural second forward, so repeat it here while
+        # still resident. Outputs are discarded, so last_pixels -- and therefore
+        # the returned image -- is identical at any warm_iters. Inert at 0.
+        warm = []
+        for _ in range(self._warm_iters):
+            t_w = time.perf_counter()
+            extra = self._compiled(latents.to(self._dev)).cpu()
+            warm.append(time.perf_counter() - t_w)
+            del extra
+        if warm:
+            self._perf.setdefault("warm", {})["vae"] = sum(warm) / len(warm)
         self.last_pixels = image
         return (image,)
 
@@ -143,10 +198,16 @@ class FluxConfig:
         height: int = HEIGHT,
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
+        warm_iters: int = 0,
     ):
         self.repo_id = REPO_ID
         self.height = height
         self.width = width
+        # Extra in-residency forwards per one-shot component, to obtain a warm
+        # number while the component is still on device. 0 = inert, and the path
+        # is then byte-identical to pre-instrumentation behaviour, so the demo
+        # and PCC paths are unaffected. Only the benchmark sets it.
+        self.warm_iters = warm_iters
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
 
@@ -162,6 +223,12 @@ class FluxTTPipeline:
     def __init__(self, config: FluxConfig):
         self.config = config
         self._perf = {}
+
+    # Every component is evicted inside generate() -- text encoders explicitly
+    # (.to("cpu") + del compiled), transformer and VAE by reassignment next call --
+    # and eviction discards the compiled graph with the weights. A second
+    # generate() therefore rebuilds, so the harness must skip its outer warmup.
+    benchmark_staged_residency = True
 
     def setup(self):
         # Enables SPMD + shardy annotations; required so the StableHLO handed to
@@ -186,23 +253,49 @@ class FluxTTPipeline:
         self._raw_transformer = self.pipe.transformer
         self._raw_vae = self.pipe.vae
 
-    def _encode(self, wrapper_cls, module, input_ids, dev):
+    def _encode(self, wrapper_cls, module, input_ids, dev, name=None):
         """Place a replicated text encoder on device, encode, evict.
 
         Returns ``(cpu_module, embeds, elapsed_seconds)``.
+
+        Unlike Z-Image's encoder this runs ONE forward per residency, so a warm
+        number needs a synthetic repeat: the encoder is evicted at the end of
+        this call (``.to("cpu")`` + ``del compiled``), and eviction discards the
+        compiled graph, so a later call rebuilds rather than reusing it.
         """
         wrapper = wrapper_cls(module).eval()
         module = module.to(dev)
-        compiled = torch.compile(wrapper, backend="tt")
+        compiled = self._intercept(name, torch.compile(wrapper, backend="tt"))
         t0 = time.perf_counter()
         with torch.no_grad():
             out = compiled(input_ids.to(dev))
         torch_xla.sync()
         out = out.cpu().to(DTYPE)
         dt = time.perf_counter() - t0
+        if name:
+            self._perf.setdefault("cold", {})[name] = dt
+            warm = []
+            for _ in range(self.config.warm_iters):
+                t_w = time.perf_counter()
+                with torch.no_grad():
+                    extra = compiled(input_ids.to(dev))
+                torch_xla.sync()
+                extra = extra.cpu()
+                warm.append(time.perf_counter() - t_w)
+                del extra
+            if warm:
+                self._perf.setdefault("warm", {})[name] = sum(warm) / len(warm)
         module = module.to("cpu")
         del compiled, wrapper
         return module, out, dt
+
+    def _intercept(self, name, compiled):
+        """Hook applied to each component's COMPILED callable. Identity by default.
+
+        The seam the PCC e2e uses: wrapping the compiled callable keeps a golden
+        comparison OUTSIDE the traced graph, where host tensors are real.
+        """
+        return compiled
 
     def generate(
         self,
@@ -217,6 +310,12 @@ class FluxTTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
+            # Staged-residency additions; components[] keeps its existing meaning
+            # (the functional total) so the published <name>_s does not move.
+            "cold": {},
+            "warm": {},
+            "counters": {},
+            "step_graphs": [],
         }
         t_total_start = time.perf_counter()
 
@@ -227,7 +326,11 @@ class FluxTTPipeline:
             pooled_prompt_embeds,
             self._perf["components"]["text_encoder_1"],
         ) = self._encode(
-            ClipTextEncoderWrapper, self.pipe.text_encoder, tokenize_clip(prompt), dev
+            ClipTextEncoderWrapper,
+            self.pipe.text_encoder,
+            tokenize_clip(prompt),
+            dev,
+            name="text_encoder_1",
         )
         logger.info("[STAGE] clip_text_encoder: done")
 
@@ -241,6 +344,7 @@ class FluxTTPipeline:
             self.pipe.text_encoder_2,
             tokenize_t5(prompt, max_sequence_length=MAX_SEQUENCE_LENGTH),
             dev,
+            name="text_encoder_2",
         )
         gc.collect()
         torch_xla.sync()
@@ -254,7 +358,9 @@ class FluxTTPipeline:
         self.pipe.transformer = _DeviceDenoiser(
             self._raw_transformer, self.mesh, self._perf
         )
-        vae_wrapper = _DeviceVAEDecoder(self._raw_vae, self._perf)
+        vae_wrapper = _DeviceVAEDecoder(
+            self._raw_vae, self._perf, warm_iters=self.config.warm_iters
+        )
         self.pipe.vae = vae_wrapper
 
         generator = torch.Generator().manual_seed(seed) if seed is not None else None
@@ -270,6 +376,26 @@ class FluxTTPipeline:
             generator=generator,
         )
         logger.info("[STAGE] transformer + vae: done")
+
+        # ---- transformer step cold/warm ---------------------------------
+        # Warm steps are SELECTED by graph count, not assumed at index 1: a step
+        # that compiled anything is not warm.
+        steps = self._perf["steps"]
+        sg = self._perf.get("step_graphs") or []
+        if steps and len(sg) == len(steps):
+            self._perf["cold"]["transformer_step"] = steps[0]
+            warm_steps = [
+                t for i, t in enumerate(steps) if i > 0 and sg[i] == sg[i - 1]
+            ]
+            if warm_steps:
+                self._perf["warm"]["transformer_step"] = sum(warm_steps) / len(
+                    warm_steps
+                )
+            self._perf["counters"]["transformer_warm_steps"] = {
+                "warm_steps": len(warm_steps),
+                "total_steps": len(steps),
+                "graphs_compiled": sg[-1] - sg[0],
+            }
 
         self._perf["total"] = time.perf_counter() - t_total_start
         # Raw VAE pixels in [-1, 1], shape (1, 3, H, W).

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -209,23 +209,17 @@ class FluxConfig:
         # is then byte-identical to pre-instrumentation behaviour, so the demo
         # and PCC paths are unaffected. Only the benchmark sets it.
         self.warm_iters = warm_iters
-        # Keep the text encoders on device between calls. They are replicated,
-        # so T5 costs 9.12 GiB on every chip -- but all four components together
-        # are only 15.05 GiB of 31.83 (51%), and evicting cost a full rebuild
-        # every call: measured T5 84.63s evicting vs 0.24s resident (353x), call
-        # wall 105.49s -> 15.94s. Set True to restore the old evicting path.
+        # Keep the text encoders on device between calls: all four components
+        # are 15.05 GiB of 31.83 (51%), and evicting cost a full rebuild every
+        # call (T5 84.63s evicting vs 0.24s resident). True restores evicting.
         self.evict_encoders = evict_encoders
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
 
 
 def _pin_execution_device_to_cpu(pipe) -> None:
-    """Force ``pipe._execution_device`` to CPU, idempotently.
-
-    Swaps in a per-instance subclass overriding the property, so the stock
-    pipeline keeps allocating its host-side tensors on CPU exactly as it did
-    when the encoders were evicted. Cheap and reversible; no diffusers patch.
-    """
+    """Force ``pipe._execution_device`` to CPU via a per-instance subclass,
+    so host-side tensors are allocated where they were before residency."""
     if getattr(type(pipe), "_tt_cpu_exec_device", False):
         return
     base = type(pipe)
@@ -251,8 +245,7 @@ class FluxTTPipeline:
     def __init__(self, config: FluxConfig):
         self.config = config
         self._perf = {}
-        # name -> (compiled, wrapper, module). Holding all three keeps both the
-        # compiled graph and its weights alive; dropping either forces a rebuild.
+        # name -> (compiled, wrapper, module); all three refs avoid a rebuild.
         self._encoder_cache = {}
 
     # Every component is evicted inside generate() -- text encoders explicitly
@@ -423,20 +416,12 @@ class FluxTTPipeline:
         )
         self.pipe.vae = vae_wrapper
 
-        # Pin the pipeline's execution device to CPU.
-        #
-        # diffusers derives _execution_device from DiffusionPipeline.device, which
-        # returns the device of the FIRST non-CPU nn.Module component
-        # (pipeline_utils.py:614). The shipped path moved both text encoders back
-        # to CPU, and _DeviceDenoiser/_DeviceVAEDecoder are plain classes rather
-        # than nn.Modules, so nothing was left on device and it reported CPU.
-        # Keeping the encoders resident makes it report the XLA device instead,
-        # and FluxPipeline.__call__ uses it to allocate latents, timesteps,
-        # guidance and image ids -- silently moving all of them onto the device
-        # and changing the numerics (measured: the VAE decode output shifted by
-        # up to 1.562e-02, and the PCC e2e's CPU twin died on an XLA tensor).
-        # Residency is a memory decision; it must not change where the host-side
-        # bookkeeping tensors live.
+        # diffusers derives _execution_device from DiffusionPipeline.device,
+        # which returns the first non-CPU nn.Module (pipeline_utils.py:614).
+        # Evicting left nothing on device, so it reported CPU; keeping the
+        # encoders resident flips it to XLA, and FluxPipeline.__call__ uses it to
+        # allocate latents/timesteps/guidance/ids -- which changed the VAE output
+        # by 1.562e-02 and broke the PCC twin. Residency must not move those.
         _pin_execution_device_to_cpu(self.pipe)
 
         generator = torch.Generator().manual_seed(seed) if seed is not None else None

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -13,9 +13,9 @@ backend via ``torch.compile(backend="tt")``:
   - transformer (FluxTransformer2DModel)   → tensor-parallel sharded (model axis)
   - VAE decoder (AutoencoderKL)            → replicated
 
-Memory strategy (peak ≈ max(component) rather than the sum): the CLIP and T5
-encoders are each placed → used → evicted before the transformer is placed, and
-the VAE is placed lazily at first decode (after the denoise loop).
+Memory strategy: all four components are 15.05 GiB of 31.83 (51%) and stay
+resident, so later calls reuse their compiled graphs. The VAE is still placed
+lazily at first decode so it does not inflate the denoiser's peak DRAM.
 
 This is the reusable implementation that both the runnable example
 (``examples/pytorch/flux1.py``) and the benchmark harness
@@ -24,7 +24,6 @@ into ``self._perf`` after each ``generate()`` (CLIP → components["text_encoder
 T5 → components["text_encoder_2"], transformer → steps, VAE → components["vae"]).
 """
 
-import gc
 import time
 from contextlib import contextmanager
 from typing import Optional
@@ -109,11 +108,10 @@ class _DeviceVAEDecoder:
     pipeline's PIL postprocess.
     """
 
-    def __init__(self, vae, perf, warm_iters=0):
+    def __init__(self, vae, perf):
         # No mesh: the VAE runs replicated, so it needs no shard annotations.
         self._dev = torch_xla.device()
         self._perf = perf
-        self._warm_iters = warm_iters
         self.config = vae.config
         self.dtype = next(vae.parameters()).dtype
         self._vae = vae
@@ -133,21 +131,7 @@ class _DeviceVAEDecoder:
         # host — the compiled lambda always returns a tensor, so no guard needed.
         out = self._compiled(latents.to(self._dev))
         image = out.cpu()
-        vae_cold = time.perf_counter() - t0
-        # components[] keeps its existing meaning: the functional decode only.
-        self._perf["components"]["vae"] = vae_cold
-        self._perf.setdefault("cold", {})["vae"] = vae_cold
-        # WARM: the VAE has no natural second forward, so repeat it here while
-        # still resident. Outputs are discarded, so last_pixels -- and therefore
-        # the returned image -- is identical at any warm_iters. Inert at 0.
-        warm = []
-        for _ in range(self._warm_iters):
-            t_w = time.perf_counter()
-            extra = self._compiled(latents.to(self._dev)).cpu()
-            warm.append(time.perf_counter() - t_w)
-            del extra
-        if warm:
-            self._perf.setdefault("warm", {})["vae"] = sum(warm) / len(warm)
+        self._perf["components"]["vae"] = time.perf_counter() - t0
         self.last_pixels = image
         return (image,)
 
@@ -158,21 +142,10 @@ class FluxConfig:
         height: int = HEIGHT,
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
-        warm_iters: int = 0,
-        evict_encoders: bool = False,
     ):
         self.repo_id = REPO_ID
         self.height = height
         self.width = width
-        # Extra in-residency forwards per one-shot component, to obtain a warm
-        # number while the component is still on device. 0 = inert, and the path
-        # is then byte-identical to pre-instrumentation behaviour, so the demo
-        # and PCC paths are unaffected. Only the benchmark sets it.
-        self.warm_iters = warm_iters
-        # Keep the text encoders on device between calls: all four components
-        # are 15.05 GiB of 31.83 (51%), and evicting cost a full rebuild every
-        # call (T5 84.63s evicting vs 0.24s resident). True restores evicting.
-        self.evict_encoders = evict_encoders
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
 
@@ -197,9 +170,8 @@ def _pin_execution_device_to_cpu(pipe) -> None:
 class FluxTTPipeline:
     """FluxPipeline with every module on TT, transformer tensor-parallel sharded.
 
-    Built once with ``setup()``; ``generate()`` can be called repeatedly. The raw
-    transformer / VAE modules are kept so the TT wrappers are rebuilt fresh on
-    each call (the benchmark harness runs a warmup pass followed by a steady one).
+    Built once with ``setup()``; ``generate()`` can be called repeatedly. Every
+    component is kept on device, so later calls reuse its compiled graph.
     """
 
     def __init__(self, config: FluxConfig):
@@ -208,17 +180,12 @@ class FluxTTPipeline:
         # name -> (compiled, wrapper, module); all three refs avoid a rebuild.
         self._encoder_cache = {}
 
-    # Every component is evicted inside generate() -- text encoders explicitly
-    # (.to("cpu") + del compiled), transformer and VAE by reassignment next call --
-    # and eviction discards the compiled graph with the weights. A second
-    # generate() therefore rebuilds, so the harness must skip its outer warmup.
-    # Text encoders stay resident (see FluxConfig.evict_encoders), so a second
-    # generate() is genuinely warm and the harness runs warmup + steady.
+    # Components stay resident, so a second generate() is genuinely warm and the
+    # harness runs its normal warmup + steady pair.
     benchmark_staged_residency = False
 
-    # Substitution seams for the plain-callable wrappers. generate()
-    # instantiates these attributes rather than the classes directly, so the
-    # PCC e2e can swap in checking subclasses without copying generate().
+    # Substitution seams: generate() instantiates these attributes rather than
+    # the classes directly, so the PCC e2e can swap in checking subclasses.
     DENOISER_CLS = _DeviceDenoiser
     VAE_CLS = _DeviceVAEDecoder
 
@@ -246,30 +213,23 @@ class FluxTTPipeline:
         self._raw_vae = self.pipe.vae
 
     def _encode(self, wrapper_cls, module, input_ids, dev, name=None):
-        """Place a replicated text encoder on device, encode, and KEEP it there.
+        """Place a replicated text encoder on device and encode.
 
-        Returns ``(module, embeds, elapsed_seconds)``.
-
-        The encoder and its compiled graph are cached on first use, so a second
-        generate() reuses both instead of rebuilding. Previously this evicted
-        (``.to("cpu")`` + ``del compiled``), which discarded the graph with the
-        weights and made every later call pay a full rebuild -- measured T5
-        84.63s evicting vs 0.24s resident. Set ``evict_encoders`` to restore
-        the old behaviour on a part where the memory matters.
+        Returns ``(module, embeds, elapsed_seconds)``. The encoder and its
+        compiled graph are cached on first use, so a second generate() reuses
+        both instead of rebuilding.
         """
         cached = self._encoder_cache.get(name) if name else None
         if cached is not None:
             compiled, wrapper, module = cached
         else:
             wrapper = wrapper_cls(module).eval()
-            # Hook while the wrapper is still on HOST. The PCC e2e computes its
-            # golden here so the check costs no second copy of the encoder --
-            # placing first and loading a twin later would double this
-            # component's peak.
+            # Hook while the wrapper is still on HOST: the PCC e2e computes
+            # its golden here, so the check costs no second copy of the encoder.
             self._pre_place(name, wrapper, input_ids)
             module = module.to(dev)
             compiled = self._intercept(name, torch.compile(wrapper, backend="tt"))
-            if name and not self.config.evict_encoders:
+            if name:
                 self._encoder_cache[name] = (compiled, wrapper, module)
         t0 = time.perf_counter()
         with torch.no_grad():
@@ -277,24 +237,6 @@ class FluxTTPipeline:
         torch_xla.sync()
         out = out.cpu().to(DTYPE)
         dt = time.perf_counter() - t0
-        if name:
-            self._perf.setdefault("cold", {})[name] = dt
-            warm = []
-            for _ in range(self.config.warm_iters):
-                t_w = time.perf_counter()
-                with torch.no_grad():
-                    extra = compiled(input_ids.to(dev))
-                torch_xla.sync()
-                extra = extra.cpu()
-                warm.append(time.perf_counter() - t_w)
-                del extra
-            if warm:
-                self._perf.setdefault("warm", {})[name] = sum(warm) / len(warm)
-        if self.config.evict_encoders:
-            # Old path: eviction discards the compiled graph along with the
-            # weights, so the next call rebuilds both.
-            module = module.to("cpu")
-            del compiled, wrapper
         return module, out, dt
 
     def _pre_place(self, name, wrapper, input_ids):
@@ -325,14 +267,14 @@ class FluxTTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
-            # components[] keeps its existing meaning (the functional total),
-            # so the published <name>_s does not move.
+            # Per-component cold/warm split, alongside the functional total in
+            # components[].
             "cold": {},
             "warm": {},
         }
         t_total_start = time.perf_counter()
 
-        # ── Stage 1: text encoders (CLIP, T5, replicated) → embeds, evict ─────
+        # ── Stage 1: text encoders (CLIP, T5, replicated) → embeds ───────────
         logger.info("[STAGE] clip_text_encoder: start")
         (
             self.pipe.text_encoder,
@@ -359,7 +301,6 @@ class FluxTTPipeline:
             dev,
             name="text_encoder_2",
         )
-        gc.collect()
         torch_xla.sync()
         logger.info("[STAGE] t5_text_encoder: done")
 
@@ -371,17 +312,13 @@ class FluxTTPipeline:
         self.pipe.transformer = self.DENOISER_CLS(
             self._raw_transformer, self.mesh, self._perf
         )
-        vae_wrapper = self.VAE_CLS(
-            self._raw_vae, self._perf, warm_iters=self.config.warm_iters
-        )
+        vae_wrapper = self.VAE_CLS(self._raw_vae, self._perf)
         self.pipe.vae = vae_wrapper
 
-        # diffusers derives _execution_device from DiffusionPipeline.device,
-        # which returns the first non-CPU nn.Module (pipeline_utils.py:614).
-        # Evicting left nothing on device, so it reported CPU; keeping the
-        # encoders resident flips it to XLA, and FluxPipeline.__call__ uses it to
-        # allocate latents/timesteps/guidance/ids -- which changed the VAE output
-        # by 1.562e-02 and broke the PCC twin. Residency must not move those.
+        # Required: FluxPipeline.__call__ allocates latents/timesteps/guidance/
+        # ids on _execution_device, which diffusers derives from the first
+        # non-CPU module (pipeline_utils.py:614). With components resident that
+        # is XLA, and moving those host tensors shifts the VAE output.
         _pin_execution_device_to_cpu(self.pipe)
 
         generator = torch.Generator().manual_seed(seed) if seed is not None else None
@@ -398,9 +335,8 @@ class FluxTTPipeline:
         )
         logger.info("[STAGE] transformer + vae: done")
 
-        # ---- transformer step cold/warm ---------------------------------
-        # The transformer stays resident, so only the first step of the first
-        # call carries a build; every later step is warm.
+        # Step 1 of the first call carries the transformer build; the rest are
+        # warm.
         steps = self._perf["steps"]
         if steps:
             self._perf["cold"]["transformer_step"] = steps[0]

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -267,10 +267,6 @@ class FluxTTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
-            # Per-component cold/warm split, alongside the functional total in
-            # components[].
-            "cold": {},
-            "warm": {},
         }
         t_total_start = time.perf_counter()
 
@@ -334,16 +330,6 @@ class FluxTTPipeline:
             generator=generator,
         )
         logger.info("[STAGE] transformer + vae: done")
-
-        # Step 1 of the first call carries the transformer build; the rest are
-        # warm.
-        steps = self._perf["steps"]
-        if steps:
-            self._perf["cold"]["transformer_step"] = steps[0]
-            if len(steps) > 1:
-                self._perf["warm"]["transformer_step"] = sum(steps[1:]) / (
-                    len(steps) - 1
-                )
 
         self._perf["total"] = time.perf_counter() - t_total_start
         # Raw VAE pixels in [-1, 1], shape (1, 3, H, W).

--- a/flux/pytorch/pipeline.py
+++ b/flux/pytorch/pipeline.py
@@ -184,8 +184,8 @@ class FluxTTPipeline:
     # harness runs its normal warmup + steady pair.
     benchmark_staged_residency = False
 
-    # Substitution seams: generate() instantiates these attributes rather than
-    # the classes directly, so the PCC e2e can swap in checking subclasses.
+    # Swapped by the PCC e2e for checking subclasses; generate() uses these
+    # attributes, not the classes directly.
     DENOISER_CLS = _DeviceDenoiser
     VAE_CLS = _DeviceVAEDecoder
 

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -31,7 +31,6 @@ from typing import Optional
 
 import torch
 import torch_xla
-import torch_xla.debug.metrics as met
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from diffusers import Flux2Pipeline
@@ -55,18 +54,6 @@ from .src.model_utils import (
 )
 
 NUM_INFERENCE_STEPS = 50
-
-
-def _compile_counters():
-    """``(compile_seconds, graphs_compiled)`` accumulated process-wide so far."""
-    data = met.metric_data("CompileTime")
-    if not data:
-        return 0.0, 0
-    return (data[1] / 1e9 if len(data) > 1 else 0.0), data[0]
-
-
-def _graphs_compiled():
-    return _compile_counters()[1]
 
 
 class _DeviceDenoiser:
@@ -103,8 +90,6 @@ class _DeviceDenoiser:
         else:
             result = out.cpu()
         self._perf["steps"].append(time.perf_counter() - t0)
-        # Per-step graph count, so warm steps are selected rather than assumed.
-        self._perf.setdefault("step_graphs", []).append(_graphs_compiled())
         return result
 
 
@@ -259,8 +244,6 @@ class Flux2TTPipeline:
             "total": None,
             "cold": {},
             "warm": {},
-            "counters": {},
-            "step_graphs": [],
         }
         t_total_start = time.perf_counter()
 
@@ -340,23 +323,15 @@ class Flux2TTPipeline:
         )
         logger.info("[STAGE] transformer + vae: done")
 
-        # Warm steps are SELECTED by graph count, not assumed at index 1.
+        # Step 1 carries the transformer build; the rest are warm. Measured on
+        # this model: zero graphs compiled after step 1 across all 50 steps.
         steps = self._perf["steps"]
-        sg = self._perf.get("step_graphs") or []
-        if steps and len(sg) == len(steps):
+        if steps:
             self._perf["cold"]["transformer_step"] = steps[0]
-            warm_steps = [
-                t for i, t in enumerate(steps) if i > 0 and sg[i] == sg[i - 1]
-            ]
-            if warm_steps:
-                self._perf["warm"]["transformer_step"] = sum(warm_steps) / len(
-                    warm_steps
+            if len(steps) > 1:
+                self._perf["warm"]["transformer_step"] = sum(steps[1:]) / (
+                    len(steps) - 1
                 )
-            self._perf["counters"]["transformer_warm_steps"] = {
-                "warm_steps": len(warm_steps),
-                "total_steps": len(steps),
-                "graphs_compiled": sg[-1] - sg[0],
-            }
 
         self._perf["total"] = time.perf_counter() - t_total_start
         # Raw VAE pixels in [-1, 1], shape (1, 3, H, W).

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -198,6 +198,19 @@ class Flux2TTPipeline:
     # outer warmup pass.
     benchmark_staged_residency = True
 
+    # Substitution seams for the plain-callable wrappers. generate()
+    # instantiates these attributes rather than the classes directly, so the
+    # PCC e2e can swap in checking subclasses without copying generate().
+    DENOISER_CLS = _DeviceDenoiser
+    VAE_CLS = _DeviceVAEDecoder
+
+    def _pre_place(self, name, wrapper, *inputs):
+        """Hook called with the wrapper still on host, before device placement.
+
+        No-op by default. See the text_encoder stage for why the PCC path needs it.
+        """
+        return None
+
     def _intercept(self, name, compiled):
         """Hook on each component's COMPILED callable. Identity by default.
 
@@ -257,6 +270,10 @@ class Flux2TTPipeline:
         encoder_wrapper = Mistral3TextEncoderWrapper(text_encoder).eval()
         input_ids, attention_mask = tokenize_prompt(prompt)
 
+        # Hook while the wrapper is still on HOST. The PCC e2e computes its golden
+        # here so the check costs no second copy of the 24B encoder -- placing
+        # first and loading a twin later would double this component's peak.
+        self._pre_place("text_encoder", encoder_wrapper, input_ids, attention_mask)
         text_encoder = text_encoder.to(dev)
         if hasattr(text_encoder, "tie_weights"):
             text_encoder.tie_weights()
@@ -303,10 +320,10 @@ class Flux2TTPipeline:
             "[STAGE] transformer (sharded) + vae: start ({} steps)",
             num_inference_steps,
         )
-        self.pipe.transformer = _DeviceDenoiser(
+        self.pipe.transformer = self.DENOISER_CLS(
             self._raw_transformer, self.mesh, self._perf
         )
-        vae_wrapper = _DeviceVAEDecoder(
+        vae_wrapper = self.VAE_CLS(
             self._raw_vae, self._perf, warm_iters=self.config.warm_iters
         )
         self.pipe.vae = vae_wrapper

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -31,6 +31,7 @@ from typing import Optional
 
 import torch
 import torch_xla
+import torch_xla.debug.metrics as met
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from diffusers import Flux2Pipeline
@@ -56,6 +57,18 @@ from .src.model_utils import (
 NUM_INFERENCE_STEPS = 50
 
 
+def _compile_counters():
+    """``(compile_seconds, graphs_compiled)`` accumulated process-wide so far."""
+    data = met.metric_data("CompileTime")
+    if not data:
+        return 0.0, 0
+    return (data[1] / 1e9 if len(data) > 1 else 0.0), data[0]
+
+
+def _graphs_compiled():
+    return _compile_counters()[1]
+
+
 class _DeviceDenoiser:
     """Routes Flux2Pipeline's transformer calls to the TP-sharded model on TT.
 
@@ -65,6 +78,7 @@ class _DeviceDenoiser:
     def __init__(self, transformer, mesh, perf):
         self._dev = torch_xla.device()
         self._perf = perf
+        self._warm_iters = warm_iters
         self.config = transformer.config
         self.dtype = next(transformer.parameters()).dtype
 
@@ -90,6 +104,8 @@ class _DeviceDenoiser:
         else:
             result = out.cpu()
         self._perf["steps"].append(time.perf_counter() - t0)
+        # Per-step graph count, so warm steps are selected rather than assumed.
+        self._perf.setdefault("step_graphs", []).append(_graphs_compiled())
         return result
 
 
@@ -104,7 +120,7 @@ class _DeviceVAEDecoder:
     postprocess.
     """
 
-    def __init__(self, vae, perf):
+    def __init__(self, vae, perf, warm_iters=0):
         # No mesh: the VAE runs replicated, so it needs no shard annotations.
         self._dev = torch_xla.device()
         self._perf = perf
@@ -128,7 +144,20 @@ class _DeviceVAEDecoder:
         # host — the compiled lambda always returns a tensor, so no guard needed.
         out = self._compiled(latents.to(self._dev))
         image = out.cpu()
-        self._perf["components"]["vae"] = time.perf_counter() - t0
+        vae_cold = time.perf_counter() - t0
+        # components[] keeps its existing meaning: the functional decode only.
+        self._perf["components"]["vae"] = vae_cold
+        self._perf.setdefault("cold", {})["vae"] = vae_cold
+        # WARM: no natural second decode, so repeat while still resident. Outputs
+        # discarded, so last_pixels is identical at any warm_iters. Inert at 0.
+        _warm = []
+        for _ in range(self._warm_iters):
+            _t = time.perf_counter()
+            _extra = self._compiled(latents.to(self._dev)).cpu()
+            _warm.append(time.perf_counter() - _t)
+            del _extra
+        if _warm:
+            self._perf.setdefault("warm", {})["vae"] = sum(_warm) / len(_warm)
         self.last_pixels = image
         return (image,)
 
@@ -139,12 +168,16 @@ class Flux2Config:
         height: int = HEIGHT,
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
+        warm_iters: int = 0,
     ):
         self.repo_id = REPO_ID
         self.height = height
         self.width = width
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
+        # Extra in-residency forwards per one-shot component. 0 = inert, so the
+        # demo and PCC paths are byte-identical to pre-instrumentation behaviour.
+        self.warm_iters = warm_iters
 
 
 class Flux2TTPipeline:
@@ -158,6 +191,19 @@ class Flux2TTPipeline:
     def __init__(self, config: Flux2Config):
         self.config = config
         self._perf = {}
+
+    # Every component is evicted inside generate() -- the 24B encoder explicitly,
+    # transformer and VAE by reassignment next call -- and eviction discards the
+    # compiled graph. A second generate() rebuilds, so the harness must skip its
+    # outer warmup pass.
+    benchmark_staged_residency = True
+
+    def _intercept(self, name, compiled):
+        """Hook on each component's COMPILED callable. Identity by default.
+
+        Keeps a PCC golden comparison OUTSIDE the traced graph.
+        """
+        return compiled
 
     def setup(self):
         # Enables SPMD + shardy annotations; required so tt-mlir gets shardy
@@ -198,6 +244,10 @@ class Flux2TTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
+            "cold": {},
+            "warm": {},
+            "counters": {},
+            "step_graphs": [],
         }
         t_total_start = time.perf_counter()
 
@@ -214,7 +264,9 @@ class Flux2TTPipeline:
         assert te_specs, "text-encoder shard spec is empty — descent failed (would OOM)"
         for tensor, spec in te_specs.items():
             xs.mark_sharding(tensor, self.mesh, spec)
-        te_compiled = torch.compile(encoder_wrapper, backend="tt")
+        te_compiled = self._intercept(
+            "text_encoder", torch.compile(encoder_wrapper, backend="tt")
+        )
 
         t0 = time.perf_counter()
         with torch.no_grad():
@@ -222,7 +274,22 @@ class Flux2TTPipeline:
         # .cpu() forces execution and blocks until the embeds are on host, so it
         # is the sync point that ends this component's timer.
         prompt_embeds = prompt_embeds.cpu()
-        self._perf["components"]["text_encoder"] = time.perf_counter() - t0
+        te_cold = time.perf_counter() - t0
+        self._perf["components"]["text_encoder"] = te_cold
+        self._perf.setdefault("cold", {})["text_encoder"] = te_cold
+        # WARM: this encoder runs ONE forward per residency and is evicted at the
+        # end of the stage, so a warm number needs a synthetic repeat here while
+        # the graph still exists. Discarded, so prompt_embeds is unchanged.
+        _warm = []
+        for _ in range(self.config.warm_iters):
+            _t = time.perf_counter()
+            with torch.no_grad():
+                _extra = te_compiled(input_ids.to(dev), attention_mask.to(dev))
+            _extra = _extra.cpu()
+            _warm.append(time.perf_counter() - _t)
+            del _extra
+        if _warm:
+            self._perf.setdefault("warm", {})["text_encoder"] = sum(_warm) / len(_warm)
 
         # Free the 24B encoder from device before placing the 32B denoiser.
         self.pipe.text_encoder = text_encoder.to("cpu")
@@ -239,7 +306,9 @@ class Flux2TTPipeline:
         self.pipe.transformer = _DeviceDenoiser(
             self._raw_transformer, self.mesh, self._perf
         )
-        vae_wrapper = _DeviceVAEDecoder(self._raw_vae, self._perf)
+        vae_wrapper = _DeviceVAEDecoder(
+            self._raw_vae, self._perf, warm_iters=self.config.warm_iters
+        )
         self.pipe.vae = vae_wrapper
 
         generator = torch.Generator().manual_seed(seed) if seed is not None else None
@@ -253,6 +322,24 @@ class Flux2TTPipeline:
             generator=generator,
         )
         logger.info("[STAGE] transformer + vae: done")
+
+        # Warm steps are SELECTED by graph count, not assumed at index 1.
+        steps = self._perf["steps"]
+        sg = self._perf.get("step_graphs") or []
+        if steps and len(sg) == len(steps):
+            self._perf["cold"]["transformer_step"] = steps[0]
+            warm_steps = [
+                t for i, t in enumerate(steps) if i > 0 and sg[i] == sg[i - 1]
+            ]
+            if warm_steps:
+                self._perf["warm"]["transformer_step"] = sum(warm_steps) / len(
+                    warm_steps
+                )
+            self._perf["counters"]["transformer_warm_steps"] = {
+                "warm_steps": len(warm_steps),
+                "total_steps": len(steps),
+                "graphs_compiled": sg[-1] - sg[0],
+            }
 
         self._perf["total"] = time.perf_counter() - t_total_start
         # Raw VAE pixels in [-1, 1], shape (1, 3, H, W).

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -130,11 +130,10 @@ class _DeviceVAEDecoder:
         out = self._compiled(latents.to(self._dev))
         image = out.cpu()
         vae_cold = time.perf_counter() - t0
-        # components[] keeps its existing meaning: the functional decode only.
         self._perf["components"]["vae"] = vae_cold
         self._perf.setdefault("cold", {})["vae"] = vae_cold
         # WARM: no natural second decode, so repeat while still resident. Outputs
-        # discarded, so last_pixels is identical at any warm_iters. Inert at 0.
+        # are discarded, so last_pixels is identical at any warm_iters.
         _warm = []
         for _ in range(self._warm_iters):
             _t = time.perf_counter()
@@ -160,8 +159,9 @@ class Flux2Config:
         self.width = width
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
-        # Extra in-residency forwards per one-shot component. 0 = inert, so the
-        # demo and PCC paths are byte-identical to pre-instrumentation behaviour.
+        # Extra in-residency forwards per one-shot component, to get a warm
+        # number while it is still on device. 0 = inert; only the benchmark
+        # sets it.
         self.warm_iters = warm_iters
 
 
@@ -177,15 +177,14 @@ class Flux2TTPipeline:
         self.config = config
         self._perf = {}
 
-    # Every component is evicted inside generate() -- the 24B encoder explicitly,
-    # transformer and VAE by reassignment next call -- and eviction discards the
-    # compiled graph. A second generate() rebuilds, so the harness must skip its
-    # outer warmup pass.
+    # 29.97 GiB of weights alone (94% of the 4-chip budget), so components
+    # cannot all stay resident: each is evicted inside generate(), which
+    # discards its compiled graph. A second generate() would rebuild, so the
+    # harness runs a single call and warm cost is measured in-residency.
     benchmark_staged_residency = True
 
-    # Substitution seams for the plain-callable wrappers. generate()
-    # instantiates these attributes rather than the classes directly, so the
-    # PCC e2e can swap in checking subclasses without copying generate().
+    # Substitution seams: generate() instantiates these attributes rather than
+    # the classes directly, so the PCC e2e can swap in checking subclasses.
     DENOISER_CLS = _DeviceDenoiser
     VAE_CLS = _DeviceVAEDecoder
 
@@ -253,9 +252,8 @@ class Flux2TTPipeline:
         encoder_wrapper = Mistral3TextEncoderWrapper(text_encoder).eval()
         input_ids, attention_mask = tokenize_prompt(prompt)
 
-        # Hook while the wrapper is still on HOST. The PCC e2e computes its golden
-        # here so the check costs no second copy of the 24B encoder -- placing
-        # first and loading a twin later would double this component's peak.
+        # Hook while the wrapper is still on HOST: the PCC e2e computes its
+        # golden here, so the check costs no second copy of the 24B encoder.
         self._pre_place("text_encoder", encoder_wrapper, input_ids, attention_mask)
         text_encoder = text_encoder.to(dev)
         if hasattr(text_encoder, "tie_weights"):
@@ -323,8 +321,7 @@ class Flux2TTPipeline:
         )
         logger.info("[STAGE] transformer + vae: done")
 
-        # Step 1 carries the transformer build; the rest are warm. Measured on
-        # this model: zero graphs compiled after step 1 across all 50 steps.
+        # Step 1 carries the transformer build; the rest are warm.
         steps = self._perf["steps"]
         if steps:
             self._perf["cold"]["transformer_step"] = steps[0]

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -78,7 +78,6 @@ class _DeviceDenoiser:
     def __init__(self, transformer, mesh, perf):
         self._dev = torch_xla.device()
         self._perf = perf
-        self._warm_iters = warm_iters
         self.config = transformer.config
         self.dtype = next(transformer.parameters()).dtype
 
@@ -124,6 +123,7 @@ class _DeviceVAEDecoder:
         # No mesh: the VAE runs replicated, so it needs no shard annotations.
         self._dev = torch_xla.device()
         self._perf = perf
+        self._warm_iters = warm_iters
         self.config = vae.config
         self.dtype = next(vae.parameters()).dtype
         self.bn = vae.bn  # stays on CPU; pipeline reads it host-side for denorm

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -61,10 +61,9 @@ NUM_INFERENCE_STEPS = 50
 def _staging(perf):
     """Accumulate host<->device weight movement into ``perf["staging"]``.
 
-    Placing and evicting a component is neither a forward nor host bookkeeping,
-    and at ~30 GiB per call it dwarfs both. Reported separately so the harness
-    can bill it to ``staging_overhead_s`` instead of ``cpu_overhead_s``, which is
-    what makes that metric mean the same thing here and on a resident pipeline.
+    Placing and evicting is neither a forward nor host bookkeeping, and at
+    ~30 GiB per call it dwarfs both. Billed to ``staging_overhead_s`` so
+    ``cpu_overhead_s`` means the same thing here and on a resident pipeline.
     """
     t0 = time.perf_counter()
     try:
@@ -151,8 +150,8 @@ class _DeviceVAEDecoder:
         vae_cold = time.perf_counter() - t0
         self._perf["components"]["vae"] = vae_cold
         self._perf.setdefault("cold", {})["vae"] = vae_cold
-        # WARM: no natural second decode, so repeat while still resident. Outputs
-        # are discarded, so last_pixels is identical at any warm_iters.
+        # WARM: no natural second decode, so repeat while still resident.
+        # Outputs are discarded, so last_pixels is unchanged.
         _warm = []
         for _ in range(self._warm_iters):
             _t = time.perf_counter()
@@ -180,8 +179,7 @@ class Flux2Config:
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
         # Extra in-residency forwards per one-shot component, to get a warm
-        # number while it is still on device. 0 = inert; only the benchmark
-        # sets it.
+        # number while it is still on device. 0 = inert.
         self.warm_iters = warm_iters
 
 
@@ -198,9 +196,8 @@ class Flux2TTPipeline:
         self._perf = {}
 
     # 29.97 GiB of weights alone (94% of the 4-chip budget), so components
-    # cannot all stay resident: each is evicted inside generate(), which
-    # discards its compiled graph. A second generate() would rebuild, so the
-    # harness runs a single call and warm cost is measured in-residency.
+    # cannot stay resident. Eviction discards the compiled graph, so the harness
+    # runs a single call and warm cost is measured in-residency.
     benchmark_staged_residency = True
 
     # Substitution seams: generate() instantiates these attributes rather than
@@ -263,8 +260,8 @@ class Flux2TTPipeline:
             "total": None,
             "cold": {},
             "warm": {},
-            # Weight movement, and time spent in the discarded warm repeats.
-            # Both are device work, so neither belongs in host overhead.
+            # Device work that is not a forward; neither belongs in host
+            # overhead.
             "staging": 0.0,
             "synthetic": 0.0,
         }

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -27,6 +27,7 @@ go into ``self._perf`` after each ``generate()``.
 
 import gc
 import time
+from contextlib import contextmanager
 from typing import Optional
 
 import torch
@@ -56,6 +57,22 @@ from .src.model_utils import (
 NUM_INFERENCE_STEPS = 50
 
 
+@contextmanager
+def _staging(perf):
+    """Accumulate host<->device weight movement into ``perf["staging"]``.
+
+    Placing and evicting a component is neither a forward nor host bookkeeping,
+    and at ~30 GiB per call it dwarfs both. Reported separately so the harness
+    can bill it to ``staging_overhead_s`` instead of ``cpu_overhead_s``, which is
+    what makes that metric mean the same thing here and on a resident pipeline.
+    """
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        perf["staging"] = perf.get("staging", 0.0) + (time.perf_counter() - t0)
+
+
 class _DeviceDenoiser:
     """Routes Flux2Pipeline's transformer calls to the TP-sharded model on TT.
 
@@ -68,14 +85,15 @@ class _DeviceDenoiser:
         self.config = transformer.config
         self.dtype = next(transformer.parameters()).dtype
 
-        transformer = transformer.to(self._dev)
-        if hasattr(transformer, "tie_weights"):
-            transformer.tie_weights()
-        specs = shard_transformer_specs(transformer)
-        assert specs, "transformer shard spec is empty — would run replicated/OOM"
-        for tensor, spec in specs.items():
-            xs.mark_sharding(tensor, mesh, spec)
-        self._compiled = torch.compile(transformer, backend="tt")
+        with _staging(perf):
+            transformer = transformer.to(self._dev)
+            if hasattr(transformer, "tie_weights"):
+                transformer.tie_weights()
+            specs = shard_transformer_specs(transformer)
+            assert specs, "transformer shard spec is empty — would run replicated/OOM"
+            for tensor, spec in specs.items():
+                xs.mark_sharding(tensor, mesh, spec)
+            self._compiled = torch.compile(transformer, backend="tt")
 
     def __call__(self, **kwargs):
         moved = {
@@ -120,10 +138,11 @@ class _DeviceVAEDecoder:
         # Lazy device placement: keep the VAE off-device during the denoise loop
         # so it does not inflate the denoiser's peak DRAM; place it only now.
         if self._compiled is None:
-            vae = self._vae.to(self._dev)
-            self._compiled = torch.compile(
-                lambda z: vae.decode(z, return_dict=False)[0], backend="tt"
-            )
+            with _staging(self._perf):
+                vae = self._vae.to(self._dev)
+                self._compiled = torch.compile(
+                    lambda z: vae.decode(z, return_dict=False)[0], backend="tt"
+                )
         t0 = time.perf_counter()
         # .cpu() forces the graph to execute and blocks until the result is on
         # host — the compiled lambda always returns a tensor, so no guard needed.
@@ -142,6 +161,7 @@ class _DeviceVAEDecoder:
             del _extra
         if _warm:
             self._perf.setdefault("warm", {})["vae"] = sum(_warm) / len(_warm)
+            self._perf["synthetic"] = self._perf.get("synthetic", 0.0) + sum(_warm)
         self.last_pixels = image
         return (image,)
 
@@ -243,6 +263,10 @@ class Flux2TTPipeline:
             "total": None,
             "cold": {},
             "warm": {},
+            # Weight movement, and time spent in the discarded warm repeats.
+            # Both are device work, so neither belongs in host overhead.
+            "staging": 0.0,
+            "synthetic": 0.0,
         }
         t_total_start = time.perf_counter()
 
@@ -255,16 +279,19 @@ class Flux2TTPipeline:
         # Hook while the wrapper is still on HOST: the PCC e2e computes its
         # golden here, so the check costs no second copy of the 24B encoder.
         self._pre_place("text_encoder", encoder_wrapper, input_ids, attention_mask)
-        text_encoder = text_encoder.to(dev)
-        if hasattr(text_encoder, "tie_weights"):
-            text_encoder.tie_weights()
-        te_specs = shard_text_encoder_specs(text_encoder)
-        assert te_specs, "text-encoder shard spec is empty — descent failed (would OOM)"
-        for tensor, spec in te_specs.items():
-            xs.mark_sharding(tensor, self.mesh, spec)
-        te_compiled = self._intercept(
-            "text_encoder", torch.compile(encoder_wrapper, backend="tt")
-        )
+        with _staging(self._perf):
+            text_encoder = text_encoder.to(dev)
+            if hasattr(text_encoder, "tie_weights"):
+                text_encoder.tie_weights()
+            te_specs = shard_text_encoder_specs(text_encoder)
+            assert (
+                te_specs
+            ), "text-encoder shard spec is empty — descent failed (would OOM)"
+            for tensor, spec in te_specs.items():
+                xs.mark_sharding(tensor, self.mesh, spec)
+            te_compiled = self._intercept(
+                "text_encoder", torch.compile(encoder_wrapper, backend="tt")
+            )
 
         t0 = time.perf_counter()
         with torch.no_grad():
@@ -288,12 +315,14 @@ class Flux2TTPipeline:
             del _extra
         if _warm:
             self._perf.setdefault("warm", {})["text_encoder"] = sum(_warm) / len(_warm)
+            self._perf["synthetic"] = self._perf.get("synthetic", 0.0) + sum(_warm)
 
         # Free the 24B encoder from device before placing the 32B denoiser.
-        self.pipe.text_encoder = text_encoder.to("cpu")
-        del te_compiled, encoder_wrapper
-        gc.collect()
-        torch_xla.sync()
+        with _staging(self._perf):
+            self.pipe.text_encoder = text_encoder.to("cpu")
+            del te_compiled, encoder_wrapper
+            gc.collect()
+            torch_xla.sync()
         logger.info("[STAGE] text_encoder: done")
 
         # ── Stage 2: denoiser (sharded) + VAE (replicated, lazy) → image ─────
@@ -320,15 +349,6 @@ class Flux2TTPipeline:
             generator=generator,
         )
         logger.info("[STAGE] transformer + vae: done")
-
-        # Step 1 carries the transformer build; the rest are warm.
-        steps = self._perf["steps"]
-        if steps:
-            self._perf["cold"]["transformer_step"] = steps[0]
-            if len(steps) > 1:
-                self._perf["warm"]["transformer_step"] = sum(steps[1:]) / (
-                    len(steps) - 1
-                )
 
         self._perf["total"] = time.perf_counter() - t_total_start
         # Raw VAE pixels in [-1, 1], shape (1, 3, H, W).

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -200,8 +200,8 @@ class Flux2TTPipeline:
     # runs a single call and warm cost is measured in-residency.
     benchmark_staged_residency = True
 
-    # Substitution seams: generate() instantiates these attributes rather than
-    # the classes directly, so the PCC e2e can swap in checking subclasses.
+    # Swapped by the PCC e2e for checking subclasses; generate() uses these
+    # attributes, not the classes directly.
     DENOISER_CLS = _DeviceDenoiser
     VAE_CLS = _DeviceVAEDecoder
 

--- a/flux2/pytorch/pipeline.py
+++ b/flux2/pytorch/pipeline.py
@@ -299,9 +299,8 @@ class Flux2TTPipeline:
         te_cold = time.perf_counter() - t0
         self._perf["components"]["text_encoder"] = te_cold
         self._perf.setdefault("cold", {})["text_encoder"] = te_cold
-        # WARM: this encoder runs ONE forward per residency and is evicted at the
-        # end of the stage, so a warm number needs a synthetic repeat here while
-        # the graph still exists. Discarded, so prompt_embeds is unchanged.
+        # WARM: one forward per residency, then evicted, so the warm number
+        # needs a repeat here. Discarded, so prompt_embeds is unchanged.
         _warm = []
         for _ in range(self.config.warm_iters):
             _t = time.perf_counter()

--- a/playground_v2_5/pytorch/pipeline.py
+++ b/playground_v2_5/pytorch/pipeline.py
@@ -1,0 +1,417 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Playground v2.5 text-to-image pipeline running on Tenstorrent.
+
+Four compute modules run on the TT backend via ``model.compile(backend="tt")``;
+the tokenizers, scheduler and latent bookkeeping stay on CPU:
+
+  - CLIP text encoder    (CLIPTextModel)                -> text_encoder_1
+  - CLIP text encoder 2  (CLIPTextModelWithProjection)  -> text_encoder_2
+  - UNet                 (UNet2DConditionModel)         -> looped, bf16
+  - VAE decoder          (AutoencoderKL)                -> vae
+
+The model uses classifier-free guidance, so each step is one UNet forward over a
+batch of 2 (uncond, text) that is split and recombined on the host. Its VAE
+latents are mean/std normalised rather than plain scaling-factor scaled.
+
+Memory strategy: all four components are 8.14 GiB of 31.83 (26%) and stay
+resident, so later calls reuse their compiled graphs.
+
+This is the reusable implementation that the runnable example
+(``examples/pytorch/playground_v2_5.py``), the benchmark harness
+(``tests/benchmark/test_imagegen.py::test_playground_v2_5``) and the PCC-gated
+e2e (``tests/torch/models/playground_v2_5/``) all consume. Per-component times
+go into ``self._perf`` after each ``generate()``.
+"""
+
+import time
+from typing import Optional
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+from diffusers import EDMDPMSolverMultistepScheduler
+from loguru import logger
+from PIL import Image
+from transformers import CLIPTokenizer
+
+from .loader import ModelLoader, ModelVariant
+from .src.model_utils import HEIGHT, PLAYGROUND_REPO_ID, VAE_SCALE, WIDTH
+
+PROMPT = "Astronaut in a jungle, cold color palette, muted colors, detailed, 8k"
+NEGATIVE_PROMPT = None
+SEED = 42
+GUIDANCE_SCALE = 3.0
+NUM_INFERENCE_STEPS = 50
+
+
+class PlaygroundV25Config:
+    def __init__(
+        self,
+        text_encoder_on_tt: bool = True,
+        text_encoder_2_on_tt: bool = True,
+        unet_on_tt: bool = True,
+        vae_on_tt: bool = True,
+        compile_options: Optional[dict] = None,
+    ):
+        self.model_id = PLAYGROUND_REPO_ID
+        self.width = WIDTH
+        self.height = HEIGHT
+        self.vae_scale_factor = VAE_SCALE
+        self.latents_width = self.width // self.vae_scale_factor
+        self.latents_height = self.height // self.vae_scale_factor
+        self.text_encoder_on_tt = text_encoder_on_tt
+        self.text_encoder_2_on_tt = text_encoder_2_on_tt
+        self.unet_on_tt = unet_on_tt
+        self.vae_on_tt = vae_on_tt
+        # Harness-set compile options; merged with the VAE-only opt_level bump
+        # in generate() (only relevant if vae_on_tt is True).
+        self.compile_options = compile_options or {}
+
+
+class PlaygroundV25TTPipeline:
+    """Playground v2.5 with every module on a single TT chip.
+
+    Built once with ``setup()``; ``generate()`` can be called repeatedly. Each
+    module is placed on first use and kept on device, so later calls reuse its
+    compiled graph.
+    """
+
+    # Components stay resident, so a second generate() is genuinely warm and the
+    # harness runs its normal warmup + steady pair.
+    benchmark_staged_residency = False
+
+    def __init__(self, config: PlaygroundV25Config):
+        self.config = config
+        self._perf = {}
+
+    def _check(self, name, tt_out, *cpu_inputs):
+        """Hook after each component's TT forward. No-op by default.
+
+        The seam the PCC e2e uses: it runs a CPU twin on ``cpu_inputs`` -- the
+        same fp32 tensors the TT component consumed -- and asserts on PCC. Kept
+        outside the component so the comparison never enters a traced graph.
+
+        ``name`` is one of "text_encoder_1", "text_encoder_2", "unet", "vae".
+        """
+        return None
+
+    def setup(self):
+        self.load_models()
+        self.load_scheduler()
+        self.load_tokenizers()
+
+    def load_models(self):
+        # Load on CPU and only register the "tt" dynamo backend here; the move
+        # to xla_device happens in generate() right before the first forward.
+        self.text_encoder = ModelLoader(ModelVariant.TEXT_ENCODER).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.text_encoder_on_tt:
+            self.text_encoder.compile(backend="tt")
+
+        self.text_encoder_2 = ModelLoader(ModelVariant.TEXT_ENCODER_2).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.text_encoder_2_on_tt:
+            self.text_encoder_2.compile(backend="tt")
+
+        # UNet on fp32 throws OOM on the second iteration of the denoising loop,
+        # so UNet runs in bf16.
+        unet_dtype = torch.bfloat16 if self.config.unet_on_tt else torch.float32
+        self.unet = ModelLoader(ModelVariant.UNET).load_model(dtype_override=unet_dtype)
+        if self.config.unet_on_tt:
+            self.unet.compile(backend="tt")
+
+        self.vae = ModelLoader(ModelVariant.VAE).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.vae_on_tt:
+            self.vae.compile(backend="tt")
+
+    def load_scheduler(self):
+        self.scheduler = EDMDPMSolverMultistepScheduler.from_pretrained(
+            self.config.model_id, subfolder="scheduler"
+        )
+
+    def load_tokenizers(self):
+        self.tokenizer = CLIPTokenizer.from_pretrained(
+            self.config.model_id, subfolder="tokenizer"
+        )
+        self.tokenizer_2 = CLIPTokenizer.from_pretrained(
+            self.config.model_id, subfolder="tokenizer_2"
+        )
+
+    def _get_add_time_ids(self, dtype):
+        original_size = (self.config.height, self.config.width)
+        crops_coords_top_left = (0, 0)
+        target_size = (self.config.height, self.config.width)
+        add_time_ids = list(original_size + crops_coords_top_left + target_size)
+        return torch.tensor([add_time_ids], dtype=dtype)
+
+    def _encode(self, text: str, device):
+        """Both CLIP encoders over one prompt. Returns host tensors."""
+        tokens_1 = self.tokenizer(
+            [text],
+            padding="max_length",
+            max_length=self.tokenizer.model_max_length,
+            truncation=True,
+            return_tensors="pt",
+        ).input_ids.to(device="cpu")
+        if self.config.text_encoder_on_tt:
+            tokens_1 = tokens_1.to(device=device)
+        embeds_1 = self.text_encoder(tokens_1)
+        if self.config.text_encoder_on_tt:
+            embeds_1 = embeds_1.to("cpu")
+
+        tokens_2 = self.tokenizer_2(
+            [text],
+            padding="max_length",
+            max_length=self.tokenizer_2.model_max_length,
+            truncation=True,
+            return_tensors="pt",
+        ).input_ids.to(device="cpu")
+        if self.config.text_encoder_2_on_tt:
+            tokens_2 = tokens_2.to(device=device)
+        embeds_2, pooled = self.text_encoder_2(tokens_2)
+        if self.config.text_encoder_2_on_tt:
+            embeds_2 = embeds_2.to("cpu")
+            pooled = pooled.to("cpu")
+        return torch.cat([embeds_1, embeds_2], dim=-1), pooled
+
+    def generate(
+        self,
+        prompt: str = PROMPT,
+        negative_prompt: Optional[str] = NEGATIVE_PROMPT,
+        cfg_scale: float = GUIDANCE_SCALE,
+        num_inference_steps: int = NUM_INFERENCE_STEPS,
+        seed: Optional[int] = SEED,
+    ) -> torch.Tensor:
+        """End-to-end generation. Returns pixels in [-1, 1], shape (1, 3, H, W)."""
+        assert isinstance(
+            prompt, str
+        ), "Only single-prompt generation (batch_size=1) is tested for now"
+        batch_size = 1
+
+        device = xm.xla_device()
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "unet_step",
+            "total": None,
+        }
+        t_total_start = time.perf_counter()
+
+        with torch.no_grad():
+            generator = torch.Generator(device="cpu")
+            if seed is not None:
+                generator.manual_seed(seed)
+            else:
+                generator.seed()
+
+            # -- Text encoder 1 (CLIPTextModel) ---------------------------
+            logger.info("[STAGE] Text encoder 1: start")
+            tokens_1 = self.tokenizer(
+                [prompt],
+                padding="max_length",
+                max_length=self.tokenizer.model_max_length,
+                truncation=True,
+                return_tensors="pt",
+            ).input_ids.to(device="cpu")
+            tokens_1_cpu = tokens_1
+
+            # CPU -> TT
+            if self.config.text_encoder_on_tt:
+                self.text_encoder = self.text_encoder.to(device)
+                tokens_1 = tokens_1.to(device=device)
+
+            t0 = time.perf_counter()
+            prompt_embeds_1 = self.text_encoder(tokens_1)
+            # TT -> CPU (cpu cast forces sync -- timer ends after this)
+            if self.config.text_encoder_on_tt:
+                prompt_embeds_1 = prompt_embeds_1.to("cpu")
+            self._perf["components"]["text_encoder_1"] = time.perf_counter() - t0
+
+            self._check("text_encoder_1", prompt_embeds_1, tokens_1_cpu)
+            logger.info("[STAGE] Text encoder 1: done")
+
+            # -- Text encoder 2 (CLIPTextModelWithProjection) --------------
+            logger.info("[STAGE] Text encoder 2: start")
+            tokens_2 = self.tokenizer_2(
+                [prompt],
+                padding="max_length",
+                max_length=self.tokenizer_2.model_max_length,
+                truncation=True,
+                return_tensors="pt",
+            ).input_ids.to(device="cpu")
+            tokens_2_cpu = tokens_2
+
+            # CPU -> TT
+            if self.config.text_encoder_2_on_tt:
+                self.text_encoder_2 = self.text_encoder_2.to(device)
+                tokens_2 = tokens_2.to(device=device)
+
+            t0 = time.perf_counter()
+            prompt_embeds_2, pooled_prompt_embeds = self.text_encoder_2(tokens_2)
+            # TT -> CPU (cpu cast forces sync -- timer ends after this)
+            if self.config.text_encoder_2_on_tt:
+                prompt_embeds_2 = prompt_embeds_2.to("cpu")
+                pooled_prompt_embeds = pooled_prompt_embeds.to("cpu")
+            self._perf["components"]["text_encoder_2"] = time.perf_counter() - t0
+
+            self._check(
+                "text_encoder_2",
+                (prompt_embeds_2, pooled_prompt_embeds),
+                tokens_2_cpu,
+            )
+            logger.info("[STAGE] Text encoder 2: done")
+
+            # Concat the two encoders' hidden states
+            prompt_embeds = torch.cat([prompt_embeds_1, prompt_embeds_2], dim=-1)
+
+            # force_zeros_for_empty_prompt=True for playground-v2.5: zero path
+            # only when negative_prompt is None.
+            if negative_prompt is None:
+                negative_prompt_embeds = torch.zeros_like(prompt_embeds)
+                negative_pooled_prompt_embeds = torch.zeros_like(pooled_prompt_embeds)
+            else:
+                negative_prompt_embeds, negative_pooled_prompt_embeds = self._encode(
+                    negative_prompt, device
+                )
+
+            # CFG concat (uncond first)
+            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+            add_text_embeds = torch.cat(
+                [negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0
+            )
+
+            add_time_ids = self._get_add_time_ids(prompt_embeds.dtype)
+            add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0).to("cpu")
+
+            # -- Timesteps -------------------------------------------------
+            self.scheduler.set_timesteps(num_inference_steps, device="cpu")
+            timesteps = self.scheduler.timesteps
+
+            # -- Latents ---------------------------------------------------
+            latent_shape = (
+                batch_size,
+                4,
+                self.config.latents_height,
+                self.config.latents_width,
+            )
+            latents = torch.randn(
+                latent_shape, generator=generator, dtype=torch.float32
+            ).to(device="cpu")
+            latents = latents * self.scheduler.init_noise_sigma
+
+            # -- Denoising loop (UNet) -------------------------------------
+            logger.info(
+                f"[STAGE] UNet denoising loop: start ({num_inference_steps} steps)"
+            )
+            # Move the UNet to TT once, before the loop.
+            if self.config.unet_on_tt:
+                self.unet = self.unet.to(device)
+
+            # Loop-invariant inputs: convert once, reuse across all steps.
+            if self.config.unet_on_tt:
+                unet_eh = prompt_embeds.to(torch.bfloat16).to(device)
+                unet_te = add_text_embeds.to(torch.bfloat16).to(device)
+                unet_ti = add_time_ids.to(torch.bfloat16).to(device)
+            else:
+                unet_eh = prompt_embeds
+                unet_te = add_text_embeds
+                unet_ti = add_time_ids
+
+            for i, t in enumerate(timesteps):
+                logger.info(f"[STEP] UNet step {i + 1}/{num_inference_steps}")
+
+                latent_model_input = torch.cat([latents] * 2)
+                latent_model_input = self.scheduler.scale_model_input(
+                    latent_model_input, t
+                )
+
+                # CPU -> TT (UNet runs in bf16 on TT). Only sample + timestep
+                # change per step; embeds/time_ids are hoisted above.
+                if self.config.unet_on_tt:
+                    unet_sample = latent_model_input.to(torch.bfloat16).to(device)
+                    unet_t = t.to(torch.bfloat16).to(device)
+                else:
+                    unet_sample = latent_model_input
+                    unet_t = t
+
+                t0 = time.perf_counter()
+                noise_pred = self.unet(unet_sample, unet_t, unet_eh, unet_te, unet_ti)
+                # TT -> CPU (cpu cast forces sync -- timer ends after this)
+                if self.config.unet_on_tt:
+                    noise_pred = noise_pred.to("cpu").to(torch.float32)
+                self._perf["steps"].append(time.perf_counter() - t0)
+
+                self._check(
+                    "unet",
+                    noise_pred,
+                    latent_model_input,
+                    t,
+                    prompt_embeds,
+                    add_text_embeds,
+                    add_time_ids,
+                )
+
+                # CFG + scheduler step
+                uncond, text = noise_pred.chunk(2)
+                noise_pred = uncond + cfg_scale * (text - uncond)
+
+                latents = self.scheduler.step(
+                    noise_pred, t, latents, return_dict=False
+                )[0]
+            logger.info("[STAGE] UNet denoising loop: done")
+
+            # -- VAE decode ------------------------------------------------
+            logger.info("[STAGE] VAE decode: start")
+            latents_mean = (
+                torch.tensor(self.vae.vae.config.latents_mean)
+                .view(1, 4, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            latents_std = (
+                torch.tensor(self.vae.vae.config.latents_std)
+                .view(1, 4, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            scaling_factor = self.vae.vae.config.scaling_factor
+            latents = latents * latents_std / scaling_factor + latents_mean
+            latents_cpu = latents
+
+            # opt_level=1 keeps ttir.group_norm -> ttnn.group_norm; opt_level=0
+            # decomposes GroupNorm which OOMs the VAE (issue #4710).
+            if self.config.vae_on_tt:
+                torch_xla.set_custom_compile_options(
+                    {**self.config.compile_options, "optimization_level": 1}
+                )
+                self.vae = self.vae.to(device)
+                latents = latents.to(device)
+
+            t0 = time.perf_counter()
+            image = self.vae(latents)
+            # TT -> CPU (cpu cast forces sync -- timer ends after this)
+            if self.config.vae_on_tt:
+                image = image.to("cpu")
+            self._perf["components"]["vae"] = time.perf_counter() - t0
+
+            self._check("vae", image, latents_cpu)
+            logger.info("[STAGE] VAE decode: done")
+
+            self._perf["total"] = time.perf_counter() - t_total_start
+            return image
+
+
+def save_image(image: torch.Tensor, filepath: str = "output.png"):
+    """Rescale ([-1,1]->[0,255]), reshape and save the pipeline output as PNG."""
+    image = (
+        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
+    )
+    image_np = image.cpu().squeeze().numpy()
+    assert image_np.ndim == 3, "Image must be 3D"
+    if image_np.shape[0] == 3:
+        image_np = image_np.transpose(1, 2, 0)
+    Image.fromarray(image_np).save(filepath)

--- a/playground_v2_5/pytorch/pipeline.py
+++ b/playground_v2_5/pytorch/pipeline.py
@@ -74,8 +74,7 @@ class PlaygroundV25TTPipeline:
     """Playground v2.5 with every module on a single TT chip.
 
     Built once with ``setup()``; ``generate()`` can be called repeatedly. Each
-    module is placed on first use and kept on device, so later calls reuse its
-    compiled graph.
+    module is kept on device, so later calls reuse its compiled graph.
     """
 
     # Components stay resident, so a second generate() is genuinely warm and the
@@ -90,9 +89,7 @@ class PlaygroundV25TTPipeline:
         """Hook after each component's TT forward. No-op by default.
 
         The seam the PCC e2e uses: it runs a CPU twin on ``cpu_inputs`` -- the
-        same fp32 tensors the TT component consumed -- and asserts on PCC. Kept
-        outside the component so the comparison never enters a traced graph.
-
+        same fp32 tensors the TT component consumed -- outside the traced graph.
         ``name`` is one of "text_encoder_1", "text_encoder_2", "unet", "vae".
         """
         return None
@@ -103,8 +100,8 @@ class PlaygroundV25TTPipeline:
         self.load_tokenizers()
 
     def load_models(self):
-        # Load on CPU and only register the "tt" dynamo backend here; the move
-        # to xla_device happens in generate() right before the first forward.
+        # Load on CPU; the move to xla_device happens in generate() right
+        # before the first forward.
         self.text_encoder = ModelLoader(ModelVariant.TEXT_ENCODER).load_model(
             dtype_override=torch.float32
         )

--- a/playground_v2_5/pytorch/pipeline.py
+++ b/playground_v2_5/pytorch/pipeline.py
@@ -203,7 +203,7 @@ class PlaygroundV25TTPipeline:
             "step_metric_name": "unet_step",
             "total": None,
             # Each text encoder runs twice per call (positive, then negative), so
-            # the two forwards are reported separately as z_image's are.
+            # the two forwards are reported separately.
             "cold": {},
             "warm": {},
         }

--- a/playground_v2_5/pytorch/pipeline.py
+++ b/playground_v2_5/pytorch/pipeline.py
@@ -150,9 +150,11 @@ class PlaygroundV25TTPipeline:
         ).input_ids.to(device="cpu")
         if self.config.text_encoder_on_tt:
             tokens_1 = tokens_1.to(device=device)
+        t0 = time.perf_counter()
         embeds_1 = self.text_encoder(tokens_1)
         if self.config.text_encoder_on_tt:
             embeds_1 = embeds_1.to("cpu")
+        self._record_encode("text_encoder_1", time.perf_counter() - t0)
 
         tokens_2 = self.tokenizer_2(
             [text],
@@ -163,11 +165,22 @@ class PlaygroundV25TTPipeline:
         ).input_ids.to(device="cpu")
         if self.config.text_encoder_2_on_tt:
             tokens_2 = tokens_2.to(device=device)
+        t0 = time.perf_counter()
         embeds_2, pooled = self.text_encoder_2(tokens_2)
         if self.config.text_encoder_2_on_tt:
             embeds_2 = embeds_2.to("cpu")
             pooled = pooled.to("cpu")
+        self._record_encode("text_encoder_2", time.perf_counter() - t0)
         return torch.cat([embeds_1, embeds_2], dim=-1), pooled
+
+    def _record_encode(self, name, elapsed):
+        """The negative prompt's forward: adds to the stage total and is the warm
+        sample, the positive one having carried any build."""
+        perf = getattr(self, "_perf", None)
+        if not perf:
+            return
+        perf["components"][name] = perf["components"].get(name, 0.0) + elapsed
+        perf["warm"][name] = elapsed
 
     def generate(
         self,
@@ -189,6 +202,10 @@ class PlaygroundV25TTPipeline:
             "steps": [],
             "step_metric_name": "unet_step",
             "total": None,
+            # Each text encoder runs twice per call (positive, then negative), so
+            # the two forwards are reported separately as z_image's are.
+            "cold": {},
+            "warm": {},
         }
         t_total_start = time.perf_counter()
 
@@ -218,7 +235,9 @@ class PlaygroundV25TTPipeline:
             prompt_embeds_1 = self.text_encoder(tokens_1)
             if self.config.text_encoder_on_tt:
                 prompt_embeds_1 = prompt_embeds_1.to("cpu")
-            self._perf["components"]["text_encoder_1"] = time.perf_counter() - t0
+            positive = time.perf_counter() - t0
+            self._perf["components"]["text_encoder_1"] = positive
+            self._perf["cold"]["text_encoder_1"] = positive
 
             self._check("text_encoder_1", prompt_embeds_1, tokens_1_cpu)
             logger.info("[STAGE] Text encoder 1: done")
@@ -243,7 +262,9 @@ class PlaygroundV25TTPipeline:
             if self.config.text_encoder_2_on_tt:
                 prompt_embeds_2 = prompt_embeds_2.to("cpu")
                 pooled_prompt_embeds = pooled_prompt_embeds.to("cpu")
-            self._perf["components"]["text_encoder_2"] = time.perf_counter() - t0
+            positive = time.perf_counter() - t0
+            self._perf["components"]["text_encoder_2"] = positive
+            self._perf["cold"]["text_encoder_2"] = positive
 
             self._check(
                 "text_encoder_2",

--- a/playground_v2_5/pytorch/pipeline.py
+++ b/playground_v2_5/pytorch/pipeline.py
@@ -3,26 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 """Playground v2.5 text-to-image pipeline running on Tenstorrent.
 
-Four compute modules run on the TT backend via ``model.compile(backend="tt")``;
-the tokenizers, scheduler and latent bookkeeping stay on CPU:
+Two CLIP text encoders, the UNet (bf16, looped) and the VAE decoder run on the TT
+backend via ``model.compile(backend="tt")``; tokenizers, scheduler and latent
+bookkeeping stay on CPU. It uses classifier-free guidance, so each step is one
+UNet forward over a batch of 2 (uncond, text) split and recombined on the host,
+and its VAE latents are mean/std normalised rather than scaling-factor scaled.
+Every component is placed before its forward and its output cast back with
+``.to("cpu")``, the sync point that ends its timer.
 
-  - CLIP text encoder    (CLIPTextModel)                -> text_encoder_1
-  - CLIP text encoder 2  (CLIPTextModelWithProjection)  -> text_encoder_2
-  - UNet                 (UNet2DConditionModel)         -> looped, bf16
-  - VAE decoder          (AutoencoderKL)                -> vae
+All four are 8.14 GiB of 31.83 (26%) and stay resident, so later calls reuse
+their compiled graphs.
 
-The model uses classifier-free guidance, so each step is one UNet forward over a
-batch of 2 (uncond, text) that is split and recombined on the host. Its VAE
-latents are mean/std normalised rather than plain scaling-factor scaled.
-
-Memory strategy: all four components are 8.14 GiB of 31.83 (26%) and stay
-resident, so later calls reuse their compiled graphs.
-
-This is the reusable implementation that the runnable example
-(``examples/pytorch/playground_v2_5.py``), the benchmark harness
-(``tests/benchmark/test_imagegen.py::test_playground_v2_5``) and the PCC-gated
-e2e (``tests/torch/models/playground_v2_5/``) all consume. Per-component times
-go into ``self._perf`` after each ``generate()``.
+Shared by the example (``examples/pytorch/playground_v2_5.py``), the benchmark
+(``test_imagegen.py::test_playground_v2_5``) and the PCC e2e
+(``tests/torch/models/playground_v2_5/``); per-component times go into ``_perf``.
 """
 
 import time
@@ -88,9 +82,8 @@ class PlaygroundV25TTPipeline:
     def _check(self, name, tt_out, *cpu_inputs):
         """Hook after each component's TT forward. No-op by default.
 
-        The seam the PCC e2e uses: it runs a CPU twin on ``cpu_inputs`` -- the
-        same fp32 tensors the TT component consumed -- outside the traced graph.
-        ``name`` is one of "text_encoder_1", "text_encoder_2", "unet", "vae".
+        The PCC e2e overrides it to run a CPU twin on ``cpu_inputs`` -- the same
+        fp32 tensors the TT component saw -- outside the traced graph.
         """
         return None
 
@@ -100,8 +93,7 @@ class PlaygroundV25TTPipeline:
         self.load_tokenizers()
 
     def load_models(self):
-        # Load on CPU; the move to xla_device happens in generate() right
-        # before the first forward.
+        # Loaded on CPU; placed on device in generate().
         self.text_encoder = ModelLoader(ModelVariant.TEXT_ENCODER).load_model(
             dtype_override=torch.float32
         )
@@ -218,14 +210,12 @@ class PlaygroundV25TTPipeline:
             ).input_ids.to(device="cpu")
             tokens_1_cpu = tokens_1
 
-            # CPU -> TT
             if self.config.text_encoder_on_tt:
                 self.text_encoder = self.text_encoder.to(device)
                 tokens_1 = tokens_1.to(device=device)
 
             t0 = time.perf_counter()
             prompt_embeds_1 = self.text_encoder(tokens_1)
-            # TT -> CPU (cpu cast forces sync -- timer ends after this)
             if self.config.text_encoder_on_tt:
                 prompt_embeds_1 = prompt_embeds_1.to("cpu")
             self._perf["components"]["text_encoder_1"] = time.perf_counter() - t0
@@ -244,14 +234,12 @@ class PlaygroundV25TTPipeline:
             ).input_ids.to(device="cpu")
             tokens_2_cpu = tokens_2
 
-            # CPU -> TT
             if self.config.text_encoder_2_on_tt:
                 self.text_encoder_2 = self.text_encoder_2.to(device)
                 tokens_2 = tokens_2.to(device=device)
 
             t0 = time.perf_counter()
             prompt_embeds_2, pooled_prompt_embeds = self.text_encoder_2(tokens_2)
-            # TT -> CPU (cpu cast forces sync -- timer ends after this)
             if self.config.text_encoder_2_on_tt:
                 prompt_embeds_2 = prompt_embeds_2.to("cpu")
                 pooled_prompt_embeds = pooled_prompt_embeds.to("cpu")
@@ -328,8 +316,7 @@ class PlaygroundV25TTPipeline:
                     latent_model_input, t
                 )
 
-                # CPU -> TT (UNet runs in bf16 on TT). Only sample + timestep
-                # change per step; embeds/time_ids are hoisted above.
+                # Only sample + timestep change per step.
                 if self.config.unet_on_tt:
                     unet_sample = latent_model_input.to(torch.bfloat16).to(device)
                     unet_t = t.to(torch.bfloat16).to(device)
@@ -339,7 +326,6 @@ class PlaygroundV25TTPipeline:
 
                 t0 = time.perf_counter()
                 noise_pred = self.unet(unet_sample, unet_t, unet_eh, unet_te, unet_ti)
-                # TT -> CPU (cpu cast forces sync -- timer ends after this)
                 if self.config.unet_on_tt:
                     noise_pred = noise_pred.to("cpu").to(torch.float32)
                 self._perf["steps"].append(time.perf_counter() - t0)
@@ -390,7 +376,6 @@ class PlaygroundV25TTPipeline:
 
             t0 = time.perf_counter()
             image = self.vae(latents)
-            # TT -> CPU (cpu cast forces sync -- timer ends after this)
             if self.config.vae_on_tt:
                 image = image.to("cpu")
             self._perf["components"]["vae"] = time.perf_counter() - t0

--- a/qwen_image/pytorch/pipeline.py
+++ b/qwen_image/pytorch/pipeline.py
@@ -14,18 +14,18 @@ warmup-then-time loop across ``generate()`` calls would time recompilation.
 Warm is instead measured inside one residency: iteration 1 carries the build,
 2..N are cache hits, and the returned result is always iteration 1's.
 
-Times, per-step times and compile counters land in ``self._perf``.
+Times and per-step times land in ``self._perf``.
 """
 
 import gc
 import time
+from contextlib import contextmanager
 import weakref
 from types import SimpleNamespace
 from typing import Optional
 
 import torch
 import torch_xla
-import torch_xla.debug.metrics as met
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
 from diffusers import QwenImagePipeline as DiffusersQwenImagePipeline
@@ -53,45 +53,19 @@ from .src.model_utils import (
 )
 
 
-def _compile_counters():
-    """``(compile_seconds, graphs_compiled)`` accumulated process-wide so far.
+@contextmanager
+def _staging(perf):
+    """Accumulate host<->device weight movement into ``perf["staging"]``.
 
-    torch-xla's ``CompileTime`` metric is ``[count, total_ns, ...]``, and is
-    absent until the first compile.
+    Placing and evicting is neither a forward nor host bookkeeping. Billed to
+    ``staging_overhead_s`` so ``cpu_overhead_s`` means the same thing here and
+    on a resident pipeline.
     """
-    data = met.metric_data("CompileTime")
-    if not data:
-        return 0.0, 0
-    return (data[1] / 1e9 if len(data) > 1 else 0.0), data[0]
-
-
-class _StageCounters:
-    """Compile time and graph count of one staged residency, as a delta.
-
-    Makes the warm numbers falsifiable: a warm iteration must add zero graphs.
-    """
-
-    def __init__(self, sink, name):
-        self._sink = sink
-        self._name = name
-
-    def __enter__(self):
-        self._t0 = time.perf_counter()
-        self._before = _compile_counters()
-        return self
-
-    def __exit__(self, *exc):
-        after = _compile_counters()
-        self._sink[self._name] = {
-            "wall_s": time.perf_counter() - self._t0,
-            "compile_s": after[0] - self._before[0],
-            "graphs_compiled": after[1] - self._before[1],
-        }
-        return False
-
-
-def _graphs_compiled():
-    return _compile_counters()[1]
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        perf["staging"] = perf.get("staging", 0.0) + (time.perf_counter() - t0)
 
 
 class _DeviceTextEncoder:
@@ -101,20 +75,21 @@ class _DeviceTextEncoder:
     ``dtype`` passthrough.
     """
 
-    def __init__(self, text_encoder, mesh, forward_times):
+    def __init__(self, text_encoder, mesh, forward_times, perf=None):
         self._dev = torch_xla.device()
         # Per forward, in call order; [0] carries the compile.
         self._forward_times = forward_times
         self.dtype = next(text_encoder.parameters()).dtype
         self.config = text_encoder.config
-        text_encoder = text_encoder.to(self._dev)
-        if hasattr(text_encoder, "tie_weights"):
-            text_encoder.tie_weights()
-        # Replicated the encoder is ~16.6 GB/chip and cannot coexist with the
-        # transformer; sharding drops it to ~4 GB/chip.
-        for tensor, spec in shard_text_encoder_specs(text_encoder).items():
-            xs.mark_sharding(tensor, mesh, spec)
-        self._compiled = torch.compile(text_encoder, backend="tt")
+        with _staging(perf if perf is not None else {}):
+            text_encoder = text_encoder.to(self._dev)
+            if hasattr(text_encoder, "tie_weights"):
+                text_encoder.tie_weights()
+            # Replicated the encoder is ~16.6 GB/chip and cannot coexist with the
+            # transformer; sharding drops it to ~4 GB/chip.
+            for tensor, spec in shard_text_encoder_specs(text_encoder).items():
+                xs.mark_sharding(tensor, mesh, spec)
+            self._compiled = torch.compile(text_encoder, backend="tt")
 
     def __call__(self, input_ids, attention_mask=None, output_hidden_states=True):
         t0 = time.perf_counter()
@@ -135,23 +110,23 @@ class _DeviceTextEncoder:
 class _DeviceDenoiser:
     """Transformer on TT (tensor-parallel sharded); one call is one forward."""
 
-    def __init__(self, transformer, mesh, forward_times, graph_counts):
+    def __init__(self, transformer, mesh, forward_times, perf=None):
         self._dev = torch_xla.device()
         self._forward_times = forward_times
-        # Cumulative graphs-compiled after each forward; warm steps must add none.
-        self._graph_counts = graph_counts
+        self._perf = perf if perf is not None else {}
         self.config = transformer.config
         self.dtype = next(transformer.parameters()).dtype
         self.cache_context = transformer.cache_context
         # So free() can report whether the module was actually collected.
         self._module_ref = weakref.ref(transformer)
 
-        transformer = transformer.to(self._dev)
-        if hasattr(transformer, "tie_weights"):
-            transformer.tie_weights()
-        for tensor, spec in shard_transformer_specs(transformer).items():
-            xs.mark_sharding(tensor, mesh, spec)
-        self._compiled = torch.compile(transformer, backend="tt")
+        with _staging(self._perf):
+            transformer = transformer.to(self._dev)
+            if hasattr(transformer, "tie_weights"):
+                transformer.tie_weights()
+            for tensor, spec in shard_transformer_specs(transformer).items():
+                xs.mark_sharding(tensor, mesh, spec)
+            self._compiled = torch.compile(transformer, backend="tt")
 
     def free(self):
         """Release the transformer's device memory; config/dtype stay readable.
@@ -172,7 +147,6 @@ class _DeviceDenoiser:
         (sample,) = self._compiled(**moved)
         sample = sample.cpu()
         self._forward_times.append(time.perf_counter() - t0)
-        self._graph_counts.append(_graphs_compiled())
         return (sample,)
 
 
@@ -185,10 +159,10 @@ class _DeviceVAEDecoder:
     re-expands to 5D so the pipeline's ``decode(...)[0][:, :, 0]`` still reads.
     """
 
-    def __init__(self, vae, perf, warm_iters=1, before_place=None):
+    def __init__(self, vae, perf, warm_iters=0, before_place=None):
         self._dev = torch_xla.device()
         self._perf = perf
-        self._warm_iters = max(1, warm_iters)
+        self._warm_iters = max(0, warm_iters)
         self._before_place = before_place
         self.config = vae.config
         self.dtype = next(vae.parameters()).dtype
@@ -198,35 +172,37 @@ class _DeviceVAEDecoder:
 
     def decode(self, latents, return_dict=False):
         # Denoising is over; evict the transformer before this decode allocates.
-        if self._before_place is not None:
-            self._before_place()
+        with _staging(self._perf):
+            if self._before_place is not None:
+                self._before_place()
+            vae = self._vae.to(self._dev)
+            compiled = torch.compile(
+                lambda z: vae.decode(z, return_dict=False)[0][:, :, 0], backend="tt"
+            )
+            z = latents.to(self._dev)
 
-        vae = self._vae.to(self._dev)
-        compiled = torch.compile(
-            lambda z: vae.decode(z, return_dict=False)[0][:, :, 0], backend="tt"
-        )
-        z = latents.to(self._dev)
+        t0 = time.perf_counter()
+        image = compiled(z).cpu()
+        vae_cold = time.perf_counter() - t0
+        self._perf["components"]["vae"] = vae_cold
+        self._perf["cold"]["vae"] = vae_cold
+        # WARM: no natural second decode, so repeat while still resident.
+        # Outputs are discarded, so the image is unchanged.
+        _warm = []
+        for _ in range(self._warm_iters):
+            _t = time.perf_counter()
+            _extra = compiled(z).cpu()
+            _warm.append(time.perf_counter() - _t)
+            del _extra
+        if _warm:
+            self._perf["warm"]["vae"] = sum(_warm) / len(_warm)
+            self._perf["synthetic"] = self._perf.get("synthetic", 0.0) + sum(_warm)
 
-        # Iteration 1 carries the build, 2..N are cache hits. Decode is pure, so
-        # repeating is safe; the image is always iteration 1's.
-        times = []
-        image = None
-        for i in range(self._warm_iters):
-            t0 = time.perf_counter()
-            out = compiled(z).cpu()
-            times.append(time.perf_counter() - t0)
-            if i == 0:
-                image = out
-
-        self._perf["components"]["vae"] = times[0]
-        self._perf["cold"]["vae"] = times[0]
-        if len(times) > 1:
-            self._perf["warm"]["vae"] = sum(times[1:]) / len(times[1:])
-
-        del compiled, vae, z
-        self._vae = self._vae.to("cpu")
-        gc.collect()
-        torch_xla.sync()
+        with _staging(self._perf):
+            del compiled, vae, z
+            self._vae = self._vae.to("cpu")
+            gc.collect()
+            torch_xla.sync()
 
         self.last_pixels = image
         return (image.unsqueeze(2),)
@@ -238,14 +214,14 @@ class QwenImageConfig:
         height: int = HEIGHT,
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
-        warm_iters: int = 2,
+        warm_iters: int = 1,
     ):
         self.repo_id = REPO_ID
         self.height = height
         self.width = width
         self.max_sequence_length = TOKENIZER_MAX_LENGTH
-        # Forwards repeated inside one residency to expose warm cost; 1 disables
-        # warm measurement. The functional result is iteration 1 either way.
+        # EXTRA in-residency forwards per one-shot component, to get a warm
+        # number while it is still on device. 0 = inert. Same meaning as flux2.
         self.warm_iters = warm_iters
         # Applied globally by the caller; carried here for reference.
         self.compile_options = compile_options or {}
@@ -258,6 +234,11 @@ class QwenImagePipeline:
     turn per ``generate()``. A second ``generate()`` recompiles everything and is
     NOT a warm pass -- see the module docstring.
     """
+
+    # Every component is freed inside generate(), which discards its compiled
+    # graph, so a second call would rebuild. The harness runs a single call and
+    # takes warm cost from the in-residency repeats.
+    benchmark_staged_residency = True
 
     # Overridable so a test can subclass in PCC checks without duplicating the
     # staging logic (tt-xla tests/torch/models/qwen_image/test_pipeline.py).
@@ -278,12 +259,12 @@ class QwenImagePipeline:
             # cache-hit iterations, taken while the component was still resident.
             "cold": {},
             "warm": {},
-            # Per-stage compile time and graph count.
-            "counters": {},
+            # Device work that is not a forward; neither belongs in host overhead.
+            "staging": 0.0,
+            "synthetic": 0.0,
         }
         # Raw per-forward times; collapsed into per-step entries in generate().
         self._forward_times = []
-        self._graph_counts = []
         self._encode_times = []
         self._denoiser = None
 
@@ -329,33 +310,32 @@ class QwenImagePipeline:
         """Place the sharded text encoder, encode both prompts, then evict it."""
         logger.info("[STAGE] text_encoder (sharded): start")
         self._encode_times.clear()
-        with _StageCounters(self._perf["counters"], "text_encoder"):
-            text_encoder = load_text_encoder(DTYPE)
-            self.pipe.text_encoder = self.TEXT_ENCODER_CLS(
-                text_encoder, self.mesh, self._encode_times
-            )
+        text_encoder = load_text_encoder(DTYPE)
+        self.pipe.text_encoder = self.TEXT_ENCODER_CLS(
+            text_encoder, self.mesh, self._encode_times, self._perf
+        )
 
-            # The masked-embedding extraction downstream runs on host.
-            cpu = torch.device("cpu")
-            t0 = time.perf_counter()
-            prompt_embeds, prompt_embeds_mask = self.pipe.encode_prompt(
-                prompt=prompt + POSITIVE_MAGIC,
-                device=cpu,
-                num_images_per_prompt=1,
-                max_sequence_length=self.config.max_sequence_length,
-            )
-            # Same padded shape, so this second forward reuses the graph: it is
-            # the encoder's warm sample, taken while it is still resident.
-            (
-                negative_prompt_embeds,
-                negative_prompt_embeds_mask,
-            ) = self.pipe.encode_prompt(
-                prompt=NEGATIVE_PROMPT,
-                device=cpu,
-                num_images_per_prompt=1,
-                max_sequence_length=self.config.max_sequence_length,
-            )
-            elapsed = time.perf_counter() - t0
+        # The masked-embedding extraction downstream runs on host.
+        cpu = torch.device("cpu")
+        t0 = time.perf_counter()
+        prompt_embeds, prompt_embeds_mask = self.pipe.encode_prompt(
+            prompt=prompt + POSITIVE_MAGIC,
+            device=cpu,
+            num_images_per_prompt=1,
+            max_sequence_length=self.config.max_sequence_length,
+        )
+        # Same padded shape, so this second forward reuses the graph: it is
+        # the encoder's warm sample, taken while it is still resident.
+        (
+            negative_prompt_embeds,
+            negative_prompt_embeds_mask,
+        ) = self.pipe.encode_prompt(
+            prompt=NEGATIVE_PROMPT,
+            device=cpu,
+            num_images_per_prompt=1,
+            max_sequence_length=self.config.max_sequence_length,
+        )
+        elapsed = time.perf_counter() - t0
 
         if self._encode_times:
             self._perf["cold"]["text_encoder"] = self._encode_times[0]
@@ -366,10 +346,11 @@ class QwenImagePipeline:
         # Dropped before the transformer is placed. Verified, not assumed: the
         # later decode fails on DRAM contiguity by only ~20 MB.
         encoder_ref = weakref.ref(text_encoder)
-        self.pipe.text_encoder = None
-        del text_encoder
-        gc.collect()
-        torch_xla.sync()
+        with _staging(self._perf):
+            self.pipe.text_encoder = None
+            del text_encoder
+            gc.collect()
+            torch_xla.sync()
         if encoder_ref() is None:
             logger.info("[STAGE] text_encoder: done (module collected)")
         else:
@@ -396,9 +377,9 @@ class QwenImagePipeline:
         self._perf["steps"].clear()
         self._perf["cold"].clear()
         self._perf["warm"].clear()
-        self._perf["counters"].clear()
+        self._perf["staging"] = 0.0
+        self._perf["synthetic"] = 0.0
         self._forward_times.clear()
-        self._graph_counts.clear()
         self._perf["total"] = None
         t_total_start = time.perf_counter()
 
@@ -409,15 +390,16 @@ class QwenImagePipeline:
 
         # Release the previous call's transformer first, so two never coexist on
         # device while the new one is being placed.
-        self._denoiser = None
-        self.pipe.transformer = None
-        gc.collect()
+        with _staging(self._perf):
+            self._denoiser = None
+            self.pipe.transformer = None
+            gc.collect()
         torch_xla.sync()
 
         # Loaded fresh, then freed before the VAE is placed.
         transformer = load_transformer(DTYPE)
         self._denoiser = self.DENOISER_CLS(
-            transformer, self.mesh, self._forward_times, self._graph_counts
+            transformer, self.mesh, self._forward_times, self._perf
         )
         self.pipe.transformer = self._denoiser
         del transformer
@@ -443,30 +425,30 @@ class QwenImagePipeline:
             num_inference_steps,
         )
         generator = torch.Generator().manual_seed(seed) if seed is not None else None
-        with _StageCounters(self._perf["counters"], "transformer_and_vae"):
-            self.pipe(
-                prompt=None,
-                negative_prompt=None,
-                prompt_embeds=prompt_embeds,
-                prompt_embeds_mask=prompt_embeds_mask,
-                negative_prompt_embeds=negative_prompt_embeds,
-                negative_prompt_embeds_mask=negative_prompt_embeds_mask,
-                height=self.config.height,
-                width=self.config.width,
-                num_inference_steps=num_inference_steps,
-                true_cfg_scale=TRUE_CFG_SCALE,
-                generator=generator,
-            )
+        self.pipe(
+            prompt=None,
+            negative_prompt=None,
+            prompt_embeds=prompt_embeds,
+            prompt_embeds_mask=prompt_embeds_mask,
+            negative_prompt_embeds=negative_prompt_embeds,
+            negative_prompt_embeds_mask=negative_prompt_embeds_mask,
+            height=self.config.height,
+            width=self.config.width,
+            num_inference_steps=num_inference_steps,
+            true_cfg_scale=TRUE_CFG_SCALE,
+            generator=generator,
+        )
         logger.info("[STAGE] transformer + vae: done")
 
         pixels = vae_wrapper.last_pixels
 
         # The VAE freed itself at the end of its decode, so generate() returns
         # with nothing resident.
-        self.pipe.vae = None
-        del vae_wrapper
-        gc.collect()
-        torch_xla.sync()
+        with _staging(self._perf):
+            self.pipe.vae = None
+            del vae_wrapper
+            gc.collect()
+            torch_xla.sync()
         logger.info("[STAGE] vae: freed -- no component resident")
 
         per_step = 2 if TRUE_CFG_SCALE > 1.0 else 1
@@ -474,29 +456,6 @@ class QwenImagePipeline:
             sum(self._forward_times[i : i + per_step])
             for i in range(0, len(self._forward_times), per_step)
         )
-        # Step 1 carries the compile; 2..N are cache hits taken while the
-        # transformer is resident.
-        steps = self._perf["steps"]
-        if steps:
-            self._perf["cold"]["transformer_step"] = steps[0]
-            if len(steps) > 1:
-                self._perf["warm"]["transformer_step"] = sum(steps[1:]) / (
-                    len(steps) - 1
-                )
-
-        # Diagnostic only; warm is established by the in-residency repeats.
-        counts = self._graph_counts
-        if len(counts) > per_step:
-            self._perf["counters"]["warm_steps"] = {
-                "graphs_compiled": counts[-1] - counts[per_step - 1]
-            }
-        logger.info(
-            "[COUNTERS] text_encoder={} | transformer+vae={} | denoise graph curve={}",
-            self._perf["counters"].get("text_encoder"),
-            self._perf["counters"].get("transformer_and_vae"),
-            counts[: min(len(counts), 6)],
-        )
-
         self._perf["total"] = time.perf_counter() - t_total_start
         return pixels
 

--- a/qwen_image/pytorch/pipeline.py
+++ b/qwen_image/pytorch/pipeline.py
@@ -221,7 +221,7 @@ class QwenImageConfig:
         self.width = width
         self.max_sequence_length = TOKENIZER_MAX_LENGTH
         # EXTRA in-residency forwards per one-shot component, to get a warm
-        # number while it is still on device. 0 = inert. Same meaning as flux2.
+        # number while it is still on device. 0 = inert.
         self.warm_iters = warm_iters
         # Applied globally by the caller; carried here for reference.
         self.compile_options = compile_options or {}

--- a/qwen_image/pytorch/pipeline.py
+++ b/qwen_image/pytorch/pipeline.py
@@ -19,8 +19,8 @@ Times and per-step times land in ``self._perf``.
 
 import gc
 import time
-from contextlib import contextmanager
 import weakref
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Optional
 
@@ -214,7 +214,7 @@ class QwenImageConfig:
         height: int = HEIGHT,
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
-        warm_iters: int = 1,
+        warm_iters: int = 0,
     ):
         self.repo_id = REPO_ID
         self.height = height

--- a/qwen_image/pytorch/pipeline.py
+++ b/qwen_image/pytorch/pipeline.py
@@ -240,8 +240,8 @@ class QwenImagePipeline:
     # takes warm cost from the in-residency repeats.
     benchmark_staged_residency = True
 
-    # Overridable so a test can subclass in PCC checks without duplicating the
-    # staging logic (tt-xla tests/torch/models/qwen_image/test_pipeline.py).
+    # Swapped by the PCC e2e for checking subclasses; generate() uses these
+    # attributes, not the classes directly.
     TEXT_ENCODER_CLS = _DeviceTextEncoder
     DENOISER_CLS = _DeviceDenoiser
     VAE_CLS = _DeviceVAEDecoder

--- a/sdxl_lightning/pytorch/pipeline.py
+++ b/sdxl_lightning/pytorch/pipeline.py
@@ -9,8 +9,10 @@ bookkeeping stay on CPU. It is a 4-step distilled model without CFG, so each ste
 is one UNet forward. Every component is placed before its forward and its output
 cast back with ``.to("cpu")``, the sync point that ends its timer.
 
-All four are 8.14 GiB of 31.83 (26%) and stay resident, so later calls reuse
-their compiled graphs.
+All four are 8.14 GiB and stay resident, so later calls reuse their compiled
+graphs. That is 26% of a Blackhole part's 31.83 GiB but ~68% of a Wormhole
+n150's 12 GiB, so the benchmark is pinned to p150-perf; running it on Wormhole
+would mean going back to evicting one component at a time.
 
 Shared by the example (``examples/pytorch/sdxl_lightning.py``), the benchmark
 (``test_imagegen.py::test_sdxl_lightning``) and the PCC e2e

--- a/sdxl_lightning/pytorch/pipeline.py
+++ b/sdxl_lightning/pytorch/pipeline.py
@@ -3,25 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """SDXL-Lightning text-to-image pipeline running on Tenstorrent.
 
-Four compute modules run on the TT backend via ``model.compile(backend="tt")``;
-the tokenizers, scheduler and latent bookkeeping stay on CPU:
+Two CLIP text encoders, the UNet (bf16, looped) and the VAE decoder run on the TT
+backend via ``model.compile(backend="tt")``; tokenizers, scheduler and latent
+bookkeeping stay on CPU. It is a 4-step distilled model without CFG, so each step
+is one UNet forward. Every component is placed before its forward and its output
+cast back with ``.to("cpu")``, the sync point that ends its timer.
 
-  - CLIP text encoder    (CLIPTextModel)                → text_encoder_1
-  - CLIP text encoder 2  (CLIPTextModelWithProjection)  → text_encoder_2
-  - UNet                 (UNet2DConditionModel)         → looped, bf16
-  - VAE decoder          (AutoencoderKL)                → vae
+All four are 8.14 GiB of 31.83 (26%) and stay resident, so later calls reuse
+their compiled graphs.
 
-SDXL-Lightning is a 4-step distilled model and runs without CFG (batch stays 1),
-so each step is a single UNet forward.
-
-Memory strategy: all four components are 8.14 GiB of 31.83 (26%) and stay
-resident, so later calls reuse their compiled graphs.
-
-This is the reusable implementation that the runnable example
-(``examples/pytorch/sdxl_lightning.py``), the benchmark harness
-(``tests/benchmark/test_imagegen.py::test_sdxl_lightning``) and the PCC-gated
-e2e (``tests/torch/models/sdxl_lightning/``) all consume. Per-component times go
-into ``self._perf`` after each ``generate()``.
+Shared by the example (``examples/pytorch/sdxl_lightning.py``), the benchmark
+(``test_imagegen.py::test_sdxl_lightning``) and the PCC e2e
+(``tests/torch/models/sdxl_lightning/``); per-component times go into ``_perf``.
 """
 
 import time
@@ -85,9 +78,8 @@ class SDXLLightningTTPipeline:
     def _check(self, name, tt_out, *cpu_inputs):
         """Hook after each component's TT forward. No-op by default.
 
-        The seam the PCC e2e uses: it runs a CPU twin on ``cpu_inputs`` -- the
-        same fp32 tensors the TT component consumed -- outside the traced graph.
-        ``name`` is one of "text_encoder_1", "text_encoder_2", "unet", "vae".
+        The PCC e2e overrides it to run a CPU twin on ``cpu_inputs`` -- the same
+        fp32 tensors the TT component saw -- outside the traced graph.
         """
         return None
 
@@ -97,8 +89,7 @@ class SDXLLightningTTPipeline:
         self.load_tokenizers()
 
     def load_models(self):
-        # Load on CPU; the move to xla_device happens in generate() right
-        # before the first forward.
+        # Loaded on CPU; placed on device in generate().
         self.text_encoder = ModelLoader(ModelVariant.TEXT_ENCODER).load_model(
             dtype_override=torch.float32
         )
@@ -183,14 +174,12 @@ class SDXLLightningTTPipeline:
             ).input_ids.to(device="cpu")
             tokens_1_cpu = tokens_1
 
-            # CPU → TT
             if self.config.text_encoder_on_tt:
                 self.text_encoder = self.text_encoder.to(device)
                 tokens_1 = tokens_1.to(device=device)
 
             t0 = time.perf_counter()
             prompt_embeds_1 = self.text_encoder(tokens_1)
-            # TT → CPU (cpu cast forces sync — timer ends after this)
             if self.config.text_encoder_on_tt:
                 prompt_embeds_1 = prompt_embeds_1.to("cpu")
             self._perf["components"]["text_encoder_1"] = time.perf_counter() - t0
@@ -209,14 +198,12 @@ class SDXLLightningTTPipeline:
             ).input_ids.to(device="cpu")
             tokens_2_cpu = tokens_2
 
-            # CPU → TT
             if self.config.text_encoder_2_on_tt:
                 self.text_encoder_2 = self.text_encoder_2.to(device)
                 tokens_2 = tokens_2.to(device=device)
 
             t0 = time.perf_counter()
             prompt_embeds_2, pooled_prompt_embeds = self.text_encoder_2(tokens_2)
-            # TT → CPU (cpu cast forces sync — timer ends after this)
             if self.config.text_encoder_2_on_tt:
                 prompt_embeds_2 = prompt_embeds_2.to("cpu")
                 pooled_prompt_embeds = pooled_prompt_embeds.to("cpu")
@@ -276,8 +263,7 @@ class SDXLLightningTTPipeline:
 
                 latent_model_input = self.scheduler.scale_model_input(latents, t)
 
-                # CPU → TT (UNet runs in bf16 on TT). Only sample + timestep
-                # change per step; embeds/time_ids are hoisted above.
+                # Only sample + timestep change per step.
                 if self.config.unet_on_tt:
                     unet_sample = latent_model_input.to(torch.bfloat16).to(device)
                     unet_t = t.to(torch.bfloat16).to(device)
@@ -287,7 +273,6 @@ class SDXLLightningTTPipeline:
 
                 t0 = time.perf_counter()
                 noise_pred = self.unet(unet_sample, unet_t, unet_eh, unet_te, unet_ti)
-                # TT → CPU (cpu cast forces sync — timer ends after this)
                 if self.config.unet_on_tt:
                     noise_pred = noise_pred.to("cpu").to(torch.float32)
                 self._perf["steps"].append(time.perf_counter() - t0)
@@ -324,7 +309,6 @@ class SDXLLightningTTPipeline:
 
             t0 = time.perf_counter()
             image = self.vae(latents)
-            # TT → CPU (cpu cast forces sync — timer ends after this)
             if self.config.vae_on_tt:
                 image = image.to("cpu")
             self._perf["components"]["vae"] = time.perf_counter() - t0

--- a/sdxl_lightning/pytorch/pipeline.py
+++ b/sdxl_lightning/pytorch/pipeline.py
@@ -299,7 +299,7 @@ class SDXLLightningTTPipeline:
             latents_cpu = latents
 
             # opt_level=1 (composite ttnn.group_norm) is only needed when the VAE
-            # runs on TT; by default it runs on CPU.
+            # runs on TT, which is the default.
             if self.config.vae_on_tt:
                 torch_xla.set_custom_compile_options(
                     {**self.config.compile_options, "optimization_level": 1}

--- a/sdxl_lightning/pytorch/pipeline.py
+++ b/sdxl_lightning/pytorch/pipeline.py
@@ -71,8 +71,7 @@ class SDXLLightningTTPipeline:
     """SDXL-Lightning with every module on a single TT chip.
 
     Built once with ``setup()``; ``generate()`` can be called repeatedly. Each
-    module is placed on first use and kept on device, so later calls reuse its
-    compiled graph.
+    module is kept on device, so later calls reuse its compiled graph.
     """
 
     # Components stay resident, so a second generate() is genuinely warm and the
@@ -87,9 +86,7 @@ class SDXLLightningTTPipeline:
         """Hook after each component's TT forward. No-op by default.
 
         The seam the PCC e2e uses: it runs a CPU twin on ``cpu_inputs`` -- the
-        same fp32 tensors the TT component consumed -- and asserts on PCC. Kept
-        outside the component so the comparison never enters a traced graph.
-
+        same fp32 tensors the TT component consumed -- outside the traced graph.
         ``name`` is one of "text_encoder_1", "text_encoder_2", "unet", "vae".
         """
         return None
@@ -100,8 +97,8 @@ class SDXLLightningTTPipeline:
         self.load_tokenizers()
 
     def load_models(self):
-        # Load on CPU and only register the "tt" dynamo backend here; the move
-        # to xla_device happens in generate() right before the first forward.
+        # Load on CPU; the move to xla_device happens in generate() right
+        # before the first forward.
         self.text_encoder = ModelLoader(ModelVariant.TEXT_ENCODER).load_model(
             dtype_override=torch.float32
         )

--- a/sdxl_lightning/pytorch/pipeline.py
+++ b/sdxl_lightning/pytorch/pipeline.py
@@ -1,0 +1,351 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""SDXL-Lightning text-to-image pipeline running on Tenstorrent.
+
+Four compute modules run on the TT backend via ``model.compile(backend="tt")``;
+the tokenizers, scheduler and latent bookkeeping stay on CPU:
+
+  - CLIP text encoder    (CLIPTextModel)                → text_encoder_1
+  - CLIP text encoder 2  (CLIPTextModelWithProjection)  → text_encoder_2
+  - UNet                 (UNet2DConditionModel)         → looped, bf16
+  - VAE decoder          (AutoencoderKL)                → vae
+
+SDXL-Lightning is a 4-step distilled model and runs without CFG (batch stays 1),
+so each step is a single UNet forward.
+
+Memory strategy: all four components are 8.14 GiB of 31.83 (26%) and stay
+resident, so later calls reuse their compiled graphs.
+
+This is the reusable implementation that the runnable example
+(``examples/pytorch/sdxl_lightning.py``), the benchmark harness
+(``tests/benchmark/test_imagegen.py::test_sdxl_lightning``) and the PCC-gated
+e2e (``tests/torch/models/sdxl_lightning/``) all consume. Per-component times go
+into ``self._perf`` after each ``generate()``.
+"""
+
+import time
+from typing import Optional
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+from diffusers import EulerDiscreteScheduler
+from loguru import logger
+from PIL import Image
+from transformers import CLIPTokenizer
+
+from .loader import ModelLoader, ModelVariant
+from .src.model_utils import HEIGHT, SDXL_BASE_REPO_ID, VAE_SCALE, WIDTH
+
+PROMPT = "A girl smiling"
+SEED = 42
+NUM_INFERENCE_STEPS = 4
+
+
+class SDXLLightningConfig:
+    def __init__(
+        self,
+        text_encoder_on_tt: bool = True,
+        text_encoder_2_on_tt: bool = True,
+        unet_on_tt: bool = True,
+        vae_on_tt: bool = True,
+        compile_options: Optional[dict] = None,
+    ):
+        self.model_id = SDXL_BASE_REPO_ID
+        self.width = WIDTH
+        self.height = HEIGHT
+        self.vae_scale_factor = VAE_SCALE
+        self.latents_width = self.width // self.vae_scale_factor
+        self.latents_height = self.height // self.vae_scale_factor
+        self.text_encoder_on_tt = text_encoder_on_tt
+        self.text_encoder_2_on_tt = text_encoder_2_on_tt
+        self.unet_on_tt = unet_on_tt
+        self.vae_on_tt = vae_on_tt
+        # Harness-set compile options; merged with the VAE-only opt_level bump
+        # in generate() (only relevant if vae_on_tt is True).
+        self.compile_options = compile_options or {}
+
+
+class SDXLLightningTTPipeline:
+    """SDXL-Lightning with every module on a single TT chip.
+
+    Built once with ``setup()``; ``generate()`` can be called repeatedly. Each
+    module is placed on first use and kept on device, so later calls reuse its
+    compiled graph.
+    """
+
+    # Components stay resident, so a second generate() is genuinely warm and the
+    # harness runs its normal warmup + steady pair.
+    benchmark_staged_residency = False
+
+    def __init__(self, config: SDXLLightningConfig):
+        self.config = config
+        self._perf = {}
+
+    def _check(self, name, tt_out, *cpu_inputs):
+        """Hook after each component's TT forward. No-op by default.
+
+        The seam the PCC e2e uses: it runs a CPU twin on ``cpu_inputs`` -- the
+        same fp32 tensors the TT component consumed -- and asserts on PCC. Kept
+        outside the component so the comparison never enters a traced graph.
+
+        ``name`` is one of "text_encoder_1", "text_encoder_2", "unet", "vae".
+        """
+        return None
+
+    def setup(self):
+        self.load_models()
+        self.load_scheduler()
+        self.load_tokenizers()
+
+    def load_models(self):
+        # Load on CPU and only register the "tt" dynamo backend here; the move
+        # to xla_device happens in generate() right before the first forward.
+        self.text_encoder = ModelLoader(ModelVariant.TEXT_ENCODER).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.text_encoder_on_tt:
+            self.text_encoder.compile(backend="tt")
+
+        self.text_encoder_2 = ModelLoader(ModelVariant.TEXT_ENCODER_2).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.text_encoder_2_on_tt:
+            self.text_encoder_2.compile(backend="tt")
+
+        # UNet runs in bf16 on TT to fit DRAM (fp32 weights ~10.3 GB).
+        unet_dtype = torch.bfloat16 if self.config.unet_on_tt else torch.float32
+        self.unet = ModelLoader(ModelVariant.UNET).load_model(dtype_override=unet_dtype)
+        if self.config.unet_on_tt:
+            self.unet.compile(backend="tt")
+
+        self.vae = ModelLoader(ModelVariant.VAE).load_model(
+            dtype_override=torch.float32
+        )
+        if self.config.vae_on_tt:
+            self.vae.compile(backend="tt")
+
+    def load_scheduler(self):
+        # SDXL-Lightning requires Euler with "trailing" timestep spacing.
+        self.scheduler = EulerDiscreteScheduler.from_pretrained(
+            self.config.model_id, subfolder="scheduler", timestep_spacing="trailing"
+        )
+
+    def load_tokenizers(self):
+        self.tokenizer = CLIPTokenizer.from_pretrained(
+            self.config.model_id, subfolder="tokenizer"
+        )
+        self.tokenizer_2 = CLIPTokenizer.from_pretrained(
+            self.config.model_id, subfolder="tokenizer_2"
+        )
+
+    def _get_add_time_ids(self, dtype):
+        original_size = (self.config.height, self.config.width)
+        crops_coords_top_left = (0, 0)
+        target_size = (self.config.height, self.config.width)
+        add_time_ids = list(original_size + crops_coords_top_left + target_size)
+        return torch.tensor([add_time_ids], dtype=dtype)
+
+    def generate(
+        self,
+        prompt: str = PROMPT,
+        num_inference_steps: int = NUM_INFERENCE_STEPS,
+        seed: Optional[int] = SEED,
+    ) -> torch.Tensor:
+        """End-to-end generation. Returns pixels in [-1, 1], shape (1, 3, H, W)."""
+        assert isinstance(
+            prompt, str
+        ), "Only single-prompt generation (batch_size=1) is tested for now"
+        batch_size = 1
+
+        device = xm.xla_device()
+        self._perf = {
+            "components": {},
+            "steps": [],
+            "step_metric_name": "unet_step",
+            "total": None,
+        }
+        t_total_start = time.perf_counter()
+
+        with torch.no_grad():
+            generator = torch.Generator(device="cpu")
+            if seed is not None:
+                generator.manual_seed(seed)
+            else:
+                generator.seed()
+
+            # ── Text encoder 1 (CLIPTextModel) ────────────────────────────
+            logger.info("[STAGE] Text encoder 1: start")
+            tokens_1 = self.tokenizer(
+                [prompt],
+                padding="max_length",
+                max_length=self.tokenizer.model_max_length,
+                truncation=True,
+                return_tensors="pt",
+            ).input_ids.to(device="cpu")
+            tokens_1_cpu = tokens_1
+
+            # CPU → TT
+            if self.config.text_encoder_on_tt:
+                self.text_encoder = self.text_encoder.to(device)
+                tokens_1 = tokens_1.to(device=device)
+
+            t0 = time.perf_counter()
+            prompt_embeds_1 = self.text_encoder(tokens_1)
+            # TT → CPU (cpu cast forces sync — timer ends after this)
+            if self.config.text_encoder_on_tt:
+                prompt_embeds_1 = prompt_embeds_1.to("cpu")
+            self._perf["components"]["text_encoder_1"] = time.perf_counter() - t0
+
+            self._check("text_encoder_1", prompt_embeds_1, tokens_1_cpu)
+            logger.info("[STAGE] Text encoder 1: done")
+
+            # ── Text encoder 2 (CLIPTextModelWithProjection) ──────────────
+            logger.info("[STAGE] Text encoder 2: start")
+            tokens_2 = self.tokenizer_2(
+                [prompt],
+                padding="max_length",
+                max_length=self.tokenizer_2.model_max_length,
+                truncation=True,
+                return_tensors="pt",
+            ).input_ids.to(device="cpu")
+            tokens_2_cpu = tokens_2
+
+            # CPU → TT
+            if self.config.text_encoder_2_on_tt:
+                self.text_encoder_2 = self.text_encoder_2.to(device)
+                tokens_2 = tokens_2.to(device=device)
+
+            t0 = time.perf_counter()
+            prompt_embeds_2, pooled_prompt_embeds = self.text_encoder_2(tokens_2)
+            # TT → CPU (cpu cast forces sync — timer ends after this)
+            if self.config.text_encoder_2_on_tt:
+                prompt_embeds_2 = prompt_embeds_2.to("cpu")
+                pooled_prompt_embeds = pooled_prompt_embeds.to("cpu")
+            self._perf["components"]["text_encoder_2"] = time.perf_counter() - t0
+
+            self._check(
+                "text_encoder_2",
+                (prompt_embeds_2, pooled_prompt_embeds),
+                tokens_2_cpu,
+            )
+            logger.info("[STAGE] Text encoder 2: done")
+
+            # Concat the two encoders' hidden states (no CFG: batch stays 1).
+            prompt_embeds = torch.cat([prompt_embeds_1, prompt_embeds_2], dim=-1)
+            add_text_embeds = pooled_prompt_embeds  # (1, 1280)
+
+            add_time_ids = self._get_add_time_ids(prompt_embeds.dtype).to(
+                "cpu"
+            )  # (1, 6)
+
+            # ── Timesteps ─────────────────────────────────────────────────
+            self.scheduler.set_timesteps(num_inference_steps, device="cpu")
+            timesteps = self.scheduler.timesteps
+
+            # ── Latents ───────────────────────────────────────────────────
+            latent_shape = (
+                batch_size,
+                4,
+                self.config.latents_height,
+                self.config.latents_width,
+            )
+            latents = torch.randn(
+                latent_shape, generator=generator, dtype=torch.float32
+            ).to(device="cpu")
+            latents = latents * self.scheduler.init_noise_sigma
+
+            # ── Denoising loop (UNet, no CFG) ─────────────────────────────
+            logger.info(
+                f"[STAGE] UNet denoising loop: start ({num_inference_steps} steps)"
+            )
+            # Move the UNet to TT once, before the loop.
+            if self.config.unet_on_tt:
+                self.unet = self.unet.to(device)
+
+            # Loop-invariant inputs: convert once, reuse across all steps.
+            if self.config.unet_on_tt:
+                unet_eh = prompt_embeds.to(torch.bfloat16).to(device)
+                unet_te = add_text_embeds.to(torch.bfloat16).to(device)
+                unet_ti = add_time_ids.to(torch.bfloat16).to(device)
+            else:
+                unet_eh = prompt_embeds
+                unet_te = add_text_embeds
+                unet_ti = add_time_ids
+
+            for i, t in enumerate(timesteps):
+                logger.info(f"[STEP] UNet step {i + 1}/{num_inference_steps}")
+
+                latent_model_input = self.scheduler.scale_model_input(latents, t)
+
+                # CPU → TT (UNet runs in bf16 on TT). Only sample + timestep
+                # change per step; embeds/time_ids are hoisted above.
+                if self.config.unet_on_tt:
+                    unet_sample = latent_model_input.to(torch.bfloat16).to(device)
+                    unet_t = t.to(torch.bfloat16).to(device)
+                else:
+                    unet_sample = latent_model_input
+                    unet_t = t
+
+                t0 = time.perf_counter()
+                noise_pred = self.unet(unet_sample, unet_t, unet_eh, unet_te, unet_ti)
+                # TT → CPU (cpu cast forces sync — timer ends after this)
+                if self.config.unet_on_tt:
+                    noise_pred = noise_pred.to("cpu").to(torch.float32)
+                self._perf["steps"].append(time.perf_counter() - t0)
+
+                self._check(
+                    "unet",
+                    noise_pred,
+                    latent_model_input,
+                    t,
+                    prompt_embeds,
+                    add_text_embeds,
+                    add_time_ids,
+                )
+
+                # No CFG combine (guidance_scale=0): use noise_pred directly.
+                latents = self.scheduler.step(
+                    noise_pred, t, latents, return_dict=False
+                )[0]
+            logger.info("[STAGE] UNet denoising loop: done")
+
+            # ── VAE decode (standard SDXL: divide by scaling_factor) ──────
+            logger.info("[STAGE] VAE decode: start")
+            latents = latents / self.vae.vae.config.scaling_factor
+            latents_cpu = latents
+
+            # opt_level=1 (composite ttnn.group_norm) is only needed when the VAE
+            # runs on TT; by default it runs on CPU.
+            if self.config.vae_on_tt:
+                torch_xla.set_custom_compile_options(
+                    {**self.config.compile_options, "optimization_level": 1}
+                )
+                self.vae = self.vae.to(device)
+                latents = latents.to(device)
+
+            t0 = time.perf_counter()
+            image = self.vae(latents)
+            # TT → CPU (cpu cast forces sync — timer ends after this)
+            if self.config.vae_on_tt:
+                image = image.to("cpu")
+            self._perf["components"]["vae"] = time.perf_counter() - t0
+
+            self._check("vae", image, latents_cpu)
+            logger.info("[STAGE] VAE decode: done")
+
+            self._perf["total"] = time.perf_counter() - t_total_start
+            return image
+
+
+def save_image(image: torch.Tensor, filepath: str = "output.png"):
+    """Rescale ([-1,1]→[0,255]), reshape and save the pipeline output as PNG."""
+    image = (
+        (torch.clamp(image / 2 + 0.5, 0.0, 1.0) * 255.0).round().to(dtype=torch.uint8)
+    )
+    image_np = image.cpu().squeeze().numpy()
+    assert image_np.ndim == 3, "Image must be 3D"
+    if image_np.shape[0] == 3:
+        image_np = image_np.transpose(1, 2, 0)
+    Image.fromarray(image_np).save(filepath)

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -176,6 +176,27 @@ class ZImageConfig:
         self.vae_tiling = vae_tiling
 
 
+def _populate_rope_cache(transformer, device) -> None:
+    """Build the RoPE frequency table BEFORE compiling, not on first forward.
+
+    ``diffusers`` RopeEmbedder.__call__ does ``if self.freqs_cis is None:`` and
+    fills the cache on first use (transformer_z_image.py:344). The first forward
+    therefore compiles under a "freqs_cis is None" guard that the SAME forward
+    then falsifies, so the next forward rebuilds -- measured as the unexplained
+    +3 graphs on denoise step 2. Precomputing is deterministic and produces the
+    identical table, so the output is unchanged; it only moves the work out of
+    the traced region. Guarded by hasattr so a diffusers version without this
+    attribute is a silent no-op rather than a crash.
+    """
+    rope = getattr(transformer, "rope_embedder", None)
+    if rope is None or getattr(rope, "freqs_cis", None) is not None:
+        return
+    if not hasattr(rope, "precompute_freqs_cis"):
+        return
+    freqs = rope.precompute_freqs_cis(rope.axes_dims, rope.axes_lens, theta=rope.theta)
+    rope.freqs_cis = [f.to(device) for f in freqs]
+
+
 class ZImageTTPipeline:
     """Z-Image text-to-image pipeline with every module on a single TT chip.
 
@@ -221,6 +242,28 @@ class ZImageTTPipeline:
             self.config.repo_id, subfolder="scheduler"
         )
         self._device = torch_xla.device()
+        self._freeze_model_output_registry()
+
+    @staticmethod
+    def _freeze_model_output_registry():
+        """Import every model class up front so no LATER import can invalidate an
+        already-compiled graph.
+
+        transformers registers each ``ModelOutput`` subclass as a pytree node in
+        ``__init_subclass__`` (utils/generic.py:375), i.e. at IMPORT time, and
+        dynamo bakes ``len(_registered_model_output_types) == N`` into the guards
+        of anything compiled while the module is traced. Staged residency loads
+        each component lazily inside generate(), so the transformer's and VAE's
+        imports grow that set AFTER the text encoder has compiled -- and the
+        encoder's next forward then fails the guard and rebuilds (measured: one
+        rebuild, 52.7s against a 0.9s warm forward).
+
+        Importing costs no weights and no device memory, so this does not affect
+        the staging strategy. Models that load everything before compiling (e.g.
+        HunyuanImage-2.1) never hit this; it is specific to lazy staging.
+        """
+        from diffusers import AutoencoderKL, ZImageTransformer2DModel  # noqa: F401
+        from transformers import Qwen3Model  # noqa: F401
 
     def _encode(self, prompt: str, encoder) -> torch.Tensor:
         input_ids, attention_mask = tokenize_prompt(prompt)
@@ -331,6 +374,7 @@ class ZImageTTPipeline:
             logger.info("[STAGE] transformer: start ({} steps)", num_inference_steps)
             transformer = self.TRANSFORMER_CLS(load_transformer(DTYPE)).eval()
             transformer = transformer.to(self._device)
+            _populate_rope_cache(transformer.transformer, self._device)
             tf_compiled = self._intercept(
                 "transformer", torch.compile(transformer, backend="tt")
             )

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -174,13 +174,10 @@ class ZImageConfig:
         # tokenize_prompt, so the same graph), and the shipped code merely summed
         # them into one timer.
         self.warm_iters = warm_iters
-        # Keep each component on device between calls. Measured co-resident:
-        # 23.221 GiB of 31.83 (73.0%) with no OOM. Evicting discards the compiled
-        # graph along with the weights, so every later call rebuilt from scratch
-        # and the benchmark's second pass measured that rebuild rather than warm
-        # performance (issue #6010). Set True to restore the staged behaviour on
-        # a part where the memory does not fit -- a single Wormhole, for example,
-        # cannot hold this model at all (issue #4756).
+        # Keep components on device between calls (23.2 GiB of 31.8, 73%).
+        # Evicting discards the compiled graph with the weights, so every later
+        # call rebuilds (#6010). True restores staging where memory is tight
+        # (a single Wormhole cannot hold this model at all, #4756).
         self.evict_components = evict_components
         # Tiled VAE decode keeps the 1280x720 decode activations small so the
         # host-side spike during decode stays bounded. Flip off to revert to a
@@ -227,8 +224,7 @@ class ZImageTTPipeline:
     def __init__(self, config: ZImageConfig):
         self.config = config
         self._perf = {}
-        # name -> (compiled, module). Holding BOTH keeps the graph and its
-        # weights alive; dropping either forces a rebuild on the next call.
+        # name -> (compiled, module); both refs are needed to avoid a rebuild.
         self._resident = {}
 
     def setup(self):
@@ -404,8 +400,7 @@ class ZImageTTPipeline:
                     noise_pred.to(torch.float32), t, latents, return_dict=False
                 )[0]
             if self.config.evict_components:
-                # Staged path: free the transformer (~12 GB) and its compiled
-                # graph before the VAE decode, so the decode runs alone.
+                # Staged path: free the transformer (~12 GB) before the decode.
                 del tf_compiled, transformer
                 gc.collect()
                 torch_xla.sync()
@@ -421,8 +416,7 @@ class ZImageTTPipeline:
                 if self.config.vae_tiling and hasattr(
                     vae_wrapper.vae, "enable_tiling"
                 ):
-                    # Tiled decode bounds the 1280x720 decode activations (and
-                    # their host staging) to a single tile, not the full frame.
+                    # Tiled decode bounds the 1280x720 activations to one tile.
                     vae_wrapper.vae.enable_tiling()
                 vae_wrapper = vae_wrapper.to(self._device)
                 vae_compiled = self._intercept(

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -176,27 +176,6 @@ class ZImageConfig:
         self.vae_tiling = vae_tiling
 
 
-def _populate_rope_cache(transformer, device) -> None:
-    """Build the RoPE frequency table BEFORE compiling, not on first forward.
-
-    ``diffusers`` RopeEmbedder.__call__ does ``if self.freqs_cis is None:`` and
-    fills the cache on first use (transformer_z_image.py:344). The first forward
-    therefore compiles under a "freqs_cis is None" guard that the SAME forward
-    then falsifies, so the next forward rebuilds -- measured as the unexplained
-    +3 graphs on denoise step 2. Precomputing is deterministic and produces the
-    identical table, so the output is unchanged; it only moves the work out of
-    the traced region. Guarded by hasattr so a diffusers version without this
-    attribute is a silent no-op rather than a crash.
-    """
-    rope = getattr(transformer, "rope_embedder", None)
-    if rope is None or getattr(rope, "freqs_cis", None) is not None:
-        return
-    if not hasattr(rope, "precompute_freqs_cis"):
-        return
-    freqs = rope.precompute_freqs_cis(rope.axes_dims, rope.axes_lens, theta=rope.theta)
-    rope.freqs_cis = [f.to(device) for f in freqs]
-
-
 class ZImageTTPipeline:
     """Z-Image text-to-image pipeline with every module on a single TT chip.
 
@@ -374,7 +353,6 @@ class ZImageTTPipeline:
             logger.info("[STAGE] transformer: start ({} steps)", num_inference_steps)
             transformer = self.TRANSFORMER_CLS(load_transformer(DTYPE)).eval()
             transformer = transformer.to(self._device)
-            _populate_rope_cache(transformer.transformer, self._device)
             tf_compiled = self._intercept(
                 "transformer", torch.compile(transformer, backend="tt")
             )

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -191,15 +191,26 @@ class ZImageTTPipeline:
     # benchmark harness reads this to skip its outer warmup pass.
     benchmark_staged_residency = True
 
-    # Substitution seams. generate() instantiates these attributes rather than the
-    # classes directly, so a consumer can swap in a subclass without copying
-    # generate(). The PCC e2e uses this to intercept each component's forward and
-    # compare against a CPU twin, instead of duplicating the whole pipeline --
-    # residency, eviction, staging and the warm machinery stay in this one file.
-    # Default values keep behaviour identical.
+    # Substitution seams for the module classes. generate() instantiates these
+    # attributes rather than the classes directly, so a consumer can swap in a
+    # subclass without copying generate(). Defaults keep behaviour identical.
     TEXT_ENCODER_CLS = TextEncoderWrapper
     TRANSFORMER_CLS = TransformerWrapper
     VAE_CLS = VaeDecodeWrapper
+
+    def _intercept(self, name, compiled):
+        """Hook applied to each component's COMPILED callable. Identity by default.
+
+        This is the seam the PCC e2e uses, not the ``*_CLS`` ones. Z-Image compiles
+        the whole wrapper module (``torch.compile(TextEncoderWrapper(...))``), so a
+        check placed in the wrapper's ``forward`` would run INSIDE the traced graph
+        and fail with "Cannot copy out of meta tensor" the moment it touches a CPU
+        twin. Wrapping the compiled callable instead keeps the comparison outside
+        the graph, where host tensors are real.
+
+        ``name`` is one of "text_encoder", "transformer", "vae".
+        """
+        return compiled
 
     def __init__(self, config: ZImageConfig):
         self.config = config
@@ -259,7 +270,9 @@ class ZImageTTPipeline:
             logger.info("[STAGE] text_encoder: start")
             text_encoder = self.TEXT_ENCODER_CLS(load_text_encoder(DTYPE)).eval()
             text_encoder = text_encoder.to(self._device)
-            te_compiled = torch.compile(text_encoder, backend="tt")
+            te_compiled = self._intercept(
+                "text_encoder", torch.compile(text_encoder, backend="tt")
+            )
             with _StageCounters(self._perf["counters"], "text_encoder"):
                 t0 = time.perf_counter()
                 # COLD: first forward in this residency, carries the build.
@@ -318,7 +331,9 @@ class ZImageTTPipeline:
             logger.info("[STAGE] transformer: start ({} steps)", num_inference_steps)
             transformer = self.TRANSFORMER_CLS(load_transformer(DTYPE)).eval()
             transformer = transformer.to(self._device)
-            tf_compiled = torch.compile(transformer, backend="tt")
+            tf_compiled = self._intercept(
+                "transformer", torch.compile(transformer, backend="tt")
+            )
             for i, t in enumerate(timesteps):
                 logger.info("[STEP] transformer step {}/{}", i + 1, num_inference_steps)
                 timestep = ((1000 - t.expand(1)) / 1000).to(DTYPE)
@@ -353,7 +368,9 @@ class ZImageTTPipeline:
                 # host staging) to a single tile instead of the full frame.
                 vae_wrapper.vae.enable_tiling()
             vae_wrapper = vae_wrapper.to(self._device)
-            vae_compiled = torch.compile(vae_wrapper, backend="tt")
+            vae_compiled = self._intercept(
+                "vae", torch.compile(vae_wrapper, backend="tt")
+            )
             with _StageCounters(self._perf["counters"], "vae"):
                 t0 = time.perf_counter()
                 image = vae_compiled(latents.to(self._device)).cpu().float()

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -15,9 +15,12 @@ runs unchanged on any Blackhole host (it uses one chip even when more are
 visible, because SPMD is never enabled). Its weights exceed the DRAM a single
 Wormhole chip provides, so it OOMs there and is Blackhole-only.
 
-Memory strategy: the ~6.2B transformer, the Qwen3 text encoder and the VAE do
-not all fit resident at once (issue #4756), so each is loaded → placed → used →
-freed in turn, keeping peak DRAM ≈ max(component).
+Memory strategy: all three components stay resident by default -- measured
+co-resident at 23.221 GiB of 31.83 (73.0%) on a Blackhole, with no OOM -- so a
+second generate() reuses their compiled graphs instead of rebuilding them. Set
+``evict_components`` to load → place → use → free each in turn, keeping peak
+DRAM ≈ max(component), for a part where they do not all fit (a single Wormhole
+cannot hold this model at all, issue #4756).
 
 This is the reusable implementation that both the runnable example
 (``examples/pytorch/z_image.py``) and the benchmark harness
@@ -154,6 +157,7 @@ class ZImageConfig:
         compile_options: Optional[dict] = None,
         vae_tiling: bool = True,
         warm_iters: int = 0,
+        evict_components: bool = False,
     ):
         self.repo_id = REPO_ID
         self.height = height
@@ -170,6 +174,14 @@ class ZImageConfig:
         # tokenize_prompt, so the same graph), and the shipped code merely summed
         # them into one timer.
         self.warm_iters = warm_iters
+        # Keep each component on device between calls. Measured co-resident:
+        # 23.221 GiB of 31.83 (73.0%) with no OOM. Evicting discards the compiled
+        # graph along with the weights, so every later call rebuilt from scratch
+        # and the benchmark's second pass measured that rebuild rather than warm
+        # performance (issue #6010). Set True to restore the staged behaviour on
+        # a part where the memory does not fit -- a single Wormhole, for example,
+        # cannot hold this model at all (issue #4756).
+        self.evict_components = evict_components
         # Tiled VAE decode keeps the 1280x720 decode activations small so the
         # host-side spike during decode stays bounded. Flip off to revert to a
         # single full-frame decode.
@@ -215,6 +227,9 @@ class ZImageTTPipeline:
     def __init__(self, config: ZImageConfig):
         self.config = config
         self._perf = {}
+        # name -> (compiled, module). Holding BOTH keeps the graph and its
+        # weights alive; dropping either forces a rebuild on the next call.
+        self._resident = {}
 
     def setup(self):
         self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
@@ -290,11 +305,17 @@ class ZImageTTPipeline:
             # Loaded here (not in setup) and fully released at the end of the
             # stage so its ~7.5 GB never overlaps the transformer or VAE.
             logger.info("[STAGE] text_encoder: start")
-            text_encoder = self.TEXT_ENCODER_CLS(load_text_encoder(DTYPE)).eval()
-            text_encoder = text_encoder.to(self._device)
-            te_compiled = self._intercept(
-                "text_encoder", torch.compile(text_encoder, backend="tt")
-            )
+            cached = self._resident.get("text_encoder")
+            if cached is not None:
+                te_compiled, text_encoder = cached
+            else:
+                text_encoder = self.TEXT_ENCODER_CLS(load_text_encoder(DTYPE)).eval()
+                text_encoder = text_encoder.to(self._device)
+                te_compiled = self._intercept(
+                    "text_encoder", torch.compile(text_encoder, backend="tt")
+                )
+                if not self.config.evict_components:
+                    self._resident["text_encoder"] = (te_compiled, text_encoder)
             with _StageCounters(self._perf["counters"], "text_encoder"):
                 t0 = time.perf_counter()
                 # COLD: first forward in this residency, carries the build.
@@ -312,9 +333,10 @@ class ZImageTTPipeline:
                     cap_neg = None
                 # Unchanged meaning: the functional total of both forwards.
                 self._perf["components"]["text_encoder"] = time.perf_counter() - t0
-            del te_compiled, text_encoder
-            gc.collect()
-            torch_xla.sync()
+            if self.config.evict_components:
+                del te_compiled, text_encoder
+                gc.collect()
+                torch_xla.sync()
             logger.info("[STAGE] text_encoder: done")
 
             # ── Latents (fp32 on CPU) ─────────────────────────────────────
@@ -351,11 +373,17 @@ class ZImageTTPipeline:
 
             # ── Denoising loop (transformer), then free ───────────────────
             logger.info("[STAGE] transformer: start ({} steps)", num_inference_steps)
-            transformer = self.TRANSFORMER_CLS(load_transformer(DTYPE)).eval()
-            transformer = transformer.to(self._device)
-            tf_compiled = self._intercept(
-                "transformer", torch.compile(transformer, backend="tt")
-            )
+            cached = self._resident.get("transformer")
+            if cached is not None:
+                tf_compiled, transformer = cached
+            else:
+                transformer = self.TRANSFORMER_CLS(load_transformer(DTYPE)).eval()
+                transformer = transformer.to(self._device)
+                tf_compiled = self._intercept(
+                    "transformer", torch.compile(transformer, backend="tt")
+                )
+                if not self.config.evict_components:
+                    self._resident["transformer"] = (tf_compiled, transformer)
             for i, t in enumerate(timesteps):
                 logger.info("[STEP] transformer step {}/{}", i + 1, num_inference_steps)
                 timestep = ((1000 - t.expand(1)) / 1000).to(DTYPE)
@@ -375,24 +403,33 @@ class ZImageTTPipeline:
                 latents = self.scheduler.step(
                     noise_pred.to(torch.float32), t, latents, return_dict=False
                 )[0]
-            # Free the transformer (~12 GB) + its compiled graph before the VAE
-            # decode so the decode stage runs with only the VAE resident.
-            del tf_compiled, transformer
-            gc.collect()
-            torch_xla.sync()
+            if self.config.evict_components:
+                # Staged path: free the transformer (~12 GB) and its compiled
+                # graph before the VAE decode, so the decode runs alone.
+                del tf_compiled, transformer
+                gc.collect()
+                torch_xla.sync()
             logger.info("[STAGE] transformer: done")
 
             # ── VAE decode → raw pixels in [-1, 1], then free ─────────────
             logger.info("[STAGE] vae: start")
-            vae_wrapper = self.VAE_CLS(load_vae(DTYPE)).eval()
-            if self.config.vae_tiling and hasattr(vae_wrapper.vae, "enable_tiling"):
-                # Tiled decode bounds the 1280x720 decode activations (and their
-                # host staging) to a single tile instead of the full frame.
-                vae_wrapper.vae.enable_tiling()
-            vae_wrapper = vae_wrapper.to(self._device)
-            vae_compiled = self._intercept(
-                "vae", torch.compile(vae_wrapper, backend="tt")
-            )
+            cached = self._resident.get("vae")
+            if cached is not None:
+                vae_compiled, vae_wrapper = cached
+            else:
+                vae_wrapper = self.VAE_CLS(load_vae(DTYPE)).eval()
+                if self.config.vae_tiling and hasattr(
+                    vae_wrapper.vae, "enable_tiling"
+                ):
+                    # Tiled decode bounds the 1280x720 decode activations (and
+                    # their host staging) to a single tile, not the full frame.
+                    vae_wrapper.vae.enable_tiling()
+                vae_wrapper = vae_wrapper.to(self._device)
+                vae_compiled = self._intercept(
+                    "vae", torch.compile(vae_wrapper, backend="tt")
+                )
+                if not self.config.evict_components:
+                    self._resident["vae"] = (vae_compiled, vae_wrapper)
             with _StageCounters(self._perf["counters"], "vae"):
                 t0 = time.perf_counter()
                 image = vae_compiled(latents.to(self._device)).cpu().float()
@@ -411,9 +448,10 @@ class ZImageTTPipeline:
                     del extra
                 if warm_times:
                     self._perf["warm"]["vae"] = sum(warm_times) / len(warm_times)
-            del vae_compiled, vae_wrapper
-            gc.collect()
-            torch_xla.sync()
+            if self.config.evict_components:
+                del vae_compiled, vae_wrapper
+                gc.collect()
+                torch_xla.sync()
             logger.info("[STAGE] vae: done")
 
         # ---- transformer step cold/warm -------------------------------------

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -15,12 +15,9 @@ runs unchanged on any Blackhole host (it uses one chip even when more are
 visible, because SPMD is never enabled). Its weights exceed the DRAM a single
 Wormhole chip provides, so it OOMs there and is Blackhole-only.
 
-Memory strategy: all three components stay resident by default -- measured
-co-resident at 23.221 GiB of 31.83 (73.0%) on a Blackhole, with no OOM -- so a
-second generate() reuses their compiled graphs instead of rebuilding them. Set
-``evict_components`` to load → place → use → free each in turn, keeping peak
-DRAM ≈ max(component), for a part where they do not all fit (a single Wormhole
-cannot hold this model at all, issue #4756).
+Memory strategy: all three components stay resident, co-resident at 23.22 GiB
+of 31.83 (73%), so a second generate() reuses their compiled graphs instead of
+rebuilding them.
 
 This is the reusable implementation that both the runnable example
 (``examples/pytorch/z_image.py``) and the benchmark harness
@@ -28,7 +25,6 @@ This is the reusable implementation that both the runnable example
 go into ``self._perf`` after each ``generate()``.
 """
 
-import gc
 import inspect
 import time
 from typing import Optional
@@ -114,8 +110,6 @@ class ZImageConfig:
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
         vae_tiling: bool = True,
-        warm_iters: int = 0,
-        evict_components: bool = False,
     ):
         self.repo_id = REPO_ID
         self.height = height
@@ -123,20 +117,6 @@ class ZImageConfig:
         self.vae_scale_factor = VAE_SCALE_FACTOR
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
-        # Extra in-residency forwards per one-shot component, used to obtain a
-        # warm number while the component is still on device. 0 = inert, and the
-        # path is then byte-identical to pre-instrumentation behaviour, so the
-        # demo and PCC paths are unaffected. Only the benchmark sets it.
-        # The text encoder needs none: it ALREADY runs two forwards per residency
-        # (prompt, then the empty negative prompt -- both padded to 512 by
-        # tokenize_prompt, so the same graph), and the shipped code merely summed
-        # them into one timer.
-        self.warm_iters = warm_iters
-        # Keep components on device between calls (23.2 GiB of 31.8, 73%).
-        # Evicting discards the compiled graph with the weights, so every later
-        # call rebuilds (#6010). True restores staging where memory is tight
-        # (a single Wormhole cannot hold this model at all, #4756).
-        self.evict_components = evict_components
         # Tiled VAE decode keeps the 1280x720 decode activations small so the
         # host-side spike during decode stays bounded. Flip off to revert to a
         # single full-frame decode.
@@ -146,16 +126,13 @@ class ZImageConfig:
 class ZImageTTPipeline:
     """Z-Image text-to-image pipeline with every module on a single TT chip.
 
-    Built once with ``setup()``; ``generate()`` can be called repeatedly (the
-    benchmark harness runs a warmup pass followed by a steady one). Each heavy
-    module is loaded inside ``generate()`` and freed at the end of its stage, so
-    nothing carries over between calls.
+    Built once with ``setup()``; ``generate()`` can be called repeatedly. Each
+    heavy module is loaded on first use and kept on device, so later calls reuse
+    its compiled graph.
     """
 
-    # Components stay resident (see ZImageConfig.evict_components), so a second
-    # generate() reuses their compiled graphs and is genuinely warm. The harness
-    # therefore runs its normal warmup + steady pair and publishes the steady
-    # pass. Flip to True alongside evict_components if a part needs staging.
+    # Components stay resident, so a second generate() is genuinely warm and the
+    # harness runs its normal warmup + steady pair.
     benchmark_staged_residency = False
 
     # Substitution seams for the module classes. generate() instantiates these
@@ -197,18 +174,13 @@ class ZImageTTPipeline:
         """Import every model class up front so no LATER import can invalidate an
         already-compiled graph.
 
-        transformers registers each ``ModelOutput`` subclass as a pytree node in
-        ``__init_subclass__`` (utils/generic.py:375), i.e. at IMPORT time, and
-        dynamo bakes ``len(_registered_model_output_types) == N`` into the guards
-        of anything compiled while the module is traced. Staged residency loads
-        each component lazily inside generate(), so the transformer's and VAE's
-        imports grow that set AFTER the text encoder has compiled -- and the
-        encoder's next forward then fails the guard and rebuilds (measured: one
-        rebuild, 52.7s against a 0.9s warm forward).
-
-        Importing costs no weights and no device memory, so this does not affect
-        the staging strategy. Models that load everything before compiling (e.g.
-        HunyuanImage-2.1) never hit this; it is specific to lazy staging.
+        transformers registers each ``ModelOutput`` subclass as a pytree node at
+        IMPORT time (utils/generic.py:375), and dynamo bakes
+        ``len(_registered_model_output_types) == N`` into the guards of anything
+        compiled while that module is traced. Components load lazily inside
+        generate(), so the transformer's and VAE's imports grow that set after
+        the text encoder has compiled and its next forward would fail the guard
+        and rebuild. Importing costs no weights and no device memory.
         """
         from diffusers import AutoencoderKL, ZImageTransformer2DModel  # noqa: F401
         from transformers import Qwen3Model  # noqa: F401
@@ -244,17 +216,15 @@ class ZImageTTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
-            # components[] keeps its existing meaning (the functional total),
-            # so the published <name>_s does not move.
+            # Per-component cold/warm split, alongside the functional total in
+            # components[].
             "cold": {},
             "warm": {},
         }
         t_total_start = time.perf_counter()
 
         with torch.no_grad():
-            # ── Text encoder (Qwen3) → prompt embeds, then free ───────────
-            # Loaded here (not in setup) and fully released at the end of the
-            # stage so its ~7.5 GB never overlaps the transformer or VAE.
+            # ── Text encoder (Qwen3) → prompt embeds ──────────────────────
             logger.info("[STAGE] text_encoder: start")
             cached = self._resident.get("text_encoder")
             if cached is not None:
@@ -265,28 +235,22 @@ class ZImageTTPipeline:
                 te_compiled = self._intercept(
                     "text_encoder", torch.compile(text_encoder, backend="tt")
                 )
-                if not self.config.evict_components:
-                    self._resident["text_encoder"] = (te_compiled, text_encoder)
+                self._resident["text_encoder"] = (te_compiled, text_encoder)
             t0 = time.perf_counter()
-            # COLD: first forward in this residency, carries the build.
+            # The two prompts are separately timed: on the first call the
+            # positive forward carries the build and the negative one -- same
+            # padded shapes, same graph -- is the warm sample.
             t_enc = time.perf_counter()
             cap_pos = self._encode(prompt, te_compiled)
             self._perf["cold"]["text_encoder"] = time.perf_counter() - t_enc
-            # WARM, free: the negative prompt is a second forward inside the
-            # SAME residency with identical padded shapes, so it reuses the
-            # graph. No synthetic repeat needed.
             if do_cfg:
                 t_enc = time.perf_counter()
                 cap_neg = self._encode(NEGATIVE_PROMPT, te_compiled)
                 self._perf["warm"]["text_encoder"] = time.perf_counter() - t_enc
             else:
                 cap_neg = None
-            # Unchanged meaning: the functional total of both forwards.
+            # The functional total of both forwards.
             self._perf["components"]["text_encoder"] = time.perf_counter() - t0
-            if self.config.evict_components:
-                del te_compiled, text_encoder
-                gc.collect()
-                torch_xla.sync()
             logger.info("[STAGE] text_encoder: done")
 
             # ── Latents (fp32 on CPU) ─────────────────────────────────────
@@ -321,7 +285,7 @@ class ZImageTTPipeline:
             self.scheduler.set_begin_index(0)
             timesteps = self.scheduler.timesteps
 
-            # ── Denoising loop (transformer), then free ───────────────────
+            # ── Denoising loop (transformer) ──────────────────────────────
             logger.info("[STAGE] transformer: start ({} steps)", num_inference_steps)
             cached = self._resident.get("transformer")
             if cached is not None:
@@ -332,8 +296,7 @@ class ZImageTTPipeline:
                 tf_compiled = self._intercept(
                     "transformer", torch.compile(transformer, backend="tt")
                 )
-                if not self.config.evict_components:
-                    self._resident["transformer"] = (tf_compiled, transformer)
+                self._resident["transformer"] = (tf_compiled, transformer)
             for i, t in enumerate(timesteps):
                 logger.info("[STEP] transformer step {}/{}", i + 1, num_inference_steps)
                 timestep = ((1000 - t.expand(1)) / 1000).to(DTYPE)
@@ -352,57 +315,32 @@ class ZImageTTPipeline:
                 latents = self.scheduler.step(
                     noise_pred.to(torch.float32), t, latents, return_dict=False
                 )[0]
-            if self.config.evict_components:
-                # Staged path: free the transformer (~12 GB) before the decode.
-                del tf_compiled, transformer
-                gc.collect()
-                torch_xla.sync()
             logger.info("[STAGE] transformer: done")
 
-            # ── VAE decode → raw pixels in [-1, 1], then free ─────────────
+            # ── VAE decode → raw pixels in [-1, 1] ────────────────────────
             logger.info("[STAGE] vae: start")
             cached = self._resident.get("vae")
             if cached is not None:
                 vae_compiled, vae_wrapper = cached
             else:
                 vae_wrapper = self.VAE_CLS(load_vae(DTYPE)).eval()
-                if self.config.vae_tiling and hasattr(
-                    vae_wrapper.vae, "enable_tiling"
-                ):
-                    # Tiled decode bounds the 1280x720 activations to one tile.
+                if self.config.vae_tiling and hasattr(vae_wrapper.vae, "enable_tiling"):
+                    # Tiled decode bounds the 1280x720 decode activations (and
+                    # their host staging) to a single tile instead of the full
+                    # frame.
                     vae_wrapper.vae.enable_tiling()
                 vae_wrapper = vae_wrapper.to(self._device)
                 vae_compiled = self._intercept(
                     "vae", torch.compile(vae_wrapper, backend="tt")
                 )
-                if not self.config.evict_components:
-                    self._resident["vae"] = (vae_compiled, vae_wrapper)
+                self._resident["vae"] = (vae_compiled, vae_wrapper)
             t0 = time.perf_counter()
             image = vae_compiled(latents.to(self._device)).cpu().float()
-            vae_cold = time.perf_counter() - t0
-            self._perf["cold"]["vae"] = vae_cold
-            # Unchanged meaning: the functional decode only.
-            self._perf["components"]["vae"] = vae_cold
-            # WARM: the VAE has no natural second forward, so repeat it here
-            # while still resident. Outputs are discarded, so the returned
-            # image is identical at any warm_iters -- inert at 0.
-            warm_times = []
-            for _ in range(self.config.warm_iters):
-                t_w = time.perf_counter()
-                extra = vae_compiled(latents.to(self._device)).cpu().float()
-                warm_times.append(time.perf_counter() - t_w)
-                del extra
-            if warm_times:
-                self._perf["warm"]["vae"] = sum(warm_times) / len(warm_times)
-            if self.config.evict_components:
-                del vae_compiled, vae_wrapper
-                gc.collect()
-                torch_xla.sync()
+            self._perf["components"]["vae"] = time.perf_counter() - t0
             logger.info("[STAGE] vae: done")
 
-        # ---- transformer step cold/warm -------------------------------------
-        # The transformer stays resident, so only the first step of the first
-        # call carries a build; every later step is warm.
+        # Step 1 of the first call carries the transformer build; the rest are
+        # warm.
         steps = self._perf["steps"]
         if steps:
             self._perf["cold"]["transformer_step"] = steps[0]

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -32,6 +32,7 @@ from typing import Optional
 
 import torch
 import torch_xla
+import torch_xla.debug.metrics as met
 from diffusers import FlowMatchEulerDiscreteScheduler
 from loguru import logger
 from PIL import Image
@@ -53,6 +54,47 @@ from .src.model_utils import (
     load_vae,
     tokenize_prompt,
 )
+
+
+def _compile_counters():
+    """``(compile_seconds, graphs_compiled)`` accumulated process-wide so far.
+
+    torch-xla's ``CompileTime`` metric is ``[count, total_ns, ...]``, and is
+    absent until the first compile.
+    """
+    data = met.metric_data("CompileTime")
+    if not data:
+        return 0.0, 0
+    return (data[1] / 1e9 if len(data) > 1 else 0.0), data[0]
+
+
+def _graphs_compiled():
+    return _compile_counters()[1]
+
+
+class _StageCounters:
+    """Compile time and graph count of one staged residency, as a delta.
+
+    Makes the warm numbers falsifiable: a warm iteration must add zero graphs.
+    """
+
+    def __init__(self, sink, name):
+        self._sink = sink
+        self._name = name
+
+    def __enter__(self):
+        self._t0 = time.perf_counter()
+        self._before = _compile_counters()
+        return self
+
+    def __exit__(self, *exc):
+        after = _compile_counters()
+        self._sink[self._name] = {
+            "wall_s": time.perf_counter() - self._t0,
+            "compile_s": after[0] - self._before[0],
+            "graphs_compiled": after[1] - self._before[1],
+        }
+        return False
 
 
 def calculate_shift(image_seq_len, base_seq=256, max_seq=4096, base=0.5, max_=1.15):
@@ -111,6 +153,7 @@ class ZImageConfig:
         width: int = WIDTH,
         compile_options: Optional[dict] = None,
         vae_tiling: bool = True,
+        warm_iters: int = 0,
     ):
         self.repo_id = REPO_ID
         self.height = height
@@ -118,6 +161,15 @@ class ZImageConfig:
         self.vae_scale_factor = VAE_SCALE_FACTOR
         # Forwarded for parity with the other imagegen pipelines; unused inline.
         self.compile_options = compile_options or {}
+        # Extra in-residency forwards per one-shot component, used to obtain a
+        # warm number while the component is still on device. 0 = inert, and the
+        # path is then byte-identical to pre-instrumentation behaviour, so the
+        # demo and PCC paths are unaffected. Only the benchmark sets it.
+        # The text encoder needs none: it ALREADY runs two forwards per residency
+        # (prompt, then the empty negative prompt -- both padded to 512 by
+        # tokenize_prompt, so the same graph), and the shipped code merely summed
+        # them into one timer.
+        self.warm_iters = warm_iters
         # Tiled VAE decode keeps the 1280x720 decode activations small so the
         # host-side spike during decode stays bounded. Flip off to revert to a
         # single full-frame decode.
@@ -132,6 +184,22 @@ class ZImageTTPipeline:
     module is loaded inside ``generate()`` and freed at the end of its stage, so
     nothing carries over between calls.
     """
+
+    # Every component is loaded, run and freed inside generate(), and eviction
+    # discards the compiled graph with the weights -- so a second generate() call
+    # rebuilds from scratch and timing it reports a cold cycle as warm. The
+    # benchmark harness reads this to skip its outer warmup pass.
+    benchmark_staged_residency = True
+
+    # Substitution seams. generate() instantiates these attributes rather than the
+    # classes directly, so a consumer can swap in a subclass without copying
+    # generate(). The PCC e2e uses this to intercept each component's forward and
+    # compare against a CPU twin, instead of duplicating the whole pipeline --
+    # residency, eviction, staging and the warm machinery stay in this one file.
+    # Default values keep behaviour identical.
+    TEXT_ENCODER_CLS = TextEncoderWrapper
+    TRANSFORMER_CLS = TransformerWrapper
+    VAE_CLS = VaeDecodeWrapper
 
     def __init__(self, config: ZImageConfig):
         self.config = config
@@ -174,7 +242,14 @@ class ZImageTTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
+            # Staged-residency additions. components[] keeps its existing meaning
+            # (the functional total) so the published <name>_s does not move.
+            "cold": {},
+            "warm": {},
+            "counters": {},
         }
+        # Per-step graph counts, so warm steps are SELECTED rather than assumed.
+        step_graphs = []
         t_total_start = time.perf_counter()
 
         with torch.no_grad():
@@ -182,13 +257,26 @@ class ZImageTTPipeline:
             # Loaded here (not in setup) and fully released at the end of the
             # stage so its ~7.5 GB never overlaps the transformer or VAE.
             logger.info("[STAGE] text_encoder: start")
-            text_encoder = TextEncoderWrapper(load_text_encoder(DTYPE)).eval()
+            text_encoder = self.TEXT_ENCODER_CLS(load_text_encoder(DTYPE)).eval()
             text_encoder = text_encoder.to(self._device)
             te_compiled = torch.compile(text_encoder, backend="tt")
-            t0 = time.perf_counter()
-            cap_pos = self._encode(prompt, te_compiled)
-            cap_neg = self._encode(NEGATIVE_PROMPT, te_compiled) if do_cfg else None
-            self._perf["components"]["text_encoder"] = time.perf_counter() - t0
+            with _StageCounters(self._perf["counters"], "text_encoder"):
+                t0 = time.perf_counter()
+                # COLD: first forward in this residency, carries the build.
+                t_enc = time.perf_counter()
+                cap_pos = self._encode(prompt, te_compiled)
+                self._perf["cold"]["text_encoder"] = time.perf_counter() - t_enc
+                # WARM, free: the negative prompt is a second forward inside the
+                # SAME residency with identical padded shapes, so it reuses the
+                # graph. No synthetic repeat needed.
+                if do_cfg:
+                    t_enc = time.perf_counter()
+                    cap_neg = self._encode(NEGATIVE_PROMPT, te_compiled)
+                    self._perf["warm"]["text_encoder"] = time.perf_counter() - t_enc
+                else:
+                    cap_neg = None
+                # Unchanged meaning: the functional total of both forwards.
+                self._perf["components"]["text_encoder"] = time.perf_counter() - t0
             del te_compiled, text_encoder
             gc.collect()
             torch_xla.sync()
@@ -228,7 +316,7 @@ class ZImageTTPipeline:
 
             # ── Denoising loop (transformer), then free ───────────────────
             logger.info("[STAGE] transformer: start ({} steps)", num_inference_steps)
-            transformer = TransformerWrapper(load_transformer(DTYPE)).eval()
+            transformer = self.TRANSFORMER_CLS(load_transformer(DTYPE)).eval()
             transformer = transformer.to(self._device)
             tf_compiled = torch.compile(transformer, backend="tt")
             for i, t in enumerate(timesteps):
@@ -244,6 +332,7 @@ class ZImageTTPipeline:
                 else:
                     pred = pos
                 self._perf["steps"].append(time.perf_counter() - t0)
+                step_graphs.append(_graphs_compiled())
 
                 noise_pred = (-pred).squeeze(2)
                 latents = self.scheduler.step(
@@ -258,20 +347,58 @@ class ZImageTTPipeline:
 
             # ── VAE decode → raw pixels in [-1, 1], then free ─────────────
             logger.info("[STAGE] vae: start")
-            vae_wrapper = VaeDecodeWrapper(load_vae(DTYPE)).eval()
+            vae_wrapper = self.VAE_CLS(load_vae(DTYPE)).eval()
             if self.config.vae_tiling and hasattr(vae_wrapper.vae, "enable_tiling"):
                 # Tiled decode bounds the 1280x720 decode activations (and their
                 # host staging) to a single tile instead of the full frame.
                 vae_wrapper.vae.enable_tiling()
             vae_wrapper = vae_wrapper.to(self._device)
             vae_compiled = torch.compile(vae_wrapper, backend="tt")
-            t0 = time.perf_counter()
-            image = vae_compiled(latents.to(self._device)).cpu().float()
-            self._perf["components"]["vae"] = time.perf_counter() - t0
+            with _StageCounters(self._perf["counters"], "vae"):
+                t0 = time.perf_counter()
+                image = vae_compiled(latents.to(self._device)).cpu().float()
+                vae_cold = time.perf_counter() - t0
+                self._perf["cold"]["vae"] = vae_cold
+                # Unchanged meaning: the functional decode only.
+                self._perf["components"]["vae"] = vae_cold
+                # WARM: the VAE has no natural second forward, so repeat it here
+                # while still resident. Outputs are discarded, so the returned
+                # image is identical at any warm_iters -- inert at 0.
+                warm_times = []
+                for _ in range(self.config.warm_iters):
+                    t_w = time.perf_counter()
+                    extra = vae_compiled(latents.to(self._device)).cpu().float()
+                    warm_times.append(time.perf_counter() - t_w)
+                    del extra
+                if warm_times:
+                    self._perf["warm"]["vae"] = sum(warm_times) / len(warm_times)
             del vae_compiled, vae_wrapper
             gc.collect()
             torch_xla.sync()
             logger.info("[STAGE] vae: done")
+
+        # ---- transformer step cold/warm -------------------------------------
+        # Warm steps are SELECTED, not assumed at index 1. Measured on this model:
+        # step 2 still compiled in one call (uncached +3) and was warm in the next,
+        # so a fixed steps[1:] mean can fold a build-carrying step into "warm" and
+        # overstate it. A step is warm only if it added no graphs.
+        steps = self._perf["steps"]
+        if steps:
+            self._perf["cold"]["transformer_step"] = steps[0]
+            warm_steps = [
+                t
+                for i, t in enumerate(steps)
+                if i > 0 and step_graphs[i] == step_graphs[i - 1]
+            ]
+            if warm_steps:
+                self._perf["warm"]["transformer_step"] = sum(warm_steps) / len(
+                    warm_steps
+                )
+            self._perf["counters"]["transformer_warm_steps"] = {
+                "warm_steps": len(warm_steps),
+                "total_steps": len(steps),
+                "graphs_compiled": step_graphs[-1] - step_graphs[0],
+            }
 
         self._perf["total"] = time.perf_counter() - t_total_start
         return image

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -35,7 +35,6 @@ from typing import Optional
 
 import torch
 import torch_xla
-import torch_xla.debug.metrics as met
 from diffusers import FlowMatchEulerDiscreteScheduler
 from loguru import logger
 from PIL import Image
@@ -57,47 +56,6 @@ from .src.model_utils import (
     load_vae,
     tokenize_prompt,
 )
-
-
-def _compile_counters():
-    """``(compile_seconds, graphs_compiled)`` accumulated process-wide so far.
-
-    torch-xla's ``CompileTime`` metric is ``[count, total_ns, ...]``, and is
-    absent until the first compile.
-    """
-    data = met.metric_data("CompileTime")
-    if not data:
-        return 0.0, 0
-    return (data[1] / 1e9 if len(data) > 1 else 0.0), data[0]
-
-
-def _graphs_compiled():
-    return _compile_counters()[1]
-
-
-class _StageCounters:
-    """Compile time and graph count of one staged residency, as a delta.
-
-    Makes the warm numbers falsifiable: a warm iteration must add zero graphs.
-    """
-
-    def __init__(self, sink, name):
-        self._sink = sink
-        self._name = name
-
-    def __enter__(self):
-        self._t0 = time.perf_counter()
-        self._before = _compile_counters()
-        return self
-
-    def __exit__(self, *exc):
-        after = _compile_counters()
-        self._sink[self._name] = {
-            "wall_s": time.perf_counter() - self._t0,
-            "compile_s": after[0] - self._before[0],
-            "graphs_compiled": after[1] - self._before[1],
-        }
-        return False
 
 
 def calculate_shift(image_seq_len, base_seq=256, max_seq=4096, base=0.5, max_=1.15):
@@ -286,14 +244,11 @@ class ZImageTTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
-            # Staged-residency additions. components[] keeps its existing meaning
-            # (the functional total) so the published <name>_s does not move.
+            # components[] keeps its existing meaning (the functional total),
+            # so the published <name>_s does not move.
             "cold": {},
             "warm": {},
-            "counters": {},
         }
-        # Per-step graph counts, so warm steps are SELECTED rather than assumed.
-        step_graphs = []
         t_total_start = time.perf_counter()
 
         with torch.no_grad():
@@ -312,23 +267,22 @@ class ZImageTTPipeline:
                 )
                 if not self.config.evict_components:
                     self._resident["text_encoder"] = (te_compiled, text_encoder)
-            with _StageCounters(self._perf["counters"], "text_encoder"):
-                t0 = time.perf_counter()
-                # COLD: first forward in this residency, carries the build.
+            t0 = time.perf_counter()
+            # COLD: first forward in this residency, carries the build.
+            t_enc = time.perf_counter()
+            cap_pos = self._encode(prompt, te_compiled)
+            self._perf["cold"]["text_encoder"] = time.perf_counter() - t_enc
+            # WARM, free: the negative prompt is a second forward inside the
+            # SAME residency with identical padded shapes, so it reuses the
+            # graph. No synthetic repeat needed.
+            if do_cfg:
                 t_enc = time.perf_counter()
-                cap_pos = self._encode(prompt, te_compiled)
-                self._perf["cold"]["text_encoder"] = time.perf_counter() - t_enc
-                # WARM, free: the negative prompt is a second forward inside the
-                # SAME residency with identical padded shapes, so it reuses the
-                # graph. No synthetic repeat needed.
-                if do_cfg:
-                    t_enc = time.perf_counter()
-                    cap_neg = self._encode(NEGATIVE_PROMPT, te_compiled)
-                    self._perf["warm"]["text_encoder"] = time.perf_counter() - t_enc
-                else:
-                    cap_neg = None
-                # Unchanged meaning: the functional total of both forwards.
-                self._perf["components"]["text_encoder"] = time.perf_counter() - t0
+                cap_neg = self._encode(NEGATIVE_PROMPT, te_compiled)
+                self._perf["warm"]["text_encoder"] = time.perf_counter() - t_enc
+            else:
+                cap_neg = None
+            # Unchanged meaning: the functional total of both forwards.
+            self._perf["components"]["text_encoder"] = time.perf_counter() - t0
             if self.config.evict_components:
                 del te_compiled, text_encoder
                 gc.collect()
@@ -393,7 +347,6 @@ class ZImageTTPipeline:
                 else:
                     pred = pos
                 self._perf["steps"].append(time.perf_counter() - t0)
-                step_graphs.append(_graphs_compiled())
 
                 noise_pred = (-pred).squeeze(2)
                 latents = self.scheduler.step(
@@ -424,24 +377,23 @@ class ZImageTTPipeline:
                 )
                 if not self.config.evict_components:
                     self._resident["vae"] = (vae_compiled, vae_wrapper)
-            with _StageCounters(self._perf["counters"], "vae"):
-                t0 = time.perf_counter()
-                image = vae_compiled(latents.to(self._device)).cpu().float()
-                vae_cold = time.perf_counter() - t0
-                self._perf["cold"]["vae"] = vae_cold
-                # Unchanged meaning: the functional decode only.
-                self._perf["components"]["vae"] = vae_cold
-                # WARM: the VAE has no natural second forward, so repeat it here
-                # while still resident. Outputs are discarded, so the returned
-                # image is identical at any warm_iters -- inert at 0.
-                warm_times = []
-                for _ in range(self.config.warm_iters):
-                    t_w = time.perf_counter()
-                    extra = vae_compiled(latents.to(self._device)).cpu().float()
-                    warm_times.append(time.perf_counter() - t_w)
-                    del extra
-                if warm_times:
-                    self._perf["warm"]["vae"] = sum(warm_times) / len(warm_times)
+            t0 = time.perf_counter()
+            image = vae_compiled(latents.to(self._device)).cpu().float()
+            vae_cold = time.perf_counter() - t0
+            self._perf["cold"]["vae"] = vae_cold
+            # Unchanged meaning: the functional decode only.
+            self._perf["components"]["vae"] = vae_cold
+            # WARM: the VAE has no natural second forward, so repeat it here
+            # while still resident. Outputs are discarded, so the returned
+            # image is identical at any warm_iters -- inert at 0.
+            warm_times = []
+            for _ in range(self.config.warm_iters):
+                t_w = time.perf_counter()
+                extra = vae_compiled(latents.to(self._device)).cpu().float()
+                warm_times.append(time.perf_counter() - t_w)
+                del extra
+            if warm_times:
+                self._perf["warm"]["vae"] = sum(warm_times) / len(warm_times)
             if self.config.evict_components:
                 del vae_compiled, vae_wrapper
                 gc.collect()
@@ -449,27 +401,15 @@ class ZImageTTPipeline:
             logger.info("[STAGE] vae: done")
 
         # ---- transformer step cold/warm -------------------------------------
-        # Warm steps are SELECTED, not assumed at index 1. Measured on this model:
-        # step 2 still compiled in one call (uncached +3) and was warm in the next,
-        # so a fixed steps[1:] mean can fold a build-carrying step into "warm" and
-        # overstate it. A step is warm only if it added no graphs.
+        # The transformer stays resident, so only the first step of the first
+        # call carries a build; every later step is warm.
         steps = self._perf["steps"]
         if steps:
             self._perf["cold"]["transformer_step"] = steps[0]
-            warm_steps = [
-                t
-                for i, t in enumerate(steps)
-                if i > 0 and step_graphs[i] == step_graphs[i - 1]
-            ]
-            if warm_steps:
-                self._perf["warm"]["transformer_step"] = sum(warm_steps) / len(
-                    warm_steps
+            if len(steps) > 1:
+                self._perf["warm"]["transformer_step"] = sum(steps[1:]) / (
+                    len(steps) - 1
                 )
-            self._perf["counters"]["transformer_warm_steps"] = {
-                "warm_steps": len(warm_steps),
-                "total_steps": len(steps),
-                "graphs_compiled": step_graphs[-1] - step_graphs[0],
-            }
 
         self._perf["total"] = time.perf_counter() - t_total_start
         return image

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -194,11 +194,11 @@ class ZImageTTPipeline:
     nothing carries over between calls.
     """
 
-    # Every component is loaded, run and freed inside generate(), and eviction
-    # discards the compiled graph with the weights -- so a second generate() call
-    # rebuilds from scratch and timing it reports a cold cycle as warm. The
-    # benchmark harness reads this to skip its outer warmup pass.
-    benchmark_staged_residency = True
+    # Components stay resident (see ZImageConfig.evict_components), so a second
+    # generate() reuses their compiled graphs and is genuinely warm. The harness
+    # therefore runs its normal warmup + steady pair and publishes the steady
+    # pass. Flip to True alongside evict_components if a part needs staging.
+    benchmark_staged_residency = False
 
     # Substitution seams for the module classes. generate() instantiates these
     # attributes rather than the classes directly, so a consumer can swap in a

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -135,9 +135,8 @@ class ZImageTTPipeline:
     # harness runs its normal warmup + steady pair.
     benchmark_staged_residency = False
 
-    # Substitution seams for the module classes. generate() instantiates these
-    # attributes rather than the classes directly, so a consumer can swap in a
-    # subclass without copying generate(). Defaults keep behaviour identical.
+    # Swapped by the PCC e2e for checking subclasses; generate() uses these
+    # attributes, not the classes directly.
     TEXT_ENCODER_CLS = TextEncoderWrapper
     TRANSFORMER_CLS = TransformerWrapper
     VAE_CLS = VaeDecodeWrapper

--- a/z_image/pytorch/pipeline.py
+++ b/z_image/pytorch/pipeline.py
@@ -216,8 +216,8 @@ class ZImageTTPipeline:
             "steps": [],
             "step_metric_name": "transformer_step",
             "total": None,
-            # Per-component cold/warm split, alongside the functional total in
-            # components[].
+            # The text encoder runs twice per residency, so its two forwards
+            # are reported separately; the harness derives everything else.
             "cold": {},
             "warm": {},
         }
@@ -338,16 +338,6 @@ class ZImageTTPipeline:
             image = vae_compiled(latents.to(self._device)).cpu().float()
             self._perf["components"]["vae"] = time.perf_counter() - t0
             logger.info("[STAGE] vae: done")
-
-        # Step 1 of the first call carries the transformer build; the rest are
-        # warm.
-        steps = self._perf["steps"]
-        if steps:
-            self._perf["cold"]["transformer_step"] = steps[0]
-            if len(steps) > 1:
-                self._perf["warm"]["transformer_step"] = sum(steps[1:]) / (
-                    len(steps) - 1
-                )
 
         self._perf["total"] = time.perf_counter() - t_total_start
         return image


### PR DESCRIPTION
### Ticket

- Closes https://github.com/tenstorrent/tt-xla/issues/6010
- Companion to https://github.com/tenstorrent/tt-xla/pull/6024

### Problem

- Z-Image and FLUX.1 evicted every component inside `generate()`. Eviction discards the compiled graph with the weights, so every later call rebuilt and the benchmark's steady pass measured that rebuild rather than warm performance.

### What's changed

- **Z-Image and FLUX.1 stop evicting.** Memory allows residency on Blackhole: Z-Image 23.2 GiB of 31.83, FLUX.1 15.05. A probe calling `generate()` twice in one process, at reduced steps so the comparison is call-to-call:

| | | |
|---|---|---|
| Z-Image, 4 steps | call 1 492.9s | call 2 **117.5s** (text_encoder 69.4 → 1.77s, vae 160.0 → 2.04s) |
| FLUX.1, 1 step | evicting call 2 105.5s | resident call 2 **15.97s** (T5 84.63 → 0.24s, 353×) |

- Call 2 reports `uncached +0, dynamo +0, progs +0` at every stage.

- **One design per model.** Z-Image and FLUX.1 are resident-only; FLUX.2, Qwen-Image and DiffusionGemma keep evicting. No toggles — `benchmark_staged_residency`, declared by the pipeline, is the only switch the harness reads.

- **Evicting models report their weight movement and warm repeats.** FLUX.2 moves ~30 GiB per call outside every timer, so the benchmark billed it as CPU overhead — 359.9s of a 1607s call against ~2s on a resident model. A `_staging()` scope accumulates placements and evictions into `_perf["staging"]` and the repeats into `_perf["synthetic"]`, so `cpu_overhead_s` means host bookkeeping everywhere. Qwen-Image and DiffusionGemma do the same; DiffusionGemma's `_load_sharded()` and `free_tt_graphs()` had a 49 GiB model's movement landing in host overhead.

- **SDXL-Lightning and Playground-v2.5 gain the shared pipeline they never had.** Each had three copies in tt-xla (benchmark, PCC e2e, demo) which had drifted; one implementation here replaces all three, with a `_check` hook for the PCC path. Both are pinned to `p150-perf` in tt-xla: residency makes peak DRAM the 8.14 GiB sum rather than one component, which OOMs a Wormhole n150.

- **DiffusionGemma owns its residency, timings and PCC seam.** It gains a `_perf` dict on the shared schema, timers that exclude the `_staging()` windows so no second is counted twice, and a no-op `_check` whose `golden_fn` is a callable — so the shipped pipeline never pays for a CPU forward of a 26B model. Its benchmark used to reach into the private `_staged_forwards` and re-do `generate()`'s body to insert timers; it now just calls `generate()`.

- **`warm_iters` is unified** to mean extra in-residency passes with a floor of 0 everywhere (it meant *total* in `qwen_image`, default 2). This mattered: Qwen-Image's demo and PCC test both passed `1` meaning "no repeat" and would have silently paid for an extra full VAE decode.

- **Playground's negative-prompt encode is timed.** `_encode` carried no timer, so a second pass through both CLIP encoders would land in `cpu_overhead_s` rather than in the stage. It does not fire today (`NEGATIVE_PROMPT` is `None`, so the zeros path runs), but it would for any caller passing a real negative prompt.

**Two fixes residency exposed:**
- FLUX.1: diffusers derives `_execution_device` from the first non-CPU `nn.Module`. Evicting left nothing on device so it reported CPU; residency flipped it to XLA, and `FluxPipeline.__call__` allocates latents, timesteps, guidance and image ids there — shifting the VAE output by 1.562e-02. Pinned to CPU.
- Z-Image imports its model classes up front: transformers registers each `ModelOutput` subclass as a pytree node at import and dynamo bakes that set's size into its guards, so a lazy later import forced one encoder rebuild per call (52.7s against a 0.80s warm forward).

### Validation

- **CI run 34318996693** — 13 of 16 jobs pass; the failures are SDXL/Playground on n150 (fixed by the pin) and GLM-Image, which passes on re-run - https://github.com/tenstorrent/tt-xla/actions/runs/34318996693


- **PCC unchanged from baseline.** Z-Image 0.999974 / 0.999660 / 0.999981; FLUX.1 T5 0.988281 + vae 1.000000; FLUX.2 text_encoder 0.984375 + vae 1.000000; Playground's 54 checks identical to six decimals. Qwen-Image 1.000000 / 0.996094 / 0.992188; DiffusionGemma worst 0.980760 against 0.96.

- Demo and benchmark images are byte-identical per model, confirming they run one pipeline.

- Attaching all local logs for reference (32 tests together for affected models (demo/pcc/benchmark) - 
[models_logs.zip](https://github.com/user-attachments/files/31998856/models_logs.zip)

