### PR TITLE
[Mochi] Move VAE Decoder to TT in pipeline

### DIFF
--- a/mochi/pytorch/src/pipeline.py
+++ b/mochi/pytorch/src/pipeline.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Mochi-1 preview pipeline: DiT (bf16) and T5-XXL text encoder (fp32) both
-tensor-parallel on TT, scheduler and VAE on CPU.
+"""Mochi-1 preview pipeline: DiT (bf16), T5-XXL text encoder (fp32) and VAE
+decoder (bf16) all tensor-parallel on TT, scheduler on CPU.
 
 Mirrors ``MochiPipeline.__call__``. guidance_scale=4.5 for this checkpoint ->
 CFG is enabled, so the DiT sees a batch-2 ``cat([uncond, cond])`` input on
@@ -18,6 +18,7 @@ from typing import Optional
 
 import numpy as np
 import torch
+import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
 import torch_xla.runtime as xr
@@ -39,7 +40,9 @@ from .utils import (
     load_vae,
     shard_text_encoder_specs,
     shard_transformer_specs,
+    shard_vae_decoder_specs,
 )
+from .vae_ops import patch_vae_decoder_ops
 
 PROMPT = (
     "Close-up of a chameleon's eye, with its scaly skin changing color. "
@@ -65,6 +68,15 @@ TEXT_ENCODER_DTYPE = torch.float32
 VAE_SPATIAL_SCALE_FACTOR = 8
 VAE_TEMPORAL_SCALE_FACTOR = 6
 THRESHOLD_NOISE = 0.025
+
+# Compile options the VAE decoder needs to fit in DRAM. The decoder's
+# unpatchify permute is padded 2 -> 32 by TILE layout without the DRAM
+# space-saving pass, and const-eval pins hoisted broadcasts in DRAM for the
+# whole execution. See tests/torch/models/mochi/test_vae_decoder.py.
+VAE_COMPILE_OPTIONS = {
+    "experimental-enable-dram-space-saving-optimization": "true",
+    "enable_const_eval": "false",
+}
 
 
 def _enable_spmd() -> None:
@@ -112,6 +124,7 @@ class Mochi1Config:
         shard: bool = True,
         transformer_on_tt: bool = True,
         text_encoder_on_tt: bool = True,
+        vae_on_tt: bool = True,
     ):
         self.num_inference_steps = num_inference_steps
         self.height = height
@@ -121,6 +134,7 @@ class Mochi1Config:
         self.shard = shard
         self.transformer_on_tt = transformer_on_tt
         self.text_encoder_on_tt = text_encoder_on_tt
+        self.vae_on_tt = vae_on_tt
 
 
 class Mochi1Pipeline:
@@ -148,10 +162,19 @@ class Mochi1Pipeline:
         # attention.py.
         patch_static_attn_processor()
 
+        # Value-preserving rewrites of two decoder ops whose stock form blows
+        # up DRAM. Process-wide, so a CPU reference in the same process runs
+        # the same math; harmless when the VAE stays on CPU, but only needed
+        # for the device path.
+        if self.config.vae_on_tt:
+            patch_vae_decoder_ops()
+
         # One mesh, shared by every TT component. SPMD has to be enabled before
         # the first device op, so this runs ahead of any .to(xla_device()).
         if self.config.shard and (
-            self.config.transformer_on_tt or self.config.text_encoder_on_tt
+            self.config.transformer_on_tt
+            or self.config.text_encoder_on_tt
+            or self.config.vae_on_tt
         ):
             self._init_mesh()
 
@@ -172,6 +195,19 @@ class Mochi1Pipeline:
             )
             self.transformer.forward = torch.compile(
                 self.transformer.forward, backend="tt"
+            )
+
+        if self.config.vae_on_tt:
+            # Only the decoder goes to the device; the rest of the VAE (encoder,
+            # config, tiling helpers) is unused here. use_tiling and
+            # use_framewise_decoding are both False by default, so decode()
+            # reaches self.decoder in exactly one call - the same single graph
+            # the component test compiles.
+            self.vae.decoder = self._place_on_tt(
+                self.vae.decoder, shard_vae_decoder_specs
+            )
+            self.vae.decoder.forward = torch.compile(
+                self.vae.decoder.forward, backend="tt"
             )
 
     def load_models(self):
@@ -383,7 +419,23 @@ class Mochi1Pipeline:
         else:
             latents = latents / self.scaling_factor
 
-        video = self.vae.decode(latents.to(self.vae.dtype), return_dict=False)[0]
+        latents = latents.to(self.vae.dtype)
+        if cfg.vae_on_tt:
+            # Set here rather than in setup(): these options are read at compile
+            # time, and the DiT and text encoder must not see them. Both have
+            # already compiled by now - the encoder in _encode_prompt, the DiT
+            # on step 1 - so this only reaches the decoder's compile below.
+            torch_xla.set_custom_compile_options(VAE_COMPILE_OPTIONS)
+            logger.info(
+                "[STAGE] vae decoder (sharded, bf16) compile options: {}",
+                VAE_COMPILE_OPTIONS,
+            )
+            latents = latents.to(xm.xla_device())
+
+        video = self.vae.decode(latents, return_dict=False)[0]
+        if cfg.vae_on_tt:
+            # Sync point; postprocess_video runs on CPU.
+            video = video.to(cpu)
         frames = self.video_processor.postprocess_video(video, output_type=output_type)[
             0
         ]

--- a/mochi/pytorch/src/utils.py
+++ b/mochi/pytorch/src/utils.py
@@ -465,7 +465,9 @@ def shard_vae_decoder_specs(decoder) -> dict:
       conv1 (CogVideoXCausalConv3d): column-parallel on out_channels
       conv2 (CogVideoXCausalConv3d): row-parallel on in_channels, bias replicated
       norm2 (MochiChunkedGroupNorm3D): channel-sharded
-    norm1, top-level conv_in, proj_out, and per-up-block proj are left replicated.
+    Each up-block's proj (unpatchify linear) is column-parallel so the 8-D
+    unpatchify transpose stays channel-sharded.
+    norm1, top-level conv_in, and proj_out are left replicated.
     """
     specs: dict = {}
 
@@ -493,11 +495,23 @@ def shard_vae_decoder_specs(decoder) -> dict:
     for resnet in decoder.block_in.resnets:
         shard_resnet(resnet)
 
-    # up_blocks (MochiUpBlock3D) — resnets per block; up_block.proj
-    # (unpatchify linear) is left replicated.
+    # up_blocks (MochiUpBlock3D).
     for up_block in decoder.up_blocks:
         for resnet in up_block.resnets:
             shard_resnet(resnet)
+
+        # proj: column-parallel on out_features = out_channels * st * sh * sw.
+        # The unpatchify reshapes that axis to (out_channels, st, sh, sw) with
+        # out_channels outermost, so a contiguous shard covers whole
+        # (st, sh, sw) groups whenever out_channels % mesh("model") == 0 —
+        # true for every supported mesh, since the smallest out_channels is
+        # 128 and the widest model axis is 8. Keeping the split here means the
+        # reshape/permute/reshape unpatchify chain, whose 8-D intermediate is
+        # the largest tensor in the decoder, stays sharded across devices
+        # instead of being materialised whole on each one.
+        specs[up_block.proj.weight] = ("model", None)
+        if up_block.proj.bias is not None:
+            specs[up_block.proj.bias] = ("model",)
 
     # block_out (MochiMidBlock3D).
     for resnet in decoder.block_out.resnets:

--- a/mochi/pytorch/src/vae_ops.py
+++ b/mochi/pytorch/src/vae_ops.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""VAE decoder op rewrites needed to fit the full-res decoder in device DRAM.
+
+Both rewrites are value-preserving restatements of stock diffusers ops, aimed
+at intermediates that dominate the decoder's DRAM footprint. Neither changes
+what the decoder computes; see the per-function docstrings for why the stock
+form is expensive. Applied together with the ``up_block.proj`` shard spec in
+``utils.shard_vae_decoder_specs``, they take the decoder's peak tensor from
+42.3 GB to 1.67 GB.
+
+Call :func:`patch_vae_decoder_ops` before the first forward.
+"""
+
+import torch
+import torch.nn.functional as F
+from diffusers.models.autoencoders.autoencoder_kl_cogvideox import CogVideoXCausalConv3d
+from diffusers.models.autoencoders.autoencoder_kl_mochi import MochiChunkedGroupNorm3D
+
+_STOCK_FAKE_CONTEXT_PARALLEL_FORWARD = (
+    CogVideoXCausalConv3d.fake_context_parallel_forward
+)
+
+
+def _replicate_pad_in_native_dtype(self, inputs, conv_cache=None):
+    """CogVideoXCausalConv3d replicate padding without the f32 round trip.
+
+    F.pad(..., mode="replicate") preserves bf16 in eager torch but not in the
+    torch-xla lowering: the incoming graph carries convert(bf16 -> f32)
+    immediately before the three replicate-pad gathers and convert(f32 -> bf16)
+    immediately after - an adjacent mutually-inverse pair that neither XLA nor
+    tt-mlir folds. The permute and all three pad concats therefore run at f32,
+    each twice the DRAM it needs, on the largest tensors in the decoder.
+
+    Replication is clamp(index) per axis and therefore separable, so padding
+    one axis at a time with slice + expand + cat gives identical values while
+    staying in the input's own dtype. Order across axes doesn't matter.
+
+    Verified against F.pad by
+    tests/torch/models/mochi/check_replicate_pad_equivalence.py.
+    """
+    if self.pad_mode != "replicate":
+        return _STOCK_FAKE_CONTEXT_PARALLEL_FORWARD(self, inputs, conv_cache)
+
+    x = inputs
+    if self.time_pad:
+        # Causal: leading pad only, replicating frame 0.
+        x = torch.cat([x[:, :, :1].expand(-1, -1, self.time_pad, -1, -1), x], dim=2)
+    if self.height_pad:
+        pad = self.height_pad
+        x = torch.cat(
+            [
+                x[:, :, :, :1].expand(-1, -1, -1, pad, -1),
+                x,
+                x[:, :, :, -1:].expand(-1, -1, -1, pad, -1),
+            ],
+            dim=3,
+        )
+    if self.width_pad:
+        pad = self.width_pad
+        x = torch.cat(
+            [
+                x[..., :1].expand(-1, -1, -1, -1, pad),
+                x,
+                x[..., -1:].expand(-1, -1, -1, -1, pad),
+            ],
+            dim=4,
+        )
+    return x
+
+
+def _group_norm_with_affine_on_channels(self, x: torch.Tensor = None) -> torch.Tensor:
+    """MochiChunkedGroupNorm3D with the affine outside F.group_norm.
+
+    F.group_norm normalizes in group space, [chunks*groups, C/groups*H*W],
+    where a per-channel weight varies along the *inner* axis and so cannot
+    broadcast implicitly. Once up_block.proj is sharded the compiler keeps the
+    affine in that space, and each norm materializes its weight and bias as
+    full 1x8x128x480x848 f32 tensors - 1.70 GB apiece, via ttnn.repeat.
+    (Pre-sharding runs contain none of these, with or without the DRAM
+    space-saving pass, so this is a consequence of the shard spec.)
+
+    Applying the affine ourselves on the [chunk, C, H, W] output puts channel
+    back on a real dimension, where the broadcast is implicit and free. Same
+    arithmetic: group_norm scales by weight[c] and shifts by bias[c] after
+    normalizing, which is exactly what this does.
+
+    The normalize is also open-coded so it can run in the input's dtype.
+    F.group_norm upcasts everything to f32, which costs 1.67 GB per
+    1x256x1628160 intermediate. Only the reductions actually need f32 - their
+    outputs are tiny - so mean and variance are computed in f32 and the
+    full-size centre-and-scale runs in bf16. That is a real precision
+    reduction: the centred values are O(1) so bf16 carries them fine, but the
+    subtraction rounds the mean to bf16 first, which costs accuracy in
+    proportion to mean/std.
+
+    Verified against the stock module by
+    tests/torch/models/mochi/check_group_norm_affine_equivalence.py.
+    """
+    batch_size = x.size(0)
+    norm = self.norm_layer
+
+    x = x.permute(0, 2, 1, 3, 4).flatten(0, 1)
+
+    normalized_chunks = []
+    for chunk in x.split(self.chunk_size, dim=0):
+        grouped = chunk.reshape(chunk.shape[0], norm.num_groups, -1)
+
+        stats = grouped.float()
+        mean = stats.mean(dim=2, keepdim=True)
+        # Biased variance, matching F.group_norm.
+        var = stats.var(dim=2, unbiased=False, keepdim=True)
+        rstd = torch.rsqrt(var + norm.eps)
+
+        centred = grouped - mean.to(grouped.dtype)
+        normalized_chunks.append((centred * rstd.to(grouped.dtype)).reshape_as(chunk))
+
+    output = torch.cat(normalized_chunks, dim=0)
+    if norm.affine:
+        output = output * norm.weight.view(1, -1, 1, 1) + norm.bias.view(1, -1, 1, 1)
+
+    return output.unflatten(0, (batch_size, -1)).permute(0, 2, 1, 3, 4)
+
+
+def patch_vae_decoder_ops() -> None:
+    """Rebind the two decoder ops process-wide, including any CPU reference
+    model in the same process. Call before the first forward.
+
+    Process-wide is deliberate - the CPU golden has to run the same math for a
+    PCC comparison to mean anything - but it does reach every user of these two
+    classes in the process, CogVideoX's VAE included.
+    """
+    CogVideoXCausalConv3d.fake_context_parallel_forward = _replicate_pad_in_native_dtype
+    MochiChunkedGroupNorm3D.forward = _group_norm_with_affine_on_channels


### PR DESCRIPTION
### Ticket
[#6051](https://github.com/tenstorrent/tt-xla/issues/6051)

### Problem description
The Mochi pipeline ran the DiT (bf16) and T5-XXL encoder (fp32) tensor-parallel on TT but decoded on CPU. Moving the decoder onto the device in this PR and addressing the problems faced on doing so.

### What's changed

- Mochi1Config gains vae_on_tt beside the existing transformer_on_tt and text_encoder_on_tt, independently switchable so the VAE can fall back to CPU and serve as a reference, and the _init_mesh() gate widens to fire when any of the three is on so all components shard against the one mesh. Only vae.decoder is placed and compiled — the encoder, config and tiling helpers are unused here, and with use_tiling and use_framewise_decoding both False by default decode() reaches self.decoder in exactly one call, the same single graph the component test compiles. 

- The decode call site moves latents to the XLA device and pulls video back to host before postprocess_video. VAE_COMPILE_OPTIONS (experimental-enable-dram-space-saving-optimization, enable_const_eval=false) is applied via torch_xla.set_custom_compile_options at the decode rather than in setup(), because the options are read at compile time and the encoder and DiT must not see them — both have already compiled by then, the encoder in _encode_prompt and the DiT on step 1, so it only reaches the decoder.

- shard_vae_decoder_specs makes each up-block's proj (the unpatchify linear) column-parallel on out_features instead of leaving it replicated, which keeps the 8-D unpatchify transpose — the largest tensor in the decoder — sharded across devices rather than materialized whole on each. That's safe because the unpatchify reshapes that axis to (out_channels, st, sh, sw) with out_channels outermost, so a contiguous shard covers whole (st, sh, sw) groups whenever out_channels % mesh("model") == 0, true for every supported mesh given the smallest out_channels is 128 against a widest model axis of 8.

- A new vae_ops.py adds two value-preserving op rewrites, rebound process-wide by patch_vae_decoder_ops() before the first forward. _group_norm_with_affine_on_channels exists because of the shard spec above: F.group_norm normalizes in group space [chunks*groups, C/groups*H*W], where a per-channel weight varies along the inner axis and cannot broadcast implicitly, so once proj is sharded the compiler keeps the affine there and each norm materializes weight and bias as full 1x8x128x480x848 f32 tensors — 1.70 GB apiece via ttnn.repeat, and absent from pre-sharding runs entirely. Applying the affine on the [chunk, C, H, W] output puts channel back on a real dimension where the broadcast is free; the normalize is also open-coded so only the reductions run f32, saving a further 1.67 GB per 1x256x1628160 intermediate. 

- _replicate_pad_in_native_dtype replaces CogVideoXCausalConv3d.fake_context_parallel_forward's F.pad(mode="replicate"), which preserves bf16 in eager torch but not in the torch-xla lowering: the graph carries an adjacent, mutually-inverse convert(bf16→f32)/convert(f32→bf16) pair around the three pad gathers that neither XLA nor tt-mlir folds, so the permute and all three concats ran f32 at twice the DRAM they need on the decoder's largest tensors. Replication is clamp(index) per axis and therefore separable, so padding one axis at a time with slice + expand + cat gives identical values in the input's own dtype. Together with the shard spec these take the decoder's peak tensor from 42.3 GB to 1.67 GB. Both rewrites are checked against their stock forms by check_replicate_pad_equivalence.py and check_group_norm_affine_equivalence.py.

### Validation
Details from Log:

Nightly PCC-instrumented e2e run of [tests/torch/models/mochi/test_mochi_1_pipeline.py](vscode-webview://06au5agk3n3l1goitdjc21pifc212bo2pqnidhpgjtlagmk28gaf/tests/torch/models/mochi/test_mochi_1_pipeline.py), with the T5-XXL text encoder (fp32), the DiT (bf16) and the VAE decoder (bf16) all on TT, tensor-parallel sharded on a shared (1, 4) mesh over 4 devices, sequential_offload on so each component is resident only for its own stage. Scheduler on CPU.

Prompt: "Close-up of a chameleon's eye, with its scaly skin changing color. Ultra high resolution 4k.", 848×480, 24 frames requested → 19 decoded, 10 steps, seed 0, CFG 4.5 (batch-2 cat([uncond, cond]) per DiT forward)

All 13 per-forward PCC ≥ 0.949355 against same-dtype CPU twins, threshold 0.94 — text encoder 0.949355 / 0.951844 (it tops out ~0.95 even in fp32), DiT 1.000000 on 8 of 10 steps and 1.007812 on steps 1 and 4, VAE decoder 1.000000. The two >1.0 readings are a bf16 quantization artifact of the correlation itself, not a divergence.

```
[load_models] text_encoder / transformer / vae      10:43:55.947 → 10:44:18.800
[setup] mesh (1, 4) over 4 device(s)                10:44:18.800
[STAGE] text_encoder (T5-XXL, sharded, fp32): start 10:44:21.427
[STAGE] text_encoder: done (2 forwards)             10:45:50.395   (~1:29)
encoder offload + DiT placement                     10:45:50.395 → 10:46:30.389  (~40.0s)
[STAGE] DiT denoising loop: start (10 steps)        10:46:30.389
[STAGE] DiT denoising loop: done                    11:27:34.737   (41:04)
DiT offload + VAE decoder placement                 11:27:34.737 → 11:28:01.416  (~26.7s)
[STAGE] VAE decode (TT): start                      11:28:01.416
[STAGE] VAE decode (TT): done, 19 frames            11:32:28.983   (~4:28)
```

Final video generated from pipeline:

https://github.com/user-attachments/assets/95df8b5e-2449-4658-875a-e9b5290465ac


