### PR TITLE
Model bringup qwen3.6-35B-A3B

### DIFF
--- a/qwen_3_6/causal_lm/pytorch/__init__.py
+++ b/qwen_3_6/causal_lm/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.6 causal language modeling PyTorch model implementation for Tenstorrent projects.
+"""
+
+from .loader import ModelLoader, ModelVariant

--- a/qwen_3_6/causal_lm/pytorch/loader.py
+++ b/qwen_3_6/causal_lm/pytorch/loader.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.6 model loader implementation for causal language modeling.
+
+"""
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoConfig
+from typing import Optional
+
+from ....base import ForgeModel
+from ....tools.conv_overrides import slice_depthwise_conv1d_channels
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+
+
+class ModelVariant(StrEnum):
+    """Available Qwen 3.6 MoE model variants for causal language modeling."""
+
+    QWEN_3_6_35B_A3B = "35B_A3B"
+
+
+class ModelLoader(ForgeModel):
+    """Qwen 3.6 model loader implementation for causal language modeling tasks."""
+
+    _VARIANTS = {
+        ModelVariant.QWEN_3_6_35B_A3B: LLMModelConfig(
+            pretrained_model_name="Qwen/Qwen3.6-35B-A3B",
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.QWEN_3_6_35B_A3B
+
+    sample_text = "Give me a short introduction to large language model."
+
+    # Gated DeltaNet conv is 8192 wide; 4096 and 1024 both verified on a
+    # 4-device blackhole mesh. Lower it if the DRAM auto-slice assert returns.
+    CONV_CHANNEL_CHUNK = 4096
+
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
+        super().__init__(variant)
+        self.tokenizer = None
+        self.config = None
+        self.num_layers = num_layers
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="Qwen 3.6",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.NLP_CAUSAL_LM,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_tokenizer(self):
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.tokenizer
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        model_kwargs = {}
+
+        if self.num_layers is not None:
+            # Qwen 3.6 keeps the decoder depth in the nested text_config; setting
+            # it on the outer config is ignored (the model still builds all 64
+            # layers). Set text_config and keep layer_types consistent so the
+            # hybrid linear/full pattern still includes a full_attention layer.
+            config = AutoConfig.from_pretrained(pretrained_model_name)
+            text_cfg = getattr(config, "text_config", config)
+            text_cfg.num_hidden_layers = self.num_layers
+            if getattr(text_cfg, "layer_types", None) is not None:
+                text_cfg.layer_types = text_cfg.layer_types[: self.num_layers]
+            model_kwargs["config"] = config
+
+        model_kwargs |= kwargs
+
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        ).eval()
+
+        # Force use_cache=False so the forward output is logits only. With the
+        # checkpoint default (use_cache=True) it also carries a DynamicCache,
+        # which the runner's pytree comparator can't diff leaf-wise against the
+        # CPU golden. Set after load rather than via from_pretrained kwargs so
+        # it wins regardless of what the caller passed in **kwargs.
+        model.config.use_cache = False
+
+        slice_depthwise_conv1d_channels(model, self.CONV_CHANNEL_CHUNK)
+
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(
+        self, dtype_override=None, prompt: Optional[str] = None, batch_size=1
+    ):
+        if self.tokenizer is None:
+            self._load_tokenizer()
+
+        max_length = self._variant_config.max_length
+
+        messages = [{"role": "user", "content": prompt or self.sample_text}]
+        text = self.tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        prompts = [text]
+
+        inputs = self.tokenizer(
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_length,
+        )
+
+        for key in inputs:
+            if torch.is_tensor(inputs[key]):
+                inputs[key] = inputs[key].repeat_interleave(batch_size, dim=0)
+
+        return inputs
+
+    def load_config(self):
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.config
+
+    def get_mesh_config(self, num_devices: int):
+        mesh_shape = (1, num_devices)
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        shard_specs = {}
+
+        for layer in model.model.layers:
+            # Every layer is MoE: the routed experts' fused weights
+            # (mlp.experts.gate_up_proj / down_proj) are sharded on the expert
+            # dimension by get_tt_moe_shard_specs. The router (mlp.gate.weight)
+            # and shared_expert_gate stay replicated so every device can score
+            # all 256 experts before dispatch. The always-on shared expert is a
+            # dense MLP: column-parallel gate/up, row-parallel down.
+            shared = layer.mlp.shared_expert
+            shard_specs[shared.gate_proj.weight] = ("model", "batch")
+            shard_specs[shared.up_proj.weight] = ("model", "batch")
+            shard_specs[shared.down_proj.weight] = ("batch", "model")
+
+            if hasattr(layer, "self_attn"):
+                sa = layer.self_attn
+                shard_specs[sa.q_proj.weight] = ("batch", "model")
+                shard_specs[sa.k_proj.weight] = ("batch", "model")
+                shard_specs[sa.v_proj.weight] = ("batch", "model")
+                shard_specs[sa.o_proj.weight] = ("model", "batch")
+
+            elif hasattr(layer, "linear_attn"):
+                la = layer.linear_attn
+                shard_specs[la.in_proj_qkv.weight] = ("model", "batch")
+                if hasattr(la, "conv1d"):
+                    shard_specs[la.conv1d.weight] = (None, None, None)
+                shard_specs[la.in_proj_z.weight] = ("model", "batch")
+                shard_specs[la.in_proj_a.weight] = ("model", "batch")
+                shard_specs[la.in_proj_b.weight] = ("model", "batch")
+                shard_specs[la.out_proj.weight] = ("batch", "model")
+                if hasattr(la, "dt_bias"):
+                    shard_specs[la.dt_bias] = ("model",)
+                if hasattr(la, "A_log"):
+                    shard_specs[la.A_log] = ("model",)
+
+        shard_specs[model.model.embed_tokens.weight] = ("model", "batch")
+        if hasattr(model, "lm_head"):
+            shard_specs[model.lm_head.weight] = ("model", "batch")
+
+        return shard_specs
+
+    def load_activation_shard_spec(self, model):
+        """Sharding constraints for intermediate ACTIVATIONS (not weights).
+
+        The gated-delta block's fused ``in_proj_qkv`` is sharded contiguously on
+        the "model" axis; the subsequent ``torch.split`` into [Q, K, V] cuts that
+        sharded axis at points that don't align with the per-device boundaries,
+        which miscompiles under Shardy and scrambles q/k/v before the recurrence
+        (full-model PCC collapses). Replicating the conv output before the split
+        makes the split run on correct data.
+        """
+        constraints = {}
+        for layer in model.model.layers:
+            if layer.layer_type == "linear_attention":
+                constraints[layer.linear_attn.conv1d] = None
+        return constraints

--- a/qwen_3_6/multimodal/pytorch/__init__.py
+++ b/qwen_3_6/multimodal/pytorch/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.6 multimodal PyTorch model implementation for Tenstorrent projects.
+"""
+
+from .loader import ModelLoader, ModelVariant

--- a/qwen_3_6/multimodal/pytorch/loader.py
+++ b/qwen_3_6/multimodal/pytorch/loader.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+Qwen 3.6 vision-language (image + text -> text) model loader.
+
+Loads the Qwen 3.6 VLM (vision encoder + hybrid Gated DeltaNet / full-attention
+MoE text decoder) via AutoModelForImageTextToText for image-conditioned
+generation.
+
+Qwen 3.6 reuses the Qwen 3.5 MoE architecture verbatim: the checkpoint ships
+``model_type: "qwen3_5_moe"`` and ``Qwen3_5MoeForConditionalGeneration``, so the
+stock transformers ``qwen3_5_moe`` implementation loads it and the Qwen 3.5
+shard map applies unchanged. The vision tower is depth 27, hidden 1152, patch
+16, projecting to the 2048-wide text decoder.
+"""
+
+from transformers import AutoModelForImageTextToText, AutoProcessor, AutoConfig
+from typing import Optional
+
+from ....base import ForgeModel
+from ....tools.conv_overrides import slice_depthwise_conv1d_channels
+from ....config import (
+    LLMModelConfig,
+    ModelInfo,
+    ModelGroup,
+    ModelTask,
+    ModelSource,
+    Framework,
+    StrEnum,
+)
+from ....tools.utils import cast_input_to_type
+
+
+class ModelVariant(StrEnum):
+    """Available Qwen 3.6 multimodal model variants."""
+
+    QWEN_3_6_35B_A3B = "Qwen/Qwen3.6-35B-A3B"
+
+
+class ModelLoader(ForgeModel):
+    """Qwen 3.6 VLM loader (image + text → text) for llmbox, galaxy, and qb2."""
+
+    _VARIANTS = {
+        ModelVariant.QWEN_3_6_35B_A3B: LLMModelConfig(
+            pretrained_model_name=str(ModelVariant.QWEN_3_6_35B_A3B),
+            max_length=128,
+        ),
+    }
+
+    DEFAULT_VARIANT = ModelVariant.QWEN_3_6_35B_A3B
+
+    sample_text = "What animal is on the candy?"
+    sample_image_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/p-blog/candy.JPG"
+
+    min_pixels = 56 * 56
+    max_pixels = 14 * 28 * 1280
+
+    # Gated DeltaNet conv is 8192 wide; 4096 and 1024 both verified on a
+    # 4-device blackhole mesh. Lower it if the DRAM auto-slice assert returns.
+    CONV_CHANNEL_CHUNK = 4096
+
+    def __init__(
+        self, variant: Optional[ModelVariant] = None, num_layers: Optional[int] = None
+    ):
+        """
+        Args:
+            variant: Which Qwen 3.5 variant to load.
+            num_layers: If set, truncate the text decoder to this many layers.
+        """
+        super().__init__(variant)
+        self.processor = None
+        self.config = None
+        self.num_layers = num_layers
+
+    @classmethod
+    def _get_model_info(cls, variant: Optional[ModelVariant] = None) -> ModelInfo:
+        if variant is None:
+            variant = cls.DEFAULT_VARIANT
+
+        return ModelInfo(
+            model="Qwen 3.6",
+            variant=variant,
+            group=ModelGroup.GENERALITY,
+            task=ModelTask.MM_CONDITIONAL_GENERATION,
+            source=ModelSource.HUGGING_FACE,
+            framework=Framework.TORCH,
+        )
+
+    def _load_processor(self, dtype_override=None):
+        kwargs = {
+            "min_pixels": self.min_pixels,
+            "max_pixels": self.max_pixels,
+        }
+        if dtype_override is not None:
+            kwargs["torch_dtype"] = dtype_override
+        self.processor = AutoProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name, **kwargs
+        )
+        return self.processor
+
+    def load_model(self, *, dtype_override=None, **kwargs):
+        """Load the full Qwen 3.6 VLM (vision encoder + hybrid MoE text decoder).
+
+        AutoModelForImageTextToText resolves to
+        Qwen3_5MoeForConditionalGeneration (the checkpoint declares the
+        qwen3_5_moe architecture).
+
+        Args:
+            dtype_override: torch.dtype forwarded to the processor. The model
+                itself loads in the checkpoint dtype (bfloat16 per config).
+
+        Returns:
+            torch.nn.Module in eval mode with use_cache=False.
+        """
+        pretrained_model_name = self._variant_config.pretrained_model_name
+
+        if self.processor is None:
+            self._load_processor(dtype_override)
+
+        model_kwargs = {}
+
+        if self.num_layers is not None:
+            # Qwen 3.6 keeps the decoder depth in the nested text_config; setting
+            # it on the outer VLM config is ignored (the model still builds all 64
+            # layers). Set text_config and keep layer_types consistent so the
+            # hybrid linear/full pattern still includes a full_attention layer.
+            config = AutoConfig.from_pretrained(pretrained_model_name)
+            text_cfg = getattr(config, "text_config", config)
+            text_cfg.num_hidden_layers = self.num_layers
+            if getattr(text_cfg, "layer_types", None) is not None:
+                text_cfg.layer_types = text_cfg.layer_types[: self.num_layers]
+            model_kwargs["config"] = config
+
+        model_kwargs |= kwargs
+
+        model = AutoModelForImageTextToText.from_pretrained(
+            pretrained_model_name, **model_kwargs
+        ).eval()
+
+        # Force use_cache=False so the forward output is logits only. With the
+        # checkpoint default (use_cache=True) it also carries a DynamicCache,
+        # which the runner's pytree comparator can't diff leaf-wise against the
+        # CPU golden. Set it on both the outer VLM config and the nested
+        # text_config (the language_model reads text_config), after load so it
+        # wins regardless of what the caller passed in **kwargs.
+        model.config.use_cache = False
+        if getattr(model.config, "text_config", None) is not None:
+            model.config.text_config.use_cache = False
+
+        slice_depthwise_conv1d_channels(model, self.CONV_CHANNEL_CHUNK)
+
+        self.config = model.config
+        self.model = model
+        return model
+
+    def load_inputs(
+        self,
+        dtype_override=None,
+        batch_size=1,
+        prompt: Optional[str] = None,
+        image_url: Optional[str] = None,
+    ):
+        """Build a multimodal (image + text) input dict via the Qwen 3.6 processor.
+
+        Args:
+            dtype_override: If given, cast pixel_values to this dtype.
+            batch_size: Only batch_size=1 supported; pixel_values shapes are image-specific.
+            prompt: Override the default sample text prompt.
+            image_url: Override the default sample image URL.
+
+        Returns:
+            dict with input_ids, attention_mask, pixel_values, image_grid_thw.
+        """
+        if self.processor is None:
+            self._load_processor(dtype_override)
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "url": image_url or self.sample_image_url},
+                    {"type": "text", "text": prompt or self.sample_text},
+                ],
+            }
+        ]
+
+        inputs = self.processor.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+
+        if dtype_override is not None and "pixel_values" in inputs:
+            inputs["pixel_values"] = cast_input_to_type(
+                inputs["pixel_values"], dtype_override
+            )
+
+        return inputs
+
+    def get_mesh_config(self, num_devices: int):
+        mesh_shape = (1, num_devices)
+        return mesh_shape, ("batch", "model")
+
+    def load_shard_spec(self, model):
+        """Tensor-parallel shard specifications for the full VLM."""
+        shard_specs = {}
+
+        for block in model.model.visual.blocks:
+            # Megatron-style: fused qkv is column-parallel (shard output / heads),
+            # proj is row-parallel (shard input / heads -> all-reduce after).
+            shard_specs[block.attn.qkv.weight] = ("model", "batch")
+            if block.attn.qkv.bias is not None:
+                shard_specs[block.attn.qkv.bias] = ("model",)
+            shard_specs[block.attn.proj.weight] = ("batch", "model")
+
+            shard_specs[block.mlp.linear_fc1.weight] = ("model", None)
+            if block.mlp.linear_fc1.bias is not None:
+                shard_specs[block.mlp.linear_fc1.bias] = ("model",)
+            shard_specs[block.mlp.linear_fc2.weight] = (None, "model")
+
+        merger = model.model.visual.merger
+        shard_specs[merger.linear_fc1.weight] = ("model", "batch")
+        if merger.linear_fc1.bias is not None:
+            shard_specs[merger.linear_fc1.bias] = ("model",)
+        shard_specs[merger.linear_fc2.weight] = ("batch", "model")
+
+        for layer in model.model.language_model.layers:
+            # Every layer is MoE: the routed experts' fused weights
+            # (mlp.experts.gate_up_proj / down_proj) are sharded on the expert
+            # dimension by get_tt_moe_shard_specs. The router (mlp.gate.weight)
+            # and shared_expert_gate stay replicated so every device can score
+            # all 256 experts before dispatch. The always-on shared expert is a
+            # dense MLP: column-parallel gate/up, row-parallel down.
+            shared = layer.mlp.shared_expert
+            shard_specs[shared.gate_proj.weight] = ("model", "batch")
+            shard_specs[shared.up_proj.weight] = ("model", "batch")
+            shard_specs[shared.down_proj.weight] = ("batch", "model")
+
+            if layer.layer_type == "full_attention":
+                shard_specs[layer.self_attn.q_proj.weight] = ("batch", "model")
+                shard_specs[layer.self_attn.k_proj.weight] = ("batch", "model")
+                shard_specs[layer.self_attn.v_proj.weight] = ("batch", "model")
+                shard_specs[layer.self_attn.o_proj.weight] = ("model", "batch")
+
+            elif layer.layer_type == "linear_attention":
+                shard_specs[layer.linear_attn.in_proj_qkv.weight] = ("model", "batch")
+                shard_specs[layer.linear_attn.in_proj_z.weight] = ("model", "batch")
+                shard_specs[layer.linear_attn.in_proj_b.weight] = ("model", "batch")
+                shard_specs[layer.linear_attn.in_proj_a.weight] = ("model", "batch")
+                shard_specs[layer.linear_attn.out_proj.weight] = ("batch", "model")
+
+                shard_specs[layer.linear_attn.conv1d.weight] = (None, None, None)
+                shard_specs[layer.linear_attn.dt_bias] = ("model",)
+                shard_specs[layer.linear_attn.A_log] = ("model",)
+
+        shard_specs[model.lm_head.weight] = ("model", "batch")
+
+        return shard_specs
+
+    def load_activation_shard_spec(self, model):
+        """Sharding constraints for intermediate ACTIVATIONS.
+
+        The gated-delta block's fused ``in_proj_qkv`` is sharded contiguously on
+        the "model" axis; the subsequent ``torch.split`` into [Q, K, V] cuts that
+        sharded axis at points that don't align with the per-device boundaries,
+        which miscompiles under Shardy and scrambles q/k/v before the recurrence
+        (full-model PCC collapses). Replicating the conv output before the split
+        makes the split run on correct data.
+        """
+        constraints = {}
+        for layer in model.model.language_model.layers:
+            if layer.layer_type == "linear_attention":
+                constraints[layer.linear_attn.conv1d] = None
+        return constraints
+
+    def load_config(self):
+        """Return the top-level Qwen3_5MoeConfig (VLM; Qwen 3.6 reuses this class).
+
+        Sub-configs: config.text_config, config.vision_config
+        """
+        self.config = AutoConfig.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+        return self.config

--- a/tools/conv_overrides.py
+++ b/tools/conv_overrides.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Convolution rewrites for shapes the TT backend cannot run as-is."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def _is_depthwise_conv1d(module) -> bool:
+    if not isinstance(module, nn.Conv1d):
+        return False
+    return (
+        module.groups == module.in_channels
+        and module.in_channels == module.out_channels
+    )
+
+
+def _channel_sliced_conv1d_forward(self, hidden_states):
+    # Depthwise, so channels are independent: no halo, no partial sums, and the
+    # result is identical to the unpatched module, padding included.
+    chunk = self._tt_conv_channel_chunk
+    outputs = []
+    for start in range(0, self.in_channels, chunk):
+        end = min(start + chunk, self.in_channels)
+        outputs.append(
+            F.conv1d(
+                hidden_states[:, start:end, :],
+                self.weight[start:end],
+                self.bias[start:end] if self.bias is not None else None,
+                stride=self.stride,
+                padding=self.padding,
+                dilation=self.dilation,
+                groups=end - start,
+            )
+        )
+    return torch.cat(outputs, dim=1)
+
+
+def slice_depthwise_conv1d_channels(model, chunk: int) -> int:
+    """Split wide depthwise conv1ds in ``model`` into ``chunk``-channel slices.
+
+    ttnn can only slice a conv on height and width, so a deep but spatially tiny
+    one has no usable axis and aborts. Channels are the free axis here.
+
+    ``chunk`` has no default because the workable size depends on free L1, which
+    varies by arch and mesh; each loader passes its own measured value. Use a
+    divisor of the channel count -- 10240 with chunk 4096 leaves a 2048 tail,
+    and 2048 has been measured not to fit.
+
+    Returns the number of modules patched.
+    """
+    patched = 0
+    for module in model.modules():
+        if not _is_depthwise_conv1d(module) or module.in_channels <= chunk:
+            continue
+        module._tt_conv_channel_chunk = chunk
+        module.forward = _channel_sliced_conv1d_forward.__get__(module, type(module))
+        patched += 1
+    return patched


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5968)

### Problem description

Qwen 3.6 35B-A3B aborts before producing anything. Its Gated DeltaNet block runs a depthwise short convolution over the fused QKV stream 8192 channels, kernel 4 which does not fit L1 and which ttnn cannot split:
```
DRAM Auto slice could not find valid slice configuration.
Tried up to 1 slices for width-slicing on output dimension 23.
```
ttnn slices convs only on height and width. This output is `1 x 23 x 8192`: height is 1 and width 23 rounds into a single tile, so neither is splittable, while the 8192 channels holding the memory are not a slicing option at all. 

### What's changed
Split the conv on channels in the loader instead. Depthwise means each channel is independent, so the split is exact no halo, no partial sums. One 8192-channel conv becomes two of 4096.

- **`tools/conv_overrides.py`** (new): `slice_depthwise_conv1d_channels(model, chunk)`, gated to fully depthwise convs so ordinary convs are untouched. `chunk` is required, not defaulted the workable size depends on free L1, which varies by arch and mesh.

Causal_lm is passing with 0.99 pcc.
Multimodal is passing with 0.87 pcc.

### Logs
[qwen3_6_mm1.log](https://github.com/user-attachments/files/31707546/qwen3_6_mm1.log)
[qwen36_causal.log](https://github.com/user-attachments/files/31707568/qwen36_causal.log)

### Checklist
- [ ] New/Existing tests provide coverage for changes
