### PR TITLE
[VibeVoice] Add the TTS path, per-component variants and a chunked acoustic encode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/VibeVoice"]
 	path = third_party/VibeVoice
-	url = https://github.com/microsoft/VibeVoice
+	url = https://github.com/vibevoice-community/VibeVoice

--- a/vibevoice/pytorch/compat.py
+++ b/vibevoice/pytorch/compat.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""transformers>=5 compatibility shims for the vendored VibeVoice source.
+
+The vendored fork pins ``transformers==4.51.3``; tt-forge-models runs
+transformers 5.x. Everything here is a runtime patch applied from the loader so
+the vendored files stay unmodified, which keeps the submodule a clean upstream
+checkout.
+
+Split into three groups by when they must run:
+
+* :func:`apply_pre_import` - before the vendored package is imported at all.
+* :func:`patch_runtime` - after import, on module-level singletons.
+* :func:`patch_inference_class` - after import, on the inference model class.
+
+Every patch is idempotent, so calling these repeatedly (once per loader
+instantiation) is safe.
+"""
+
+import sys
+import types
+
+# --------------------------------------------------------------------------
+# pre-import
+# --------------------------------------------------------------------------
+
+
+def _alias_qwen2_fast_tokenizer():
+    """Restore the ``tokenization_qwen2_fast`` module path removed in transformers 5.
+
+    transformers 5 dropped the slow/fast tokenizer split: ``Qwen2Tokenizer`` is
+    now itself the tokenizers-backed implementation and ``Qwen2TokenizerFast``
+    survives only as a top-level deprecation alias. VibeVoice's text tokenizer
+    imports the class from the old submodule path, so stand up a shim module
+    exposing both names under that path.
+    """
+    name = "transformers.models.qwen2.tokenization_qwen2_fast"
+    if name in sys.modules:
+        return
+    from transformers.models.qwen2.tokenization_qwen2 import Qwen2Tokenizer
+
+    shim = types.ModuleType(name)
+    shim.Qwen2Tokenizer = Qwen2Tokenizer
+    shim.Qwen2TokenizerFast = Qwen2Tokenizer
+    sys.modules[name] = shim
+
+
+def patch_idempotent_register():
+    """Make ``AutoModel(.ForCausalLM).register`` idempotent.
+
+    transformers>=5 pre-registers the VibeVoice sub-configs, so the explicit
+    ``AutoModel.register(...)`` calls at module import time would raise
+    "already used by a Transformers model". The registrations are identical
+    config->model pairs, so forcing ``exist_ok=True`` is safe.
+    """
+    import transformers
+
+    for cls_name in ("AutoModel", "AutoModelForCausalLM"):
+        cls = getattr(transformers, cls_name)
+        if getattr(cls.register, "_tt_idempotent", False):
+            continue
+
+        def _make(orig):
+            def register(config_class, model_class=None, exist_ok=False):
+                return orig(config_class, model_class, exist_ok=True)
+
+            register._tt_idempotent = True
+            return staticmethod(register)
+
+        setattr(cls, "register", _make(cls.register))
+
+
+def apply_pre_import():
+    """Patches that must land before the vendored package is imported."""
+    _alias_qwen2_fast_tokenizer()
+    patch_idempotent_register()
+
+
+# --------------------------------------------------------------------------
+# post-import runtime patches
+# --------------------------------------------------------------------------
+
+
+def patch_scheduler_real_device():
+    """Build the DPM-Solver scheduler on a real device, not under meta init.
+
+    transformers 5 constructs models inside a ``torch.device("meta")`` context.
+    ``DPMSolverMultistepScheduler.__init__`` precomputes its betas/sigmas as
+    plain tensors and then calls ``self.sigmas.to("cpu")``, which raises
+    "Cannot copy out of meta tensor; no data!". The scheduler holds no
+    parameters and is not part of the checkpoint, so forcing its construction
+    onto CPU is safe.
+    """
+    import torch
+
+    from vibevoice.schedule.dpm_solver import DPMSolverMultistepScheduler
+
+    orig = DPMSolverMultistepScheduler.__init__
+    if getattr(orig, "_tt_real_device", False):
+        return
+
+    def __init__(self, *args, **kwargs):
+        with torch.device("cpu"):
+            return orig(self, *args, **kwargs)
+
+    __init__._tt_real_device = True
+    DPMSolverMultistepScheduler.__init__ = __init__
+
+
+def patch_get_text_config():
+    """Point ``VibeVoiceConfig.get_text_config()`` at the Qwen decoder config.
+
+    transformers 5 builds the generation cache from
+    ``self.config.get_text_config(decoder=True)``, which recognises a nested
+    text config only under the names ``decoder``/``generator``/``text_config``.
+    VibeVoice calls its own ``decoder_config``, so the base implementation
+    falls through to the composite config and ``DynamicCache`` dies on
+    ``'VibeVoiceConfig' object has no attribute 'num_hidden_layers'``.
+    """
+    from vibevoice.modular.configuration_vibevoice import VibeVoiceConfig
+
+    if getattr(VibeVoiceConfig.get_text_config, "_tt_decoder_config", False):
+        return
+
+    def get_text_config(self, decoder=None, encoder=None):
+        return self.decoder_config
+
+    get_text_config._tt_decoder_config = True
+    VibeVoiceConfig.get_text_config = get_text_config
+
+
+def patch_dynamic_cache_legacy_views():
+    """Re-expose ``DynamicCache.key_cache`` / ``.value_cache``.
+
+    transformers 5 moved the per-layer tensors behind ``cache.layers[i].keys``
+    and ``.values``. VibeVoice's CFG path walks
+    ``zip(past_key_values.key_cache, past_key_values.value_cache)`` and mutates
+    the entries in place to fix up the negative-branch KV cache. The properties
+    return the live tensor objects, so in-place writes still land on the cache.
+    """
+    from transformers.cache_utils import DynamicCache
+
+    if hasattr(DynamicCache, "key_cache"):
+        return
+
+    DynamicCache.key_cache = property(
+        lambda self: [layer.keys for layer in self.layers if layer.keys is not None]
+    )
+    DynamicCache.value_cache = property(
+        lambda self: [layer.values for layer in self.layers if layer.values is not None]
+    )
+
+
+def patch_init_weights_respects_loaded():
+    """Stop ``_init_weights`` from overwriting weights already loaded.
+
+    The single worst defect on this path, and it raises nothing.
+
+    ``VibeVoicePreTrainedModel._init_weights`` re-randomises any ``nn.Linear``
+    it is handed::
+
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+
+    transformers 4.51 only ever called it on modules the checkpoint did not
+    cover. transformers 5 calls it on *every* module after loading and expects
+    each ``_init_weights`` implementation to honour the ``_is_hf_initialized``
+    marker that the loader stamps onto restored parameters. The vendored
+    implementation predates that contract, so under transformers 5 it clobbers
+    the two ``SpeechConnector`` blocks — ``model.{acoustic,semantic}_connector``
+    ``fc1``/``fc2`` weights back to N(0, 0.02) and their biases to exactly zero.
+
+    Every other submodule survives because it is built through
+    ``AutoModel.from_config`` and so carries its own ``_init_weights``; the
+    connectors are the only plain ``nn.Module`` children of ``VibeVoiceModel``.
+    Their ``norm`` survives too, since ``LlamaRMSNorm`` matches neither
+    ``nn.Linear`` nor ``nn.LayerNorm``.
+
+    The consequence is that the voice-prompt latents are projected into the LM's
+    embedding space by an untrained matrix, so the conditioning carries no
+    speaker or content information. Generation still produces fluent speech —
+    it just has nothing to do with the prompt, which is why it survived every
+    signal-level check. See :func:`assert_speech_stack_loaded`.
+    """
+    from vibevoice.modular.modeling_vibevoice import VibeVoicePreTrainedModel
+
+    orig = VibeVoicePreTrainedModel._init_weights
+    if getattr(orig, "_tt_respects_loaded", False):
+        return
+
+    def _init_weights(self, module):
+        params = list(module.parameters(recurse=False))
+        if params and all(
+            getattr(p, "_is_hf_initialized", False) for p in params if p is not None
+        ):
+            return
+        return orig(self, module)
+
+    _init_weights._tt_respects_loaded = True
+    VibeVoicePreTrainedModel._init_weights = _init_weights
+
+
+def patch_runtime():
+    """Post-import patches that apply to module-level singletons."""
+    patch_scheduler_real_device()
+    patch_get_text_config()
+    patch_dynamic_cache_legacy_views()
+    patch_init_weights_respects_loaded()
+
+
+# --------------------------------------------------------------------------
+# inference-class patches
+# --------------------------------------------------------------------------
+
+
+def patch_tie_weights(cls):
+    """Restore lm_head <-> embed_tokens tying, which silently breaks under tf5.
+
+    Two separate problems, and the second one corrupts output rather than
+    raising:
+
+    1. transformers>=5 calls ``tie_weights(recompute_mapping=..., missing_keys=...)``
+       while the vendored method declares ``tie_weights(self)``.
+    2. The vendored guard reads ``self.config.tie_word_embeddings``, but
+       transformers 5 dropped that attribute from ``PreTrainedConfig`` and
+       ``VibeVoiceConfig`` never sets it, so the lookup yields ``None`` and the
+       method returns without tying. VibeVoice-1.5B ships no ``lm_head.weight``
+       in its checkpoint (it is tied), so the head stays at its random
+       initialisation and generation produces noise with no error raised. The
+       real flag lives on ``config.decoder_config.tie_word_embeddings``.
+
+    Callers must assert the tie actually took - see
+    :func:`assert_lm_head_tied`.
+    """
+    if getattr(cls.__dict__.get("tie_weights"), "_tt_decoder_tying", False):
+        return
+
+    def tie_weights(self, *args, **kwargs):
+        decoder_config = getattr(self.config, "decoder_config", None)
+        if not getattr(decoder_config, "tie_word_embeddings", False):
+            return
+        embed_tokens = getattr(self.model.language_model, "embed_tokens", None)
+        if embed_tokens is None or not hasattr(self, "lm_head"):
+            return
+        self.lm_head.weight = embed_tokens.weight
+
+    tie_weights._tt_decoder_tying = True
+    cls.tie_weights = tie_weights
+
+
+def assert_lm_head_tied(model):
+    """Fail loudly if ``lm_head`` did not end up sharing the embedding table.
+
+    An untied head is not an error anywhere in the stack - it is simply random,
+    and the generated audio is noise. Compare storage identity rather than
+    trusting the config.
+    """
+    embed = model.get_input_embeddings().weight
+    head = model.lm_head.weight
+    if head.data_ptr() != embed.data_ptr():
+        raise RuntimeError(
+            "lm_head is not tied to embed_tokens: the head is at its random "
+            "initialisation and generation would be noise. VibeVoice-1.5B ships "
+            "no lm_head.weight in its checkpoint, so tying is mandatory."
+        )
+
+
+def restore_nonpersistent_buffers(model):
+    """Re-materialise buffers registered ``persistent=False``.
+
+    The acoustic tokenizer holds its VAE sampling scale as::
+
+        self.register_buffer("fix_std", torch.tensor(config.fix_std),
+                             persistent=False)
+
+    Being non-persistent it is absent from the checkpoint by design, and
+    transformers 5 builds models under a ``torch.device("meta")`` context and
+    then materialises them from the checkpoint only. Nothing re-runs
+    ``__init__``, so this buffer is handed back as *uninitialised memory*: it
+    read 8986389.0, 4.3e-17 and 2.6e-06 on three consecutive loads of the same
+    checkpoint, against a true value of 0.5.
+
+    It is not a dead field. ``std_dist_type`` is ``"gaussian"`` for this
+    checkpoint, so the acoustic encode does::
+
+        std = torch.randn(batch) * (self.std / 0.8)
+        latents = mean + std * torch.randn_like(mean)
+
+    which scales the noise added to the voice-prompt latents by the garbage
+    value. That both destroys the conditioning and makes every run differ,
+    which is the run-to-run variation in generated length seen under a fixed
+    seed.
+
+    Reset from the config, which is where the true value lives.
+    """
+    import torch
+
+    for name in ("acoustic_tokenizer", "semantic_tokenizer"):
+        tok = getattr(model.model, name, None)
+        buf = getattr(tok, "fix_std", None) if tok is not None else None
+        if buf is None:
+            continue
+        want = getattr(tok.config, "fix_std", None)
+        if want is None:
+            continue
+        tok.fix_std = torch.tensor(want, dtype=buf.dtype, device=buf.device)
+
+
+def assert_speech_stack_loaded(model):
+    """Fail loudly if the speech conditioning path is not the trained one.
+
+    Guards the two defects that produce fluent-but-unrelated audio with nothing
+    raised anywhere in the stack — see
+    :func:`patch_init_weights_respects_loaded` and
+    :func:`restore_nonpersistent_buffers`. Both are cheap to check and neither
+    is detectable from the generated waveform's signal statistics.
+    """
+    for name in ("acoustic_connector", "semantic_connector"):
+        connector = getattr(model.model, name)
+        for fc_name in ("fc1", "fc2"):
+            bias = getattr(connector, fc_name).bias
+            if bias is not None and not bias.any():
+                raise RuntimeError(
+                    f"{name}.{fc_name}.bias is all zeros, which is the signature of "
+                    "_init_weights() having overwritten the checkpoint. The speech "
+                    "connectors are at their random initialisation, so the voice "
+                    "prompt conditions nothing and the generated audio will be "
+                    "fluent speech unrelated to the input text."
+                )
+
+    for name in ("acoustic_tokenizer", "semantic_tokenizer"):
+        tok = getattr(model.model, name, None)
+        buf = getattr(tok, "fix_std", None) if tok is not None else None
+        want = getattr(tok.config, "fix_std", None) if tok is not None else None
+        if buf is None or want is None:
+            continue
+        if abs(float(buf) - float(want)) > 1e-9:
+            raise RuntimeError(
+                f"{name}.fix_std is {float(buf)!r} but the config says {want!r}. "
+                "This buffer is registered persistent=False, so transformers 5 "
+                "hands back uninitialised memory; it scales the noise added to "
+                "the voice-prompt latents."
+            )
+
+
+def patch_prepare_inputs_for_generation(cls):
+    """Guarantee ``inputs_embeds`` is present in the prepared-inputs dict.
+
+    transformers 4 always emitted the key (possibly ``None``); transformers 5
+    omits it when unused. VibeVoice's CFG branch reads
+    ``negative_model_inputs['inputs_embeds']`` unconditionally and raises
+    ``KeyError``.
+    """
+    orig = cls.prepare_inputs_for_generation
+    if getattr(orig, "_tt_embeds_key", False):
+        return
+
+    def prepare_inputs_for_generation(self, *args, **kwargs):
+        model_inputs = orig(self, *args, **kwargs)
+        model_inputs.setdefault("inputs_embeds", None)
+        return model_inputs
+
+    prepare_inputs_for_generation._tt_embeds_key = True
+    cls.prepare_inputs_for_generation = prepare_inputs_for_generation
+
+
+def patch_generation_mixin(cls):
+    """Adapt the two GenerationMixin helpers whose signatures changed in tf5.
+
+    * ``_prepare_generation_config`` lost the positional ``use_model_defaults``
+      flag that the vendored code passes as ``True``.
+    * ``_prepare_cache_for_generation`` lost its trailing ``device`` argument.
+
+    Both are re-exposed on the model class with the old calling convention,
+    forwarding to the current implementation.
+    """
+    from transformers.generation import GenerationMixin
+
+    base_prepare_config = GenerationMixin._prepare_generation_config
+
+    def _prepare_generation_config(self, generation_config, *args, **kwargs):
+        return base_prepare_config(self, generation_config, **kwargs)
+
+    cls._prepare_generation_config = _prepare_generation_config
+
+    base_prepare_cache = GenerationMixin._prepare_cache_for_generation
+
+    def _prepare_cache_for_generation(
+        self,
+        generation_config,
+        model_kwargs,
+        generation_mode,
+        batch_size,
+        max_cache_length,
+        device=None,
+    ):
+        return base_prepare_cache(
+            self,
+            generation_config,
+            model_kwargs,
+            generation_mode,
+            batch_size,
+            max_cache_length,
+        )
+
+    cls._prepare_cache_for_generation = _prepare_cache_for_generation
+
+
+def patch_inference_class(cls):
+    """Apply every patch that targets the TTS inference model class."""
+    patch_tie_weights(cls)
+    patch_generation_mixin(cls)
+    patch_prepare_inputs_for_generation(cls)

--- a/vibevoice/pytorch/loader.py
+++ b/vibevoice/pytorch/loader.py
@@ -194,19 +194,139 @@ class _VibeVoiceLogitsWrapper(torch.nn.Module):
         return out.logits
 
 
+# ----------------------------------------------------------------------
+# Per-component wrappers for the single-device component tests.
+#
+# Each takes plain tensors and returns one tensor, so the graph test can
+# compare CPU against TT without a pytree comparator. They are thin views onto
+# submodules of the *pretrained* TTS model - PCC against a random-weight model
+# would not say anything about the real pipeline.
+# ----------------------------------------------------------------------
+
+
+class _AcousticEncoder(torch.nn.Module):
+    """Voice-prompt waveform -> acoustic VAE latents (causal conv VAE)."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.encoder = model.model.acoustic_tokenizer.encoder
+
+    def forward(self, audio):
+        return self.encoder(audio)
+
+
+class _AcousticDecoder(torch.nn.Module):
+    """One acoustic latent frame -> waveform chunk."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.decoder = model.model.acoustic_tokenizer.decoder
+
+    def forward(self, latents):
+        return self.decoder(latents)
+
+
+class _SemanticEncoder(torch.nn.Module):
+    """Audio chunk -> semantic features."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.encoder = model.model.semantic_tokenizer.encoder
+
+    def forward(self, audio):
+        return self.encoder(audio)
+
+
+class _Connectors(torch.nn.Module):
+    """Both SpeechConnectors, summed into the LM embedding space.
+
+    Run together rather than separately because that is how the decode loop
+    uses them - ``acoustic_embed + semantic_embed`` forms one diffusion
+    embedding - and because each on its own is only ~2.4M params.
+    """
+
+    def __init__(self, model):
+        super().__init__()
+        self.acoustic = model.model.acoustic_connector
+        self.semantic = model.model.semantic_connector
+
+    def forward(self, acoustic_latent, semantic_feature):
+        return self.acoustic(acoustic_latent) + self.semantic(semantic_feature)
+
+
+class _DiffusionHead(torch.nn.Module):
+    """One denoise step of the prediction head, conditioned on LM hidden state."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.head = model.model.prediction_head
+
+    def forward(self, noisy, timestep, condition):
+        return self.head(noisy, timestep, condition=condition)
+
+
+class _LmPrefill(torch.nn.Module):
+    """Qwen2.5 decoder over the conditioning prompt, plus the LM head."""
+
+    def __init__(self, model):
+        super().__init__()
+        self.lm = model.model.language_model
+        self.head = model.lm_head
+
+    def forward(self, inputs_embeds):
+        out = self.lm(inputs_embeds=inputs_embeds, use_cache=False, return_dict=True)
+        return self.head(out.last_hidden_state)
+
+
 class ModelVariant(StrEnum):
     """Available VibeVoice model variants."""
 
+    #: Whole model, random weights, logits-only forward - the compiler-bringup
+    #: path driven by the generic inference harness.
     VIBEVOICE_1_5B = "1.5B"
+
+    #: Individual components of the TTS pipeline, pretrained weights. Used by
+    #: the single-device component tests; see ``_COMPONENT_WRAPPER``.
+    ACOUSTIC_ENCODER = "AcousticEncoder"
+    ACOUSTIC_DECODER = "AcousticDecoder"
+    SEMANTIC_ENCODER = "SemanticEncoder"
+    CONNECTORS = "Connectors"
+    DIFFUSION_HEAD = "DiffusionHead"
+    LM_PREFILL = "LmPrefill"
+
+
+#: variant -> wrapper class. Membership in this map is what makes a variant a
+#: component variant rather than the whole-model bringup variant.
+_COMPONENT_WRAPPER = {
+    ModelVariant.ACOUSTIC_ENCODER: _AcousticEncoder,
+    ModelVariant.ACOUSTIC_DECODER: _AcousticDecoder,
+    ModelVariant.SEMANTIC_ENCODER: _SemanticEncoder,
+    ModelVariant.CONNECTORS: _Connectors,
+    ModelVariant.DIFFUSION_HEAD: _DiffusionHead,
+    ModelVariant.LM_PREFILL: _LmPrefill,
+}
+
+
+#: Sample counts taken from the reference run rather than invented, so the
+#: component tests exercise the shapes the real pipeline produces.
+#:
+#: The voice prompt ``en-Alice_woman.wav`` is 222480 samples, which the acoustic
+#: tokenizer compresses 3200:1 into 70 latent frames; the conditioning prompt
+#: tokenizes to 128 positions. One decode step consumes one latent frame and
+#: emits one 3200-sample chunk. The diffusion head runs at batch 2 because the
+#: CFG path concatenates the conditional and negative branches.
+_VOICE_PROMPT_SAMPLES = 222480
+_CHUNK_SAMPLES = 3200
+_PROMPT_TOKENS = 128
+_CFG_BATCH = 2
 
 
 class ModelLoader(ForgeModel):
     """VibeVoice model loader implementation."""
 
     _VARIANTS = {
-        ModelVariant.VIBEVOICE_1_5B: ModelConfig(
-            pretrained_model_name="microsoft/VibeVoice-1.5B",
-        ),
+        variant: ModelConfig(pretrained_model_name="microsoft/VibeVoice-1.5B")
+        for variant in ModelVariant
     }
 
     DEFAULT_VARIANT = ModelVariant.VIBEVOICE_1_5B
@@ -250,7 +370,11 @@ class ModelLoader(ForgeModel):
         return self.config
 
     def load_model(self, dtype_override=torch.bfloat16, **kwargs):
-        """Load and return the VibeVoice model instance (random weights).
+        """Load and return the VibeVoice model instance.
+
+        For the component variants this returns that single component of the
+        **pretrained** pipeline, wrapped to a tensors-only forward. For
+        ``VIBEVOICE_1_5B`` it returns the whole model with **random** weights.
 
         Args:
             dtype_override: dtype to cast the whole model to. The upstream
@@ -260,8 +384,18 @@ class ModelLoader(ForgeModel):
                 forward. Defaults to bfloat16.
 
         Returns:
-            torch.nn.Module: The VibeVoice model instance.
+            torch.nn.Module: The VibeVoice model or component instance.
         """
+        wrapper = _COMPONENT_WRAPPER.get(self._variant)
+        if wrapper is not None:
+            # The checkpoint is monolithic - there is no per-component subfolder
+            # to load from - so the whole 2.7B model is built and the component
+            # taken out of it. Real weights are the point: PCC against a
+            # randomly initialised component would not tell us anything about
+            # the pipeline it is part of.
+            model = self.load_tts_model(dtype_override=dtype_override)
+            return wrapper(model).eval()
+
         VibeVoiceForConditionalGeneration, _ = _import_vibevoice()
 
         config = self._load_config()
@@ -273,17 +407,70 @@ class ModelLoader(ForgeModel):
         # non-tensor leaves in VibeVoiceCausalLMOutputWithPast).
         return _VibeVoiceLogitsWrapper(model.eval()).eval()
 
+    def load_component_inputs(self, batch_size=1, dtype_override=torch.bfloat16):
+        """Synthetic tensors at the shapes the real pipeline produces.
+
+        Returned as a list in the wrapper's forward argument order.
+        """
+        if self.config is None:
+            self._load_config()
+
+        acoustic_dim = self.config.acoustic_vae_dim
+        semantic_dim = self.config.semantic_vae_dim
+        hidden = self.config.decoder_config.hidden_size
+        v = self._variant
+
+        if v == ModelVariant.ACOUSTIC_ENCODER:
+            return [
+                torch.randn(batch_size, 1, _VOICE_PROMPT_SAMPLES, dtype=dtype_override)
+            ]
+        if v == ModelVariant.SEMANTIC_ENCODER:
+            return [torch.randn(batch_size, 1, _CHUNK_SAMPLES, dtype=dtype_override)]
+        if v == ModelVariant.ACOUSTIC_DECODER:
+            return [torch.randn(batch_size, acoustic_dim, 1, dtype=dtype_override)]
+        if v == ModelVariant.CONNECTORS:
+            return [
+                torch.randn(batch_size, 1, acoustic_dim, dtype=dtype_override),
+                torch.randn(batch_size, 1, semantic_dim, dtype=dtype_override),
+            ]
+        if v == ModelVariant.DIFFUSION_HEAD:
+            return [
+                torch.randn(_CFG_BATCH, acoustic_dim, dtype=dtype_override),
+                # Float, not int. TimestepEmbedder.timestep_embedding() ends
+                # with `embedding.to(t.dtype)`, so an integer timestep casts the
+                # whole sinusoidal embedding to that integer dtype and the
+                # following Linear fails with "long int != BFloat16". The real
+                # call site casts to the model dtype too: `t.repeat(...).to(x)`.
+                torch.full((_CFG_BATCH,), 500.0, dtype=dtype_override),
+                torch.randn(_CFG_BATCH, hidden, dtype=dtype_override),
+            ]
+        if v == ModelVariant.LM_PREFILL:
+            return [
+                torch.randn(batch_size, _PROMPT_TOKENS, hidden, dtype=dtype_override)
+            ]
+        raise ValueError(f"{v} is not a component variant")
+
     def load_inputs(self, batch_size=1, seq_len=32, dtype_override=torch.bfloat16):
         """Load and return sample inputs for the VibeVoice model.
 
-        The bringup forward path keeps ``speech_tensors=None`` so the model
-        behaves as a Qwen2.5 causal LM with a single (unused) semantic
-        connector call. ``speech_semantic_tensors`` is therefore required but
-        its result is not consumed downstream.
+        For component variants this delegates to
+        :meth:`load_component_inputs`, which returns a list in forward-argument
+        order.
+
+        For ``VIBEVOICE_1_5B`` the bringup forward path keeps
+        ``speech_tensors=None`` so the model behaves as a Qwen2.5 causal LM with
+        a single (unused) semantic connector call.
+        ``speech_semantic_tensors`` is therefore required but its result is not
+        consumed downstream.
 
         Returns:
-            dict: Input tensors that can be fed to the model.
+            dict | list: Input tensors that can be fed to the model.
         """
+        if self._variant in _COMPONENT_WRAPPER:
+            return self.load_component_inputs(
+                batch_size=batch_size, dtype_override=dtype_override
+            )
+
         if self.config is None:
             self._load_config()
 

--- a/vibevoice/pytorch/loader.py
+++ b/vibevoice/pytorch/loader.py
@@ -5,19 +5,39 @@
 VibeVoice model loader implementation.
 
 VibeVoice (microsoft/VibeVoice-1.5B) is a long-form, generation-based
-text-to-speech model. The HuggingFace repo ships weights only; the model
-code lives in the standalone https://github.com/microsoft/VibeVoice repo,
-which is vendored as a pinned git submodule under
-``third_party/VibeVoice/`` (rather than copy-pasting the source). The two
-compat needs — a ``tie_weights`` signature widened for transformers>=5 and an
-idempotent ``AutoModel.register`` — are applied as runtime patches here so the
-upstream files are used unmodified.
+text-to-speech model. The HuggingFace repo ships weights only; the model code
+lives in a standalone GitHub repo, vendored as a pinned git submodule under
+``third_party/VibeVoice/`` (rather than copy-pasting the source). Every
+transformers>=5 incompatibility is handled as a runtime patch in
+``compat.py`` so the upstream files are used unmodified.
 
-The entry class ``VibeVoiceForConditionalGeneration`` is built from the real
-1.5B ``config.json`` (vendored alongside this loader) with random weights —
-no multi-GB safetensors download. The bringup forward path uses
-``speech_tensors=None`` so the model reduces to: embed(input_ids) -> Qwen2.5
-decoder -> lm_head -> logits, which is a clean tensor-in / tensor-out forward.
+**Which repo is pinned, and why it is not Microsoft's.** Microsoft removed the
+VibeVoice-TTS inference stack from ``microsoft/VibeVoice`` on 2025-09-05; the
+file ``modeling_vibevoice_inference.py`` does not exist anywhere in that
+repo's history. What survives there is a *training* forward returning a
+diffusion loss — no ``generate()``, no denoise sampling loop, no VAE
+decode-to-waveform. The submodule therefore pins
+``vibevoice-community/VibeVoice`` @ ``631804b``, a preserved pre-removal fork
+that still carries the full inference path and the ``VibeVoiceProcessor`` TTS
+conditioning path. The model weights are still first-party
+(``microsoft/VibeVoice-1.5B`` on HuggingFace).
+
+Two entry paths are exposed:
+
+``load_model()`` / ``load_inputs()`` — the compiler-bringup path. Builds
+``VibeVoiceForConditionalGeneration`` from the real 1.5B ``config.json``
+(vendored alongside this loader) with **random weights**, so no multi-GB
+safetensors download. The forward passes ``speech_tensors=None`` so the model
+reduces to embed(input_ids) -> Qwen2.5 decoder -> lm_head -> logits, a clean
+tensor-in / tensor-out forward the generic inference harness can compare.
+
+``load_tts_model()`` / ``load_processor()`` / ``load_tts_inputs()`` — the real
+TTS path. Downloads the pretrained checkpoint and returns
+``VibeVoiceForConditionalGenerationInference``, whose ``generate()`` runs the
+acoustic + semantic VAE tokenizers, both connectors, the diffusion-head
+sampling loop, AR generation with KV cache and the acoustic decode to
+waveform. Used by the e2e demo and the per-component tests, not by the
+generic harness (``generate()`` is not a single forward).
 
 Note: the full model is ~2.7B params (the "1.5B" refers to the Qwen LLM
 backbone only; the acoustic/semantic VAE tokenizers, diffusion head and
@@ -31,6 +51,7 @@ from typing import Optional
 
 import torch
 
+from . import compat
 from ...base import ForgeModel
 from ...config import (
     Framework,
@@ -97,10 +118,10 @@ def _patch_tie_weights(cls):
     cls.tie_weights = tie_weights
 
 
-def _import_vibevoice():
-    """Import the VibeVoice entry class + config from the pinned submodule.
+def _register_vibevoice_packages():
+    """Put the submodule's ``vibevoice`` subpackages on ``sys.modules``.
 
-    Returns ``(VibeVoiceForConditionalGeneration, VibeVoiceConfig)``.
+    Shared by both entry paths. Raises if the submodule is missing.
     """
     pkg_dir = _vibevoice_pkg_dir()
     if pkg_dir is None:
@@ -111,10 +132,19 @@ def _import_vibevoice():
 
     importlib.invalidate_caches()
     _register_bare_package("vibevoice", pkg_dir)
-    _register_bare_package("vibevoice.modular", os.path.join(pkg_dir, "modular"))
-    _register_bare_package("vibevoice.schedule", os.path.join(pkg_dir, "schedule"))
+    for sub in ("modular", "schedule", "processor"):
+        _register_bare_package(f"vibevoice.{sub}", os.path.join(pkg_dir, sub))
+    return pkg_dir
 
-    _patch_idempotent_register()
+
+def _import_vibevoice():
+    """Import the VibeVoice entry class + config from the pinned submodule.
+
+    Returns ``(VibeVoiceForConditionalGeneration, VibeVoiceConfig)``.
+    """
+    _register_vibevoice_packages()
+
+    compat.apply_pre_import()
     from vibevoice.modular import modeling_vibevoice as _modeling
     from vibevoice.modular.configuration_vibevoice import VibeVoiceConfig
 
@@ -122,31 +152,23 @@ def _import_vibevoice():
     return _modeling.VibeVoiceForConditionalGeneration, VibeVoiceConfig
 
 
-def _patch_idempotent_register():
-    """Make AutoModel(.ForCausalLM).register idempotent.
+def _import_vibevoice_tts():
+    """Import the TTS inference class + processor from the pinned submodule.
 
-    transformers>=5 pre-registers the VibeVoice sub-configs, so the explicit
-    ``AutoModel.register(...)`` calls at module import time would raise
-    "already used by a Transformers model". The registrations are identical
-    config->model pairs, so forcing ``exist_ok=True`` is safe. Upstream pins
-    transformers<5.0.0; this lets the ported code import under transformers 5.
+    Returns ``(VibeVoiceForConditionalGenerationInference, VibeVoiceProcessor)``
+    with every transformers>=5 patch already applied.
     """
-    import transformers
+    _register_vibevoice_packages()
 
-    for cls_name in ("AutoModel", "AutoModelForCausalLM"):
-        cls = getattr(transformers, cls_name)
-        if getattr(cls.register, "_tt_idempotent", False):
-            continue
-        orig_bound = cls.register
+    compat.apply_pre_import()
+    from vibevoice.modular.modeling_vibevoice_inference import (
+        VibeVoiceForConditionalGenerationInference,
+    )
+    from vibevoice.processor.vibevoice_processor import VibeVoiceProcessor
 
-        def _make(orig):
-            def register(config_class, model_class=None, exist_ok=False):
-                return orig(config_class, model_class, exist_ok=True)
-
-            register._tt_idempotent = True
-            return staticmethod(register)
-
-        setattr(cls, "register", _make(orig_bound))
+    compat.patch_runtime()
+    compat.patch_inference_class(VibeVoiceForConditionalGenerationInference)
+    return VibeVoiceForConditionalGenerationInference, VibeVoiceProcessor
 
 
 class _VibeVoiceLogitsWrapper(torch.nn.Module):
@@ -291,3 +313,115 @@ class ModelLoader(ForgeModel):
         if torch.is_tensor(output):
             return output
         return output.logits
+
+    # ------------------------------------------------------------------
+    # Real TTS path (pretrained weights, full generate()).
+    #
+    # Separate from load_model()/load_inputs() above because generate() is a
+    # sampling loop, not a single forward, so the generic inference harness
+    # cannot drive it. Used by the e2e demo and per-component tests.
+    # ------------------------------------------------------------------
+
+    #: Prompt used by the demo and reference runs when none is given. The
+    #: "Speaker 1:" prefix is required - the processor parses speaker turns out
+    #: of the script and assigns each one a voice sample.
+    DEFAULT_TEXT = (
+        "Speaker 1: Hello from Tenstorrent. This is a VibeVoice end to end test."
+    )
+
+    @staticmethod
+    def default_voice_sample():
+        """Path to a voice-prompt wav shipped with the submodule.
+
+        VibeVoice clones the timbre of a reference clip rather than selecting
+        from fixed speaker IDs, so a wav is a required input. Returns ``None``
+        if the submodule is not checked out.
+        """
+        pkg_dir = _vibevoice_pkg_dir()
+        if pkg_dir is None:
+            return None
+        wav = os.path.join(
+            os.path.dirname(pkg_dir), "demo", "voices", "en-Alice_woman.wav"
+        )
+        return wav if os.path.isfile(wav) else None
+
+    def load_processor(self):
+        """Load the ``VibeVoiceProcessor`` for the pretrained checkpoint.
+
+        Handles the text tokenizer and the voice-prompt audio conditioning
+        (db-normalise, tokenize into acoustic frames, build the speech masks).
+        """
+        _, VibeVoiceProcessor = _import_vibevoice_tts()
+        return VibeVoiceProcessor.from_pretrained(
+            self._variant_config.pretrained_model_name
+        )
+
+    def load_tts_model(self, dtype_override=torch.float32, ddpm_steps=10):
+        """Load the full TTS inference model with **pretrained** weights.
+
+        Args:
+            dtype_override: dtype for the whole model. Defaults to float32:
+                the CPU reference is the PCC golden for the TT run, so it
+                should not itself be quantised.
+            ddpm_steps: denoise steps per acoustic frame in the diffusion head.
+                Upstream's demo default is 10; more steps cost linear time.
+
+        Returns:
+            torch.nn.Module: eval-mode ``VibeVoiceForConditionalGenerationInference``.
+        """
+        InferenceCls, _ = _import_vibevoice_tts()
+
+        model = InferenceCls.from_pretrained(
+            self._variant_config.pretrained_model_name,
+            dtype=dtype_override,
+            attn_implementation="eager",
+        )
+        model.eval()
+        model.set_ddpm_inference_steps(num_steps=ddpm_steps)
+        # Buffers registered persistent=False are absent from the checkpoint,
+        # and transformers 5 materialises from the checkpoint only - so they
+        # come back as uninitialised memory rather than their __init__ value.
+        compat.restore_nonpersistent_buffers(model)
+        # Three ways this checkpoint loads into a model that generates fluent
+        # audio saying nothing like the input text, none of which raise:
+        # an untied lm_head, _init_weights() clobbering the speech connectors,
+        # and a garbage fix_std. Assert against all of them.
+        compat.assert_lm_head_tied(model)
+        compat.assert_speech_stack_loaded(model)
+        return model
+
+    def load_tts_inputs(self, text=None, voice_samples=None, processor=None):
+        """Build the conditioning inputs for ``load_tts_model().generate()``.
+
+        Args:
+            text: script string, ``"Speaker 1: ..."`` form. Defaults to
+                :attr:`DEFAULT_TEXT`.
+            voice_samples: list of voice-prompt wav paths, one per speaker.
+                Defaults to the submodule's ``en-Alice_woman.wav``.
+            processor: reuse an already-loaded processor; loaded on demand
+                otherwise.
+
+        Returns:
+            dict: ``input_ids``, ``attention_mask``, ``speech_input_mask``,
+            ``speech_tensors``, ``speech_masks``.
+        """
+        if processor is None:
+            processor = self.load_processor()
+        if text is None:
+            text = self.DEFAULT_TEXT
+        if voice_samples is None:
+            voice = self.default_voice_sample()
+            if voice is None:
+                raise FileNotFoundError(
+                    "No voice sample available; pass voice_samples=[<path.wav>] "
+                    "or check out the VibeVoice submodule."
+                )
+            voice_samples = [voice]
+
+        return processor(
+            text=[text],
+            voice_samples=[voice_samples],
+            padding=True,
+            return_tensors="pt",
+            return_attention_mask=True,
+        )

--- a/vibevoice/pytorch/loader.py
+++ b/vibevoice/pytorch/loader.py
@@ -203,16 +203,87 @@ class _VibeVoiceLogitsWrapper(torch.nn.Module):
 # would not say anything about the real pipeline.
 # ----------------------------------------------------------------------
 
+#: Samples per chunk in the chunked acoustic encode. Must be a whole number of
+#: latent frames (the acoustic tokenizer compresses 3200:1), so 32000 = 10
+#: frames. It is the largest measured length that does not overflow L1 in
+#: ``ttnn.pad``: 3200, 12800 and 32000 all pass on n150, 64000 does not.
+_ENCODE_CHUNK_SAMPLES = 32000
+
+
+class _StreamingConvCache:
+    """Minimal stand-in for upstream's ``VibeVoiceTokenizerStreamingCache``.
+
+    Same ``get``/``set`` contract, but keyed on the layer id alone instead of
+    ``(layer_id, sample_index)``. Upstream reaches the per-sample keys through
+    ``sample_indices.tolist()``, which forces a device sync and a graph break
+    under ``torch.compile``; the chunked encode always presents the same batch
+    in the same order, so storing the batched tensor whole is equivalent
+    (upstream splits on ``set`` and ``torch.stack``s back on ``get``).
+    """
+
+    def __init__(self):
+        self._states = {}
+
+    def get(self, layer_id, sample_indices=None):
+        return self._states.get(layer_id)
+
+    def set(self, layer_id, sample_indices, states):
+        self._states[layer_id] = states
+
 
 class _AcousticEncoder(torch.nn.Module):
-    """Voice-prompt waveform -> acoustic VAE latents (causal conv VAE)."""
+    """Voice-prompt waveform -> acoustic VAE latents (causal conv VAE).
 
-    def __init__(self, model):
+    Encoded in ``chunk_samples``-sample chunks rather than in one pass. The
+    component itself is correct on TT (PCC 0.9998), but ``ttnn.pad`` overflows
+    L1 somewhere in (32000, 64000] input samples — the full 222480-sample
+    prompt grows the circular buffers to 8115264 B against a 1499136 B limit —
+    so the input length, not the component, is the constraint.
+
+    Chunking uses upstream's streaming conv cache, which gives each ``SConv1d``
+    the tail of the previous chunk as left context instead of padding. That is
+    not interchangeable with chunking naively: encoding each chunk
+    independently reads **PCC 0.9616** against the single full-length encode,
+    with ``max|err| = 126`` spiking at every chunk-start frame, because each
+    chunk re-pads causally from zero and its leading frames lose the context
+    they would have had. With the cache the chunked encode is exact —
+    **PCC 1.00000000**, ``max|err| = 3.8e-05`` in float32, i.e. rounding.
+    """
+
+    def __init__(self, model, chunk_samples=_ENCODE_CHUNK_SAMPLES):
         super().__init__()
         self.encoder = model.model.acoustic_tokenizer.encoder
+        self.chunk_samples = chunk_samples
 
     def forward(self, audio):
-        return self.encoder(audio)
+        length = audio.shape[-1]
+        if length <= self.chunk_samples:
+            # Short enough to pad in one go; take the plain non-streaming path
+            # so the frame count still comes from upstream's own ceil.
+            return self.encoder(audio)
+
+        # The streaming path has no equivalent of non-streaming's
+        # ``extra_padding``, so it needs every chunk to be a whole number of
+        # latent frames. Right-pad up to a chunk multiple: all chunks then
+        # share one shape (one graph on TT) and the frame count matches what
+        # the full-length encode produces for this input.
+        n_chunks = -(-length // self.chunk_samples)
+        audio = torch.nn.functional.pad(
+            audio, (0, n_chunks * self.chunk_samples - length)
+        )
+
+        cache = _StreamingConvCache()
+        sample_indices = [0] * audio.shape[0]
+        latents = [
+            self.encoder(
+                audio[..., i * self.chunk_samples : (i + 1) * self.chunk_samples],
+                cache=cache,
+                sample_indices=sample_indices,
+                use_cache=True,
+            )
+            for i in range(n_chunks)
+        ]
+        return torch.cat(latents, dim=-1)
 
 
 class _AcousticDecoder(torch.nn.Module):

--- a/vibevoice/pytorch/pipeline.py
+++ b/vibevoice/pytorch/pipeline.py
@@ -1,0 +1,634 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VibeVoice-1.5B (microsoft/VibeVoice-1.5B) end-to-end text-to-speech on Tenstorrent.
+
+Drives the full ``generate()`` path — text + voice prompt in, waveform out — with
+a selectable set of components resident on TT and the rest on CPU. The default
+set is the target shape, not a workaround: the diffusion head and both speech
+connectors run on device, the acoustic/semantic tokenizers stay on CPU because
+they are a small share of the compute, and the LM backbone stays on CPU because
+its ``DynamicCache`` grows a token per step, so every decode step is a new shape
+(see ``LM_RESIDENCY_NOTE`` below).
+
+Residency is per component; the pipeline's tensors are not. Every CPU/TT seam
+therefore needs a rule in **both** directions:
+
+* what a *resident* module hands out — :class:`Residency`'s ``out_device``, which
+  is a property of the module's **consumer**, not of the module;
+* what a *CPU-resident* module is handed — :func:`cpu_pin`, because upstream
+  moves inputs explicitly for the two tokenizers but not for the connectors.
+
+Each resident module can be PCC-gated per forward against a CPU twin of itself
+(a deep copy taken *before* the move, so it is the same weights at the same dtype
+rather than a second load). The pipeline always consumes the TT output, so
+gating reports without changing what the run produces.
+
+**Waveform PCC is not a usable acceptance criterion for this model.** A run whose
+per-forward PCC is 0.99997 lands at waveform PCC 0.734 against a CPU golden while
+being the same length, stopping at the same step and transcribing identically:
+there are ``ddpm_steps`` solver steps per frame and each frame's latent feeds back
+through the connectors into the next LM step, so a 3e-05 per-forward difference
+compounds across the autoregressive frames. Gate on the transcript instead.
+"""
+
+from __future__ import annotations
+
+import copy
+import time
+from typing import List, Optional, Sequence
+
+import torch
+
+from .loader import ModelLoader
+
+# Every component that can be moved onto TT, in the order they appear in the
+# forward path. "connectors" moves both speech connectors together — they are
+# 2.5 M parameters each and always share a consumer.
+AVAILABLE_COMPONENTS = ("diffusion_head", "connectors", "lm")
+
+# The target configuration. The LM is deliberately absent; see LM_RESIDENCY_NOTE.
+DEFAULT_COMPONENTS = ("diffusion_head", "connectors")
+
+LM_RESIDENCY_NOTE = """\
+The LM backbone is not in DEFAULT_COMPONENTS, and that is a measurement, not an
+oversight. Adding it needs two things this pipeline does not yet have:
+
+1. A static, max-length-padded KV cache. Upstream's DynamicCache grows by one
+   token per step, so every decode step presents a new shape and recompiles
+   (~76-157 s/step), and torch._dynamo's recompile_limit trips at step 4 —
+   which silently drops the LM out of the compiled path.
+2. DRAM headroom. In float32 the run dies at step 5 allocating 933,494,784 B,
+   which is exactly 151936 x 1536 x 4: the tied embedding / lm_head table.
+
+Both are properties of the LM decode loop, not of this pipeline's seams, and
+neither blocks the end-to-end result: with the LM on CPU the full text + voice
+prompt -> waveform path completes and transcribes correctly.
+"""
+
+OUTPUT_SAMPLE_RATE = 24000
+
+# Model-card-shaped example script. The "Speaker N:" prefix is required — the
+# processor splits the script on it and assigns each speaker a voice sample.
+DEFAULT_TEXT = ModelLoader.DEFAULT_TEXT
+
+# What DEFAULT_TEXT should transcribe back to, for the transcript gate. Without
+# the speaker prefix, which is markup rather than something the model speaks.
+DEFAULT_REFERENCE_TRANSCRIPT = (
+    "Hello from Tenstorrent. This is a VibeVoice end to end test."
+)
+
+# Denoise steps per acoustic frame in the diffusion head. Upstream's demo
+# default; more steps cost linear time in the inner loop.
+DEFAULT_DDPM_STEPS = 10
+
+# Classifier-free guidance scale, upstream's demo default.
+DEFAULT_CFG_SCALE = 1.3
+
+# Per-forward correlation floor against the CPU twin.
+DEFAULT_PCC_THRESHOLD = 0.99
+
+# Stages that run outside the per-frame loop, reported as scalars. Everything
+# else the timer sees — the diffusion head, the connectors, the LM decode — is
+# per-frame work and is accumulated into the open step instead. The two sets are
+# disjoint by construction: the benchmark harness sums ``components`` and
+# ``steps`` against one wall-clock read, so anything in both would read as
+# overlapping timers.
+ONESHOT_STAGES = ("tokenizer_encode", "audio_decode")
+
+
+def pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Pearson correlation, accumulated in float64.
+
+    In float32 this reads 1.0018 for a 19.4 M-element tensor — accumulation
+    error, not correlation — so any threshold read off an fp32 number at these
+    sizes is fiction.
+    """
+    a = a.detach().to("cpu").double().flatten()
+    b = b.detach().to("cpu").double().flatten()
+    if a.numel() != b.numel():
+        return float("nan")
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = a.norm() * b.norm()
+    return float("nan") if denom == 0 else (a @ b / denom).item()
+
+
+def _to(obj, device):
+    """Recursively move tensors in a container, preserving the container class."""
+    if torch.is_tensor(obj):
+        return obj.to(device)
+    if isinstance(obj, (list, tuple)):
+        return type(obj)(_to(o, device) for o in obj)
+    if isinstance(obj, dict):
+        # Rebuild in the original class, not a plain dict: the LM returns a
+        # transformers ``ModelOutput`` (an OrderedDict subclass) and the caller
+        # reads ``.last_hidden_state`` off it. Falls back to a plain dict for
+        # anything whose constructor will not take the mapping — a Cache, say.
+        moved = {k: _to(v, device) for k, v in obj.items()}
+        try:
+            return type(obj)(**moved)
+        except Exception:
+            return moved
+    return obj
+
+
+def _sync_device() -> None:
+    """Launch any pending XLA graph and wait for it.
+
+    torch-xla is lazy, so a timer closed when a forward returns measures tracing
+    rather than device work. ``wait_device_ops()`` alone is a no-op when nothing
+    has been launched, so both calls are needed.
+    """
+    import torch_xla
+    import torch_xla.core.xla_model as xm
+
+    torch_xla.sync()
+    xm.wait_device_ops()
+
+
+def _compile_count() -> int:
+    """Cumulative number of graph compilations observed so far."""
+    import torch_xla.debug.metrics as met
+
+    data = met.metric_data("CompileTime")
+    return data[0] if data else 0
+
+
+class Residency:
+    """Move one submodule onto TT, optionally PCC-gating each forward.
+
+    The twin is a deep copy taken *before* the module moves, so it is the same
+    weights at the same dtype rather than a second load. It is kept on CPU and
+    run in lockstep; the pipeline always consumes the TT output, so a PCC report
+    never changes what the run produces.
+
+    ``out_device`` is which device the result comes back on, and it is a property
+    of the *consumer*, not of this module. The diffusion head's output is consumed
+    by the DPM-solver loop, which is device-resident once its ``speech`` tensor is
+    (``sample_speech_tokens`` builds it on the head's device), so that one stays on
+    TT. The connectors' output is written into ``next_inputs_embeds``, built from
+    the LM's own embedding table, so those follow the *LM's* device — which is not
+    a constant. Getting this wrong surfaces as "Input tensor is not an XLA tensor"
+    at the first mixed-device op.
+
+    ``timer`` is an optional callable invoked as ``timer(name, seconds)`` after
+    every forward, used by the benchmark to attribute device time per stage.
+    """
+
+    def __init__(
+        self,
+        name,
+        module,
+        device,
+        threshold=DEFAULT_PCC_THRESHOLD,
+        out_device=None,
+        gate=True,
+        timer=None,
+    ):
+        self.name = name
+        self.threshold = threshold
+        self.module = module
+        self.pccs: List[float] = []
+        self.gate = gate
+        self.out_device = device if out_device is None else out_device
+
+        self.twin = copy.deepcopy(module).to("cpu").eval() if gate else None
+        module.to(device)
+        # Compile the *unbound* original forward: torch.compile(module) would
+        # call module.forward, which we are about to replace, and recurse.
+        inner = module.forward
+        compiled = torch.compile(inner, backend="tt")
+
+        def forward(*args, **kwargs):
+            dev_args = _to(args, device)
+            dev_kwargs = _to(kwargs, device)
+            started = time.perf_counter()
+            out = compiled(*dev_args, **dev_kwargs)
+            if timer is not None:
+                _sync_device()
+                timer(self.name, time.perf_counter() - started)
+            if self.gate:
+                golden = self.twin(*_to(args, "cpu"), **_to(kwargs, "cpu"))
+                got = out[0] if isinstance(out, (tuple, list)) else out
+                exp = golden[0] if isinstance(golden, (tuple, list)) else golden
+                score = pcc(got, exp)
+                self.pccs.append(score)
+                if score < self.threshold:
+                    raise AssertionError(
+                        f"{self.name} forward {len(self.pccs)}: PCC {score:.6f} "
+                        f"below {self.threshold}"
+                    )
+            # Short-circuit the common case. Matters for the LM: its output
+            # carries the KV cache, which must stay on device and must not be
+            # rebuilt by _to() — generate() mutates it in place across the CFG
+            # branches and relies on holding the same objects.
+            if self.out_device == device:
+                return out
+            return _to(out, self.out_device)
+
+        module.forward = forward
+
+    @property
+    def forwards(self) -> int:
+        return len(self.pccs)
+
+    def summary(self) -> str:
+        if not self.pccs:
+            return f"  {self.name:16s} not gated (no CPU twin)"
+        return (
+            f"  {self.name:16s} {len(self.pccs):4d} forwards  "
+            f"min={min(self.pccs):.6f}  mean={sum(self.pccs) / len(self.pccs):.6f}"
+        )
+
+
+def time_method(obj, name, stage, timer):
+    """Attribute a CPU-resident entry point's wall time to a named stage.
+
+    The benchmark harness requires the stage timers to account for a real share
+    of the generation, and in the default residency the largest single consumer
+    of wall time is the *CPU* LM decode loop. Timing only the device components
+    would under-report so badly that the harness reads it as a missing
+    ``sync_device()``. No device sync here: CPU work is synchronous already.
+    """
+    inner = getattr(obj, name)
+
+    def wrapper(*args, **kwargs):
+        started = time.perf_counter()
+        out = inner(*args, **kwargs)
+        timer(stage, time.perf_counter() - started)
+        return out
+
+    setattr(obj, name, wrapper)
+
+
+def cpu_pin(module, out_device="cpu"):
+    """Run a CPU-resident module on CPU whatever device its inputs arrive on.
+
+    Needed because residency is per component but the pipeline's tensors are not:
+    with only ``diffusion_head`` on TT, ``sample_speech_tokens`` returns
+    ``speech_latent`` on TT (it builds ``speech`` on the head's device) and hands
+    it straight to a CPU ``acoustic_connector``. Upstream moves inputs explicitly
+    for the two tokenizers (``.to(self.model.X.device)``) but not for the
+    connectors, so those need pinning whenever they are not resident.
+
+    ``out_device`` is the consumer's device, exactly as in :class:`Residency`: a
+    CPU connector still has to hand its result back to ``next_inputs_embeds``,
+    which is on TT whenever the LM's embedding table is.
+    """
+    cpu_pin_method(module, "forward", out_device)
+
+
+def cpu_pin_method(obj, name, out_device="cpu"):
+    """:func:`cpu_pin` for an entry point that is not ``forward``.
+
+    The tokenizers are always CPU-resident here but are called through ``.encode``
+    / ``.decode``, so patching ``forward`` would not intercept them. The generation
+    loop moves their inputs explicitly, but the voice-prompt conditioning path in
+    ``_process_speech_inputs`` does not — so with the LM on TT the prompt arrives
+    on device and hits a CPU conv.
+    """
+    inner = getattr(obj, name)
+
+    def wrapper(*args, **kwargs):
+        out = inner(*_to(args, "cpu"), **_to(kwargs, "cpu"))
+        return _to(out, out_device) if out_device != "cpu" else out
+
+    setattr(obj, name, wrapper)
+
+
+def retie_lm_head(model, device):
+    """Restore the ``lm_head`` <-> embedding weight tie, which the move breaks.
+
+    ``lm_head`` is a child of the outer inference class, not of ``language_model``,
+    but its weight *is* the embedding weight — VibeVoice-1.5B ships no
+    ``lm_head.weight`` because it is tied. Moving the LM breaks that:
+    ``nn.Module._apply`` only mutates a Parameter in place when the old and new
+    tensors are shallow-copy compatible, and a CPU tensor and an XLA tensor are
+    not, so it constructs a *new* Parameter and rebinds it on the LM. The embedding
+    ends up on device, ``lm_head.weight`` keeps pointing at the orphaned CPU
+    Parameter, and the tie is gone — measured, not assumed.
+
+    The tempting fix, ``lm_head.to(device)`` on its own, reintroduces the defect
+    quietly: it puts a *copy* of the embedding table on device, correct by value
+    today, untied, and 0.93 GB of duplicated weights. So rebind, then assert
+    pointer identity. Any tied-embedding model moved onto a device
+    submodule-by-submodule has this exposure.
+    """
+    model.lm_head.to(device)
+    model.lm_head.weight = model.get_input_embeddings().weight
+    tied = (
+        model.lm_head.weight.data_ptr()
+        == model.get_input_embeddings().weight.data_ptr()
+    )
+    if not tied or model.lm_head.weight.device.type != device.type:
+        raise AssertionError(
+            f"lm_head re-tie failed: tied={tied}, device={model.lm_head.weight.device}"
+        )
+
+
+class VibeVoiceConfig:
+    """Inputs and residency choices for one :class:`VibeVoicePipeline` run."""
+
+    def __init__(
+        self,
+        text: Optional[str] = None,
+        voice_samples: Optional[Sequence[str]] = None,
+        components: Sequence[str] = DEFAULT_COMPONENTS,
+        dtype: torch.dtype = torch.float32,
+        cfg_scale: float = DEFAULT_CFG_SCALE,
+        ddpm_steps: int = DEFAULT_DDPM_STEPS,
+        seed: int = 0,
+        max_new_tokens: Optional[int] = None,
+        gate: bool = True,
+        pcc_threshold: float = DEFAULT_PCC_THRESHOLD,
+        collect_perf: bool = False,
+    ):
+        self.text = DEFAULT_TEXT if text is None else text
+        self.voice_samples = voice_samples
+        self.components = tuple(components)
+        # float32 by default: the CPU twin is the PCC golden for the TT run, so
+        # it should not itself be quantised.
+        self.dtype = dtype
+        self.cfg_scale = cfg_scale
+        self.ddpm_steps = ddpm_steps
+        # Re-applied before every generate(), so repeat runs are bit-identical.
+        # The diffusion loop draws noise per frame and that noise feeds back into
+        # the LM, so without this the generated length itself drifts run to run.
+        self.seed = seed
+        # None lets the model choose its own cap from the script length.
+        self.max_new_tokens = max_new_tokens
+        self.gate = gate
+        self.pcc_threshold = pcc_threshold
+        # Stage/step timing costs a device sync per forward, so it is opt-in.
+        self.collect_perf = collect_perf
+
+        unknown = set(self.components) - set(AVAILABLE_COMPONENTS)
+        if unknown:
+            raise ValueError(
+                f"unknown components {sorted(unknown)}; "
+                f"available: {list(AVAILABLE_COMPONENTS)}"
+            )
+
+
+class VibeVoicePipeline:
+    """The full VibeVoice TTS path with a selectable set of components on TT."""
+
+    def __init__(self, config: Optional[VibeVoiceConfig] = None):
+        self.config = config or VibeVoiceConfig()
+        self.model = None
+        self.processor = None
+        self.inputs = None
+        self.residencies: List[Residency] = []
+        self.device = None
+        self.saw_eos = False
+        self.steps = 0
+        self._perf = {}
+        self.stage_totals = {}
+        self._stage_s = {}
+        self._step_open_s = 0.0
+        self._head_forwards = 0
+
+    # -- setup ------------------------------------------------------------
+
+    def setup(self):
+        """Load the model on CPU, then move the requested components to TT."""
+        import torch_xla.core.xla_model as xm
+        import torch_xla.runtime as xr
+
+        xr.set_device_type("TT")
+        self.device = xm.xla_device()
+
+        loader = ModelLoader()
+        self.model = loader.load_tts_model(
+            dtype_override=self.config.dtype, ddpm_steps=self.config.ddpm_steps
+        )
+        self.processor = loader.load_processor()
+        self.inputs = loader.load_tts_inputs(
+            text=self.config.text,
+            voice_samples=(
+                list(self.config.voice_samples) if self.config.voice_samples else None
+            ),
+            processor=self.processor,
+        )
+        self._build_residencies()
+        return self
+
+    def _timer(self, name, seconds):
+        """Attribute one forward's time to either a one-shot stage or the open step.
+
+        The split has to be exact: the harness sums ``components`` and ``steps``
+        and compares that against a single wall-clock read, so a stage counted in
+        both would read as overlapping timers.
+        """
+        self._stage_s[name] = self._stage_s.get(name, 0.0) + seconds
+        if name in ONESHOT_STAGES:
+            return
+        self._step_open_s += seconds
+        if name == "diffusion_head":
+            self._head_forwards += 1
+            # A frame is ddpm_steps head forwards. Close the step on the last of
+            # them rather than on a connector call: the connectors fire an
+            # unequal number of times (the acoustic one also runs during
+            # voice-prompt conditioning), so their ordering is not a reliable
+            # frame boundary.
+            if self._head_forwards % self.config.ddpm_steps == 0:
+                self._perf["steps"].append(self._step_open_s)
+                self._perf["compile_curve"].append(_compile_count())
+                self._step_open_s = 0.0
+
+    def _build_residencies(self):
+        """Attach a :class:`Residency` per requested component.
+
+        ``out_device`` per component follows the consumer, not the module. The
+        head's output feeds the DPM-solver loop and stays on TT. The connectors'
+        outputs are written into ``next_inputs_embeds``, which is built by the
+        LM's own embedding table — so they follow *its* device: CPU when the LM
+        is not resident, TT when it is.
+        """
+        cfg = self.config
+        model, device = self.model, self.device
+        wanted = cfg.components
+        timer = self._timer if cfg.collect_perf else None
+
+        if timer is not None and "diffusion_head" not in wanted:
+            raise ValueError(
+                "collect_perf needs diffusion_head resident: the per-frame step "
+                "boundary is counted off its forwards"
+            )
+
+        embeds_device = device if "lm" in wanted else "cpu"
+
+        # The tokenizers stay on CPU in every configuration — that is the target
+        # shape, not a workaround — so they always get pinned.
+        cpu_pin_method(model.model.acoustic_tokenizer, "encode")
+        cpu_pin_method(model.model.acoustic_tokenizer, "decode")
+        cpu_pin_method(model.model.semantic_tokenizer, "encode")
+
+        if timer is not None:
+            # Time the CPU side too. In the default residency the LM decode loop
+            # is the largest single consumer of wall time, and the harness reads
+            # an under-reporting stage total as a missing device sync rather than
+            # as work that legitimately ran on the host.
+            time_method(
+                model.model.acoustic_tokenizer, "encode", "tokenizer_encode", timer
+            )
+            time_method(
+                model.model.semantic_tokenizer, "encode", "tokenizer_encode", timer
+            )
+            time_method(model.model.acoustic_tokenizer, "decode", "audio_decode", timer)
+            if "lm" not in wanted:
+                time_method(model.model.language_model, "forward", "lm_cpu", timer)
+
+        out: List[Residency] = []
+        if "diffusion_head" in wanted:
+            out.append(
+                Residency(
+                    "diffusion_head",
+                    model.model.prediction_head,
+                    device,
+                    cfg.pcc_threshold,
+                    out_device=device,
+                    gate=cfg.gate,
+                    timer=timer,
+                )
+            )
+        if "connectors" in wanted:
+            for name, mod in (
+                ("acoustic_conn", model.model.acoustic_connector),
+                ("semantic_conn", model.model.semantic_connector),
+            ):
+                out.append(
+                    Residency(
+                        name,
+                        mod,
+                        device,
+                        cfg.pcc_threshold,
+                        out_device=embeds_device,
+                        gate=cfg.gate,
+                        timer=timer,
+                    )
+                )
+        else:
+            cpu_pin(model.model.acoustic_connector, out_device=embeds_device)
+            cpu_pin(model.model.semantic_connector, out_device=embeds_device)
+
+        if "lm" in wanted:
+            # Never twin-gated. The twin would need its own CPU KV cache running
+            # in lockstep: generate() hands the LM a DynamicCache it mutates in
+            # place across the CFG branches, and that object is neither a tensor
+            # nor a mapping, so _to() cannot clone it onto CPU. Feeding the CPU
+            # twin the device cache would compare against a cache it never wrote.
+            # The LM is covered by the LM_PREFILL component test plus the
+            # end-to-end transcript gate instead.
+            out.append(
+                Residency(
+                    "lm",
+                    model.model.language_model,
+                    device,
+                    cfg.pcc_threshold,
+                    out_device=device,
+                    gate=False,
+                    timer=timer,
+                )
+            )
+            retie_lm_head(model, device)
+
+        self.residencies = out
+
+    # -- run --------------------------------------------------------------
+
+    def run(self) -> torch.Tensor:
+        """Synthesize one waveform. Returns it and populates ``_perf``."""
+        cfg = self.config
+        self._stage_s = {}
+        self._step_open_s = 0.0
+        self._head_forwards = 0
+        self._perf = {"steps": [], "compile_curve": []}
+
+        initial_length = self.inputs["input_ids"].shape[1]
+        generate_kwargs = dict(
+            cfg_scale=cfg.cfg_scale,
+            tokenizer=self.processor.tokenizer,
+            # Note the mapping form: upstream reads do_sample off a
+            # generation_config, not off a top-level do_sample= kwarg.
+            generation_config={"do_sample": False},
+            verbose=False,
+        )
+        generate_kwargs["max_new_tokens"] = cfg.max_new_tokens
+
+        torch.manual_seed(cfg.seed)
+        started = time.perf_counter()
+        with torch.no_grad():
+            out = self.model.generate(**self.inputs, **generate_kwargs)
+        total = time.perf_counter() - started
+
+        wav = out.speech_outputs[0]
+        if wav is None:
+            raise RuntimeError("generate() produced no audio")
+
+        self.steps = out.sequences.shape[1] - initial_length
+        eos_id = self.processor.tokenizer.eos_token_id
+        self.saw_eos = bool((out.sequences[0, initial_length:] == eos_id).any().item())
+
+        self._perf.update(
+            {
+                # Only the one-shot stages; per-frame work is in "steps".
+                "components": {
+                    k: self._stage_s[k] for k in ONESHOT_STAGES if k in self._stage_s
+                },
+                "step_metric_name": "acoustic_frame",
+                "total": total,
+                "audio_samples": int(wav.shape[-1]),
+                "text_tokens": int(initial_length),
+            }
+        )
+        # Every stage's total, including the per-frame ones that "components"
+        # deliberately leaves out. Reporting only; never summed into the
+        # harness's stage accounting.
+        self.stage_totals = dict(self._stage_s)
+        return wav
+
+    # -- reporting --------------------------------------------------------
+
+    def summary(self) -> str:
+        lines = [f"components on TT: {[r.name for r in self.residencies] or 'none'}"]
+        for r in self.residencies:
+            lines.append(r.summary())
+        return "\n".join(lines)
+
+    def worst_pcc(self) -> Optional[float]:
+        """Lowest PCC across every gated forward, or ``None`` if nothing gated."""
+        scores = [s for r in self.residencies for s in r.pccs]
+        return min(scores) if scores else None
+
+
+def save_wav(wav: torch.Tensor, filepath: str = "vibevoice_output.wav", processor=None):
+    """Write a generated waveform to disk at 24 kHz."""
+    if processor is None:
+        processor = ModelLoader().load_processor()
+    processor.save_audio(wav, output_path=filepath)
+    return filepath
+
+
+def run_vibevoice_pipeline(
+    output_path: Optional[str] = "vibevoice_output.wav",
+    config: Optional[VibeVoiceConfig] = None,
+    **config_kwargs,
+):
+    """Build, run and (optionally) save one synthesis.
+
+    Returns ``(waveform, pipeline)`` rather than just the waveform: the pipeline
+    carries the per-forward PCC each resident component recorded against its CPU
+    twin, which is what a caller needs to tell a working run from a plausible one.
+    """
+    if config is None:
+        config = VibeVoiceConfig(**config_kwargs)
+    elif config_kwargs:
+        raise TypeError("pass either config= or keyword arguments, not both")
+    pipeline = VibeVoicePipeline(config).setup()
+    wav = pipeline.run()
+    if output_path:
+        save_wav(wav, output_path, processor=pipeline.processor)
+    return wav, pipeline


### PR DESCRIPTION
### Ticket

[issue](https://github.com/tenstorrent/tt-xla/issues/6034)

### Problem description

`third_party/VibeVoice` was pinned to `microsoft/VibeVoice` @ `303b2833`, which does
**not** contain the VibeVoice-TTS inference stack — Microsoft removed it on 2025-09-05 and
`modeling_vibevoice_inference.py` does not appear anywhere in that repo's history. What
survives at the pin is a training forward returning a diffusion loss: no `generate()`, no
denoise sampling loop, no VAE decode-to-waveform. The existing logits-only bringup path
passes against it only because it exercises the surviving Qwen backbone and nothing else.

So there was no way to load VibeVoice as a text-to-speech model, and no per-component entry
points for the tt-xla single-device component tests.

### What's changed

Four commits, each independently reviewable.

**1. Re-pin the vendored submodule to the community fork.** `vibevoice-community/VibeVoice`
@ `631804b`, a preserved pre-removal fork that still carries `modeling_vibevoice_inference.py`
(`generate()` plus the CFG / DPM-solver `sample_speech_tokens()` loop) and the full
`VibeVoiceProcessor` TTS conditioning path.

*Supply-chain note, recorded deliberately in the commit message:* this moves the TTS
*inference code* off a first-party repo onto a community fork. The model **weights** are
unchanged and remain first-party (`microsoft/VibeVoice-1.5B` on HuggingFace). The fork is
vendored as a pinned submodule and used **unmodified** — every `transformers>=5`
incompatibility is handled as a runtime patch in `vibevoice/pytorch/compat.py` — so the pin
is auditable and no upstream file is edited in place.

**2. Add the TTS path, and fix two silent weight-loading defects.** New entry points
(`load_tts_model()` / `load_processor()` / `load_tts_inputs()` / `default_voice_sample()`)
alongside the existing random-weights bringup path, plus `compat.py`, the `transformers>=5`
shim layer structured by *when* each patch must run (`apply_pre_import` / `patch_runtime` /
`patch_inference_class`). Every patch is idempotent.

Two of those shims fix defects that corrupt the output **while raising nothing anywhere in
the stack**. Both were found by loading the same checkpoint under transformers 4.51.3 (the
version the fork pins) and under 5.10, then diffing every parameter and buffer — exactly 8
parameters and 1 buffer differed out of 1202 + 4:

- `_init_weights()` overwrote weights that had already been loaded. transformers 5 calls it
  on every module *after* loading and expects the implementation to honour the
  `_is_hf_initialized` marker the loader stamps onto restored parameters; the vendored
  implementation predates that contract, so it reset both speech connectors' `fc1`/`fc2`
  weights to N(0, 0.02) and their biases to exactly zero.
- A buffer registered `persistent=False` came back as **uninitialised memory**. The acoustic
  tokenizer's VAE sampling scale is absent from the checkpoint by design; transformers 5
  builds under `torch.device("meta")` and materialises from the checkpoint only. `fix_std`
  read **8986389.0, 4.3e-17 and 2.6e-06 on three consecutive loads of the same checkpoint**,
  against a true value of 0.5.

Together the voice prompt had noise of a random magnitude added to it and was then projected
into the LM's embedding space by an untrained matrix. Generation still produced fluent,
well-formed, correctly-scaled speech — it just said nothing like the input text, and it
varied run to run under a fixed seed. Every signal-level check passed. Both are now
**asserted at load time** (`compat.assert_speech_stack_loaded()`) rather than trusted,
alongside the existing `assert_lm_head_tied()`. Post-fix the transformers-5 path is
bit-identical to a transformers-4.51.3 reference: `max|diff| = 0.0` across the whole
waveform, same 92,800 samples, same EOS at step 31.

**3. Per-component `ModelVariant`s** — `AcousticEncoder`, `AcousticDecoder`,
`SemanticEncoder`, `Connectors`, `DiffusionHead`, `LmPrefill` — each returning that component
of the *pretrained* pipeline wrapped to a tensors-only forward, with `load_inputs()` building
synthetic tensors at the shapes the real pipeline produces. Unlike the diffusion-pipeline
loaders the components cannot be loaded individually: the checkpoint is monolithic with no
per-component subfolder, so the whole 2.7B model is built and the component taken out of it.
Pretrained weights are the point — PCC against a randomly initialised component says nothing
about the pipeline it belongs to.

Measured on n150, PCC against the CPU reference (accumulated in float64):

| component | params | dtype | PCC |
| --- | ---: | --- | ---: |
| `connectors` | 5.0 M | bf16 | 0.999995 |
| `semantic_encoder` | 345 M | bf16 | 0.999952 |
| `diffusion_head` | 123 M | bf16 | 0.999867 |
| `lm_prefill` | 1.54 B | bf16 | 0.999494 |
| `acoustic_decoder` | 344 M | fp32 | 0.998248 |
| `acoustic_encoder` | 344 M | bf16 | 0.999772 |

`acoustic_decoder` reads 0.988 in bf16 and 0.998 in fp32 — precision in a deep causal-conv
stack, not a compiler defect, so the tt-xla test pins fp32 rather than lowering the gate.

**4. Encode the voice prompt in chunks on the acoustic tokenizer.** The acoustic encoder is
numerically correct on TT but overflows L1 in `ttnn.pad` on long inputs: 3200, 12,800 and
32,000 samples pass on n150, 64,000 does not, and the full 222,480-sample voice prompt dies
with *"circular buffers … grow to 8115264 B which is beyond max L1 size of 1499136 B"*.

Chunking is loader-side and needs no compiler fix, but it is only correct if each chunk
receives the previous chunk's tail as left context — **causal is necessary, not sufficient.**
Both designs were measured against a single full-length encode on CPU before any loader
change:

| chunking design | PCC | `max\|err\|` |
| --- | ---: | ---: |
| naive — each 32,000-sample chunk encoded independently | 0.9616 | 126 |
| upstream's streaming cache carried across boundaries | 1.00000000 | 3.8e-05 |

The naive error spikes at exactly the chunk-start frames, each chunk re-padding causally from
zero. **0.9616 would have passed a 0.90-style gate.** So the implementation carries a
fixed-shape stand-in for upstream's `VibeVoiceTokenizerStreamingCache` across the boundaries
— fixed-shape to stay compile-friendly, since the chunked encode always presents the same
batch. Inputs that already fit keep the plain non-streaming path.

### Checklist
- [x] New/Existing tests provide coverage for changes

Coverage lands in tt-xla and is what drove every number above: six single-device component
tests under `tests/torch/models/vibevoice/`, and a PCC- and transcript-gated end-to-end
nightly test. Those are in a companion tt-xla PR that bumps this submodule.

The end-to-end path was verified on hardware through this loader API: with the diffusion head
and both speech connectors resident on TT, `generate()` completes the full text + voice
prompt → waveform path, stopping at a real EOS and transcribing correctly (WER 0.45 against
the reference sentence, better than the transformers-4 reference's own 0.64).
