### PR TITLE
[Krea Realtime 14B] Explicitly fetch encoders.py in pipeline setup

### DIFF
--- a/krea_realtime_video/pytorch/pipeline.py
+++ b/krea_realtime_video/pytorch/pipeline.py
@@ -20,6 +20,7 @@ import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
+from diffusers.utils.dynamic_modules_utils import get_cached_module_file
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
 from torch_xla.distributed.spmd import Mesh
@@ -125,6 +126,9 @@ class KreaRealtimePipeline:
             WAN_REPO_ID, subfolder="tokenizer"
         )
         self.video_processor = VideoProcessor(vae_scale_factor=VAE_SCALE_FACTOR)
+        # encoders.py is outside the transformer's auto_map import closure, so
+        # trust_remote_code never fetches it — download it explicitly first.
+        get_cached_module_file(KREA_REPO_ID, "encoders.py", trust_remote_code=True)
         enc_mod = importlib.import_module(
             type(self.transformer).__module__.rsplit(".", 1)[0] + ".encoders"
         )


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/6038

### Problem description

- The Krea Realtime e2e pipeline imports `encoders.py` (for `prompt_clean`) from the model repo's dynamic-modules cache. However, `trust_remote_code=True` on the transformer load only downloads the `auto_map` import closure (`causal_model.py`, `attention.py`, `model.py`) — `encoders.py` is never fetched, so `setup()` fails with `ModuleNotFoundError` on any fresh HF cache.
- This wasn't caught during bringup: the dev environment already had `encoders.py` in the HF modules cache (left there by earlier CPU-parity runs that loaded the full upstream pipeline), which silently masked the missing download. The first run on a clean cache exposed it.

### What's changed
- `setup()` now explicitly fetches `encoders.py` into the same dynamic-modules package via `diffusers.utils.dynamic_modules_utils.get_cached_module_file` (with `trust_remote_code=True`) before importing it.
- No-op when the file is already cached; the pipeline keeps using Krea's own `prompt_clean` implementation, so behavior is unchanged.

### Checklist
- [x] Verify the changes through local testing

### Logs

- [sep2_krea_e2e_nb_2_after_fix.log.zip](https://github.com/user-attachments/files/31738260/sep2_krea_e2e_nb_2_aif.log.zip)
- [sep2_krea_e2e_nb_2_before_fix.log](https://github.com/user-attachments/files/31738262/sep2_krea_e2e_nb_2.log)

